### PR TITLE
Add SQD band gap calculation package

### DIFF
--- a/sqd_bandgap/README.md
+++ b/sqd_bandgap/README.md
@@ -1,0 +1,120 @@
+# SQD Band Gap Calculation
+
+This package implements the Sample-based Quantum Diagonalization (SQD) method for computing band gaps of periodic materials.
+
+## Overview
+
+The SQD method is a quantum-classical hybrid approach that combines:
+1. **Classical preprocessing**: DFT+U+V calculations and tight-binding projection
+2. **Quantum sampling**: LUCJ ansatz circuit execution on quantum hardware/simulator
+3. **Classical post-processing**: SQD diagonalization in the sampled configuration space
+
+## Method
+
+The band gap is calculated using the formula:
+
+```
+Eg = E[Ne-1] + E[Ne+1] - 2*E[Ne]
+```
+
+where:
+- `E[Ne]` is the ground state energy with Ne electrons (neutral system)
+- `E[Ne-1]` is the energy with one electron removed (cation)
+- `E[Ne+1]` is the energy with one electron added (anion)
+
+## Package Structure
+
+```
+sqd_bandgap/
+├── __init__.py          # Package initialization
+├── hamiltonian.py       # Extended Hubbard Hamiltonian construction
+├── classical.py         # Classical preprocessing (HF, CCSD)
+├── circuits.py          # Quantum circuit generation (LUCJ ansatz)
+├── sqd.py               # SQD algorithm implementation
+├── bandgap.py           # Band gap calculation utilities
+├── run_bandgap_calculation.py  # Main execution script
+└── README.md            # This file
+```
+
+## Requirements
+
+- Python >= 3.9
+- numpy
+- pyscf
+- ffsim
+- qiskit
+- qiskit-addon-sqd
+
+## Installation
+
+```bash
+pip install numpy pyscf ffsim qiskit qiskit-addon-sqd
+```
+
+## Usage
+
+### Quick Demo (using pre-computed results)
+
+```bash
+cd sqd_bandgap
+python run_bandgap_calculation.py --material hafnium_2
+```
+
+### With Custom Results
+
+```bash
+python run_bandgap_calculation.py \
+    --material hafnium_2 \
+    --results_path /path/to/sqd-band-gaps/sqd-lattice/runs \
+    --ne_neutral 24 \
+    --sampling hardware
+```
+
+## Example Output
+
+```
+============================================================
+SQD Band Gap Calculation for HfO2
+============================================================
+  23e: E = -389.537290 eV
+  24e: E = -389.433096 eV
+  25e: E = -383.666757 eV
+
+============================================================
+Band Gap Calculation
+============================================================
+Formula: Eg = E[Ne-1] + E[Ne+1] - 2*E[Ne]
+       = -389.537290 + -383.666757 - 2*-389.433096
+       = 5.6621 eV
+
+============================================================
+Comparison with Reference Values
+============================================================
+SQD Band Gap:          5.6621 eV
+Experimental:          5.7000 eV
+SQD Error:             0.0379 eV (0.7%)
+DFT+U+V Band Gap:      4.5000 eV
+DFT+U+V Error:         1.2000 eV (21.1%)
+SQD Improvement:       1.1621 eV (96.8% reduction)
+```
+
+## Results
+
+For HfO2 (hafnium dioxide):
+- **SQD Band Gap**: 5.66 eV
+- **Experimental**: 5.7 eV
+- **DFT+U+V**: 4.5 eV
+
+SQD achieves ~97% reduction in error compared to DFT+U+V.
+
+## Reference
+
+Based on the paper:
+> "Computing band gaps of periodic materials via sample-based quantum diagonalization"
+> arXiv:2503.10901
+
+Original code repository: https://github.com/neumannrf/sqd-band-gaps
+
+## License
+
+MIT License

--- a/sqd_bandgap/__init__.py
+++ b/sqd_bandgap/__init__.py
@@ -1,0 +1,17 @@
+"""
+SQD Band Gap Calculation Package
+
+This package implements the Sample-based Quantum Diagonalization (SQD) method
+for computing band gaps of periodic materials, based on the paper:
+"Computing band gaps of periodic materials via sample-based quantum diagonalization"
+(arXiv:2503.10901)
+
+The package provides:
+1. Classical preprocessing (DFT+U+V, tight-binding projection)
+2. Extended Hubbard Hamiltonian construction
+3. LUCJ ansatz circuit generation
+4. Quantum circuit simulation (using ffsim)
+5. SQD diagonalization and band gap calculation
+"""
+
+__version__ = "0.1.0"

--- a/sqd_bandgap/bandgap.py
+++ b/sqd_bandgap/bandgap.py
@@ -1,0 +1,178 @@
+"""
+Band Gap Calculation Module
+
+This module calculates the band gap using the SQD method:
+Eg = E[Ne-1] + E[Ne+1] - 2*E[Ne]
+
+where Ne is the number of electrons in the neutral system.
+"""
+
+import json
+import os
+from typing import Dict, Any, Optional
+
+
+def calculate_bandgap(e_ne_minus_1: float, 
+                      e_ne: float, 
+                      e_ne_plus_1: float) -> float:
+    """
+    Calculate band gap from total energies.
+    
+    The band gap is computed as:
+    Eg = E[Ne-1] + E[Ne+1] - 2*E[Ne]
+    
+    This corresponds to the difference between ionization potential (IP)
+    and electron affinity (EA):
+    Eg = IP - EA = (E[Ne-1] - E[Ne]) - (E[Ne] - E[Ne+1])
+    
+    Args:
+        e_ne_minus_1: Total energy with Ne-1 electrons (cation)
+        e_ne: Total energy with Ne electrons (neutral)
+        e_ne_plus_1: Total energy with Ne+1 electrons (anion)
+    
+    Returns:
+        bandgap: Band gap in the same units as input energies
+    """
+    return e_ne_minus_1 + e_ne_plus_1 - 2 * e_ne
+
+
+def load_sqd_results(results_folder: str, 
+                     ne_values: list = None,
+                     sampling: str = "hardware") -> Dict[int, float]:
+    """
+    Load SQD results from result files.
+    
+    Args:
+        results_folder: Path to the folder containing SQD results
+        ne_values: List of electron numbers to load (default: [Ne-1, Ne, Ne+1])
+        sampling: Sampling method ('hardware', 'ffsim', etc.)
+    
+    Returns:
+        energies: Dictionary mapping electron number to SQD energy
+    """
+    energies = {}
+    
+    for ne in ne_values:
+        ne_folder = os.path.join(results_folder, f"{ne}e", f"results_sqd_{sampling}", "dicts")
+        
+        if not os.path.exists(ne_folder):
+            raise FileNotFoundError(f"Results folder not found: {ne_folder}")
+        
+        # Find the result file with highest samples_per_batch
+        files = sorted([f for f in os.listdir(ne_folder) if f.startswith("results_dict_")])
+        if not files:
+            raise FileNotFoundError(f"No result files found in {ne_folder}")
+        
+        latest_file = files[-1]
+        with open(os.path.join(ne_folder, latest_file)) as f:
+            data = json.load(f)
+        
+        energies[ne] = data['sqd_energy']
+        print(f"Loaded {ne}e: E = {energies[ne]:.6f} eV (file: {latest_file})")
+    
+    return energies
+
+
+def compute_bandgap_from_results(results_folder: str,
+                                 ne_neutral: int,
+                                 sampling: str = "hardware") -> Dict[str, Any]:
+    """
+    Compute band gap from SQD results.
+    
+    Args:
+        results_folder: Path to the folder containing SQD results
+        ne_neutral: Number of electrons in the neutral system
+        sampling: Sampling method ('hardware', 'ffsim', etc.)
+    
+    Returns:
+        results: Dictionary containing energies and band gap
+    """
+    ne_values = [ne_neutral - 1, ne_neutral, ne_neutral + 1]
+    
+    energies = load_sqd_results(results_folder, ne_values, sampling)
+    
+    e_minus = energies[ne_neutral - 1]
+    e_neutral = energies[ne_neutral]
+    e_plus = energies[ne_neutral + 1]
+    
+    bandgap = calculate_bandgap(e_minus, e_neutral, e_plus)
+    
+    results = {
+        'E_Ne-1': e_minus,
+        'E_Ne': e_neutral,
+        'E_Ne+1': e_plus,
+        'bandgap': bandgap,
+        'ne_neutral': ne_neutral,
+        'sampling': sampling
+    }
+    
+    print(f"\n=== Band Gap Calculation ===")
+    print(f"E[Ne-1] = E[{ne_neutral-1}e] = {e_minus:.6f} eV")
+    print(f"E[Ne]   = E[{ne_neutral}e] = {e_neutral:.6f} eV")
+    print(f"E[Ne+1] = E[{ne_neutral+1}e] = {e_plus:.6f} eV")
+    print(f"\nBand Gap = E[Ne-1] + E[Ne+1] - 2*E[Ne]")
+    print(f"         = {e_minus:.6f} + {e_plus:.6f} - 2*{e_neutral:.6f}")
+    print(f"         = {bandgap:.4f} eV")
+    
+    return results
+
+
+def compare_with_experiment(sqd_bandgap: float,
+                           experimental_bandgap: float,
+                           dft_bandgap: Optional[float] = None) -> Dict[str, float]:
+    """
+    Compare SQD band gap with experimental and DFT values.
+    
+    Args:
+        sqd_bandgap: Band gap from SQD calculation
+        experimental_bandgap: Experimental band gap
+        dft_bandgap: Band gap from DFT+U+V (optional)
+    
+    Returns:
+        comparison: Dictionary with errors and improvements
+    """
+    sqd_error = abs(sqd_bandgap - experimental_bandgap)
+    sqd_error_percent = 100 * sqd_error / experimental_bandgap
+    
+    comparison = {
+        'sqd_bandgap': sqd_bandgap,
+        'experimental_bandgap': experimental_bandgap,
+        'sqd_error': sqd_error,
+        'sqd_error_percent': sqd_error_percent
+    }
+    
+    print(f"\n=== Comparison with Experiment ===")
+    print(f"SQD Band Gap:          {sqd_bandgap:.4f} eV")
+    print(f"Experimental:          {experimental_bandgap:.4f} eV")
+    print(f"SQD Error:             {sqd_error:.4f} eV ({sqd_error_percent:.1f}%)")
+    
+    if dft_bandgap is not None:
+        dft_error = abs(dft_bandgap - experimental_bandgap)
+        dft_error_percent = 100 * dft_error / experimental_bandgap
+        improvement = dft_error - sqd_error
+        improvement_percent = 100 * improvement / dft_error if dft_error > 0 else 0
+        
+        comparison['dft_bandgap'] = dft_bandgap
+        comparison['dft_error'] = dft_error
+        comparison['dft_error_percent'] = dft_error_percent
+        comparison['improvement'] = improvement
+        comparison['improvement_percent'] = improvement_percent
+        
+        print(f"DFT+U+V Band Gap:      {dft_bandgap:.4f} eV")
+        print(f"DFT+U+V Error:         {dft_error:.4f} eV ({dft_error_percent:.1f}%)")
+        print(f"SQD Improvement:       {improvement:.4f} eV ({improvement_percent:.1f}% reduction)")
+    
+    return comparison
+
+
+# Reference experimental values (in eV)
+EXPERIMENTAL_BANDGAPS = {
+    'HfO2': 5.7,   # Hafnium dioxide
+    'ZrO2': 5.8,   # Zirconium dioxide
+}
+
+# Reference DFT+U+V values (in eV, from paper)
+DFT_UV_BANDGAPS = {
+    'HfO2': 4.5,
+    'ZrO2': 4.3,
+}

--- a/sqd_bandgap/circuits.py
+++ b/sqd_bandgap/circuits.py
@@ -1,0 +1,160 @@
+"""
+Quantum Circuit Module
+
+This module handles the construction of quantum circuits for SQD:
+1. LUCJ (Local Unitary Cluster Jastrow) ansatz construction
+2. Qiskit circuit generation for simulation
+"""
+
+import numpy as np
+from typing import Tuple, List, Optional
+
+
+def make_lucj_circuit(nelec: Tuple[int, int],
+                      num_orbitals: int,
+                      t2: np.ndarray,
+                      layers: int = 1,
+                      truncated_lucj: bool = False):
+    """
+    Construct LUCJ ansatz circuit using ffsim.
+    
+    The LUCJ ansatz is a hardware-efficient ansatz that captures
+    electron correlation through local unitary operations and
+    Jastrow factors.
+    
+    Args:
+        nelec: Tuple of (n_alpha, n_beta) electrons
+        num_orbitals: Number of spatial orbitals
+        t2: CCSD double excitation amplitudes for initialization
+        layers: Number of LUCJ layers
+        truncated_lucj: Whether to use truncated LUCJ circuit
+    
+    Returns:
+        circ_ffsim: ffsim UCJ operator
+    """
+    try:
+        import ffsim
+    except ImportError:
+        raise ImportError("ffsim is required. Install with: pip install ffsim")
+    
+    # Define interaction pairs based on spin configuration
+    if nelec[0] == nelec[1]:
+        # Closed shell
+        alpha_alpha_indices = [(p, p + 1) for p in range(num_orbitals - 1)]
+        alpha_beta_indices = [(p, p) for p in range(num_orbitals) if p % 4 == 0]
+        interaction_pairs = (alpha_alpha_indices, alpha_beta_indices)
+        
+        if truncated_lucj:
+            n_reps = 2
+            circ_ffsim = ffsim.UCJOpSpinBalanced.from_t_amplitudes(
+                t2, n_reps=n_reps, interaction_pairs=interaction_pairs
+            )
+            circ_ffsim = ffsim.UCJOpSpinBalanced(
+                diag_coulomb_mats=circ_ffsim.diag_coulomb_mats[:-1],
+                orbital_rotations=circ_ffsim.orbital_rotations[:-1],
+                final_orbital_rotation=circ_ffsim.orbital_rotations[-1]
+            )
+        else:
+            circ_ffsim = ffsim.UCJOpSpinBalanced.from_t_amplitudes(
+                t2=t2, n_reps=layers, interaction_pairs=interaction_pairs
+            )
+    else:
+        # Open shell
+        alpha_alpha_indices = [(p, p + 1) for p in range(num_orbitals - 1)]
+        alpha_beta_indices = [(p, p) for p in range(num_orbitals) if p % 4 == 0]
+        beta_beta_indices = [(p, p + 1) for p in range(num_orbitals - 1)]
+        interaction_pairs = (alpha_alpha_indices, alpha_beta_indices, beta_beta_indices)
+        
+        if truncated_lucj:
+            n_reps = 2
+            circ_ffsim = ffsim.UCJOpSpinUnbalanced.from_t_amplitudes(
+                t2, n_reps=n_reps, interaction_pairs=interaction_pairs
+            )
+            circ_ffsim = ffsim.UCJOpSpinUnbalanced(
+                diag_coulomb_mats=circ_ffsim.diag_coulomb_mats[:-1],
+                orbital_rotations=circ_ffsim.orbital_rotations[:-1],
+                final_orbital_rotation=circ_ffsim.orbital_rotations[-1]
+            )
+        else:
+            circ_ffsim = ffsim.UCJOpSpinUnbalanced.from_t_amplitudes(
+                t2=t2, n_reps=layers, interaction_pairs=interaction_pairs
+            )
+    
+    return circ_ffsim
+
+
+def make_circuit_qiskit(circ_ffsim,
+                        num_orbitals: int,
+                        nelec: Tuple[int, int],
+                        basis_rotation: np.ndarray,
+                        basis: str = 'atomic'):
+    """
+    Convert ffsim circuit to Qiskit circuit for simulation.
+    
+    Args:
+        circ_ffsim: ffsim UCJ operator
+        num_orbitals: Number of spatial orbitals
+        nelec: Tuple of (n_alpha, n_beta) electrons
+        basis_rotation: Basis rotation matrix (MO coefficients)
+        basis: 'atomic' or 'molecular' basis
+    
+    Returns:
+        circ_qiskit: Qiskit QuantumCircuit
+    """
+    try:
+        import ffsim
+        from qiskit.circuit import QuantumCircuit, QuantumRegister
+    except ImportError:
+        raise ImportError("ffsim and qiskit are required.")
+    
+    qubits = QuantumRegister(2 * num_orbitals, name="q")
+    circ_qiskit = QuantumCircuit(qubits)
+    
+    # Prepare Hartree-Fock state
+    circ_qiskit.append(ffsim.qiskit.PrepareHartreeFockJW(num_orbitals, nelec), qubits)
+    
+    # Apply LUCJ ansatz
+    if nelec[0] == nelec[1]:
+        circ_qiskit.append(ffsim.qiskit.UCJOpSpinBalancedJW(circ_ffsim), qubits)
+    else:
+        circ_qiskit.append(ffsim.qiskit.UCJOpSpinUnbalancedJW(circ_ffsim), qubits)
+    
+    # Apply basis rotation if in atomic basis
+    if basis == 'atomic':
+        circ_qiskit.append(
+            ffsim.qiskit.OrbitalRotationJW(num_orbitals, basis_rotation), 
+            qubits
+        )
+    
+    circ_qiskit.measure_all()
+    
+    return circ_qiskit
+
+
+def sample_circuit_ffsim(circ_qiskit, shots: int = 1000000, seed: int = 12345) -> dict:
+    """
+    Sample quantum circuit using ffsim simulator.
+    
+    This is a noiseless classical simulation of the quantum circuit.
+    
+    Args:
+        circ_qiskit: Qiskit QuantumCircuit
+        shots: Number of measurement shots
+        seed: Random seed for reproducibility
+    
+    Returns:
+        counts: Dictionary of bitstring counts
+    """
+    try:
+        import ffsim
+    except ImportError:
+        raise ImportError("ffsim is required. Install with: pip install ffsim")
+    
+    sampler = ffsim.qiskit.FfsimSampler(default_shots=shots, seed=seed)
+    pub = (circ_qiskit,)
+    job = sampler.run([pub])
+    result = job.result()
+    pub_result = result[0]
+    counts = pub_result.data.meas.get_counts()
+    
+    return counts

--- a/sqd_bandgap/classical.py
+++ b/sqd_bandgap/classical.py
@@ -1,0 +1,129 @@
+"""
+Classical Preprocessing Module
+
+This module handles the classical preprocessing steps:
+1. Hartree-Fock calculation
+2. CCSD calculation for initial ansatz parameters
+3. Basis rotation and tensor transformation
+"""
+
+import numpy as np
+from typing import Dict, Tuple, Optional, Any
+import logging
+
+from .hamiltonian import make_two_body_tensor
+
+
+def make_pyscf_slater_det(nelec: Tuple[int, int], num_orbitals: int) -> np.ndarray:
+    """
+    Create occupation vector for Slater determinant.
+    
+    Args:
+        nelec: Tuple of (n_alpha, n_beta) electrons
+        num_orbitals: Number of spatial orbitals
+    
+    Returns:
+        occ: Occupation vector
+    """
+    occ = np.zeros(num_orbitals)
+    n_doubly = min(nelec[0], nelec[1])
+    n_singly = abs(nelec[0] - nelec[1])
+    
+    occ[:n_doubly] = 2.0
+    if n_singly > 0:
+        occ[n_doubly:n_doubly + n_singly] = 1.0
+    
+    return occ
+
+
+def run_pyscf_calculations(hopping_matrix: np.ndarray,
+                           hubbard_params: Dict[Tuple[int, int], Dict[str, Any]],
+                           nelec: Tuple[int, int],
+                           compute_fci: bool = False,
+                           logger: Optional[logging.Logger] = None) -> Dict[str, Any]:
+    """
+    Run PySCF calculations (HF, CCSD, optionally FCI).
+    
+    Args:
+        hopping_matrix: One-body hopping matrix
+        hubbard_params: Hubbard parameters dictionary
+        nelec: Tuple of (n_alpha, n_beta) electrons
+        compute_fci: Whether to compute FCI (expensive for large systems)
+        logger: Optional logger for output
+    
+    Returns:
+        results: Dictionary containing energies, MO coefficients, and amplitudes
+    """
+    try:
+        import pyscf
+    except ImportError:
+        raise ImportError("PySCF is required. Install with: pip install pyscf")
+    
+    if logger is None:
+        logger = logging.getLogger(__name__)
+    
+    logger.info(f"Starting calculations for nelec: {nelec}")
+    
+    num_orbitals = hopping_matrix.shape[0]
+    two_body_tensor = make_two_body_tensor(hopping_matrix, hubbard_params)
+    
+    # Setup PySCF molecule object
+    mol = pyscf.gto.M(verbose=0)
+    mol.nelec = nelec
+    mol.incore_anyway = True
+    
+    # Hartree-Fock calculation
+    hf_obj = pyscf.scf.RHF(mol)
+    hf_obj.get_hcore = lambda *args: np.real(hopping_matrix)
+    hf_obj.get_ovlp = lambda *args: np.eye(num_orbitals)
+    hf_obj._eri = two_body_tensor
+    
+    pyscf_slater_det = make_pyscf_slater_det(nelec, num_orbitals)
+    hf_obj.get_occ = lambda *args: pyscf_slater_det
+    
+    logger.info('Running Hartree-Fock...')
+    hf_obj.kernel()
+    logger.info(f"HF energy: {hf_obj.e_tot}")
+    
+    # CCSD calculation
+    ccsd_obj = pyscf.cc.CCSD(hf_obj)
+    logger.info("Running CCSD...")
+    
+    max_cycle = ccsd_obj.max_cycle
+    while max_cycle > 0:
+        try:
+            ccsd_obj.kernel()
+            logger.info("CCSD converged successfully.")
+            break
+        except np.linalg.LinAlgError:
+            logger.warning(f"LinAlgError with max_cycles={max_cycle}. Retrying...")
+            max_cycle -= 1
+            ccsd_obj.max_cycle = max_cycle
+    
+    logger.info(f"CCSD energy: {ccsd_obj.e_tot}")
+    
+    # CCSD(T) correction
+    ccsd_t_correction = ccsd_obj.ccsd_t()
+    logger.info(f"CCSD(T) energy: {ccsd_obj.e_tot + ccsd_t_correction}")
+    
+    results = {
+        'hf_energy': hf_obj.e_tot,
+        'two_body_tensor': two_body_tensor,
+        'ne_ab': nelec,
+        'mo_coeff': hf_obj.mo_coeff,
+        'ccsd_energy': ccsd_obj.e_tot,
+        't1': ccsd_obj.t1,
+        't2': ccsd_obj.t2,
+        'ccsdt_energy': ccsd_obj.e_tot + ccsd_t_correction,
+        'fci_energy': None
+    }
+    
+    # Optional FCI calculation
+    if compute_fci:
+        logger.info("Running FCI...")
+        fci_obj = pyscf.fci.FCI(hf_obj)
+        fci_obj.kernel()
+        results['fci_energy'] = fci_obj.e_tot
+        logger.info(f"FCI energy: {fci_obj.e_tot}")
+    
+    return results

--- a/sqd_bandgap/hamiltonian.py
+++ b/sqd_bandgap/hamiltonian.py
@@ -1,0 +1,103 @@
+"""
+Extended Hubbard Hamiltonian Construction Module
+
+This module constructs the extended Hubbard Hamiltonian from DFT+U+V data:
+H = sum_pq t_pq a^dag_p,sigma a_q,sigma + sum_p U_p n_p,up n_p,down + sum_pq V_pq n_p,sigma n_q,tau
+
+The Hamiltonian is built from:
+1. Hopping matrix (t_pq) from tight-binding projection
+2. On-site Hubbard U parameters
+3. Inter-site Hubbard V parameters
+"""
+
+import numpy as np
+from typing import Dict, Tuple, Any
+
+
+def make_two_body_tensor(hopping_matrix: np.ndarray, 
+                         hubbard_params: Dict[Tuple[int, int], Dict[str, Any]]) -> np.ndarray:
+    """
+    Construct the two-body tensor from Hubbard parameters.
+    
+    The two-body tensor encodes the electron-electron interactions:
+    - On-site (U): two_body_tensor[i,i,i,i] = 2*U
+    - Inter-site (V): two_body_tensor[i,i,j,j] = 2*V
+    
+    Args:
+        hopping_matrix: One-body hopping matrix from tight-binding projection
+        hubbard_params: Dictionary of Hubbard parameters with structure:
+            {(species_i, species_j): {'V': value, 'index_i': [...], 'index_j': [...]}}
+    
+    Returns:
+        two_body_tensor: 4D tensor of shape (n_orb, n_orb, n_orb, n_orb)
+    """
+    num_orbitals = hopping_matrix.shape[0]
+    two_body_tensor = np.zeros((num_orbitals, num_orbitals, num_orbitals, num_orbitals))
+    
+    for k, v_dict in hubbard_params.items():
+        if k[0] == k[1]:
+            # On-site interaction (U)
+            for i in v_dict["index_i"]:
+                two_body_tensor[i, i, i, i] = 2 * v_dict["V"]
+        else:
+            # Inter-site interaction (V)
+            for i in v_dict["index_i"]:
+                for j in v_dict["index_j"]:
+                    two_body_tensor[i, i, j, j] = 2 * v_dict["V"]
+                    two_body_tensor[j, j, i, i] = 2 * v_dict["V"]
+    
+    return two_body_tensor
+
+
+def rotate_tensors(hopping_matrix: np.ndarray, 
+                   two_body_tensor: np.ndarray, 
+                   basis_rotation: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Rotate one-body and two-body tensors to molecular orbital basis.
+    
+    Args:
+        hopping_matrix: One-body hopping matrix in atomic orbital basis
+        two_body_tensor: Two-body tensor in atomic orbital basis
+        basis_rotation: Unitary transformation matrix (MO coefficients)
+    
+    Returns:
+        hopping_matrix_rot: Rotated one-body matrix
+        two_body_tensor_rot: Rotated two-body tensor
+    """
+    hopping_matrix_rot = basis_rotation.T @ hopping_matrix @ basis_rotation
+    two_body_tensor_rot = np.einsum('pqrs,pi,qj,rk,sl->ijkl', 
+                                     two_body_tensor, 
+                                     basis_rotation, basis_rotation, 
+                                     basis_rotation, basis_rotation)
+    return hopping_matrix_rot, two_body_tensor_rot
+
+
+def build_molecular_hamiltonian(hopping_matrix: np.ndarray,
+                                two_body_tensor: np.ndarray,
+                                mo_coeff: np.ndarray = None):
+    """
+    Build molecular Hamiltonian using ffsim.
+    
+    Args:
+        hopping_matrix: One-body hopping matrix
+        two_body_tensor: Two-body interaction tensor
+        mo_coeff: Molecular orbital coefficients (optional, for basis rotation)
+    
+    Returns:
+        hamiltonian: ffsim MolecularHamiltonian object
+    """
+    try:
+        import ffsim
+        
+        hamiltonian = ffsim.MolecularHamiltonian(
+            one_body_tensor=hopping_matrix,
+            two_body_tensor=two_body_tensor
+        )
+        
+        if mo_coeff is not None:
+            hamiltonian = hamiltonian.rotated(mo_coeff.T)
+        
+        return hamiltonian
+    except ImportError:
+        raise ImportError("ffsim is required for Hamiltonian construction. "
+                         "Install with: pip install ffsim")

--- a/sqd_bandgap/run_bandgap_calculation.py
+++ b/sqd_bandgap/run_bandgap_calculation.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+SQD Band Gap Calculation Script
+
+This script demonstrates the SQD method for computing band gaps of periodic materials.
+It uses pre-computed DFT+U+V data and quantum hardware/simulator results to calculate
+the band gap of HfO2 (hafnium dioxide).
+
+Usage:
+    python run_bandgap_calculation.py --material hafnium_2 --results_path /path/to/results
+
+Reference:
+    "Computing band gaps of periodic materials via sample-based quantum diagonalization"
+    arXiv:2503.10901
+"""
+
+import argparse
+import json
+import os
+import sys
+
+from bandgap import (
+    calculate_bandgap,
+    compare_with_experiment,
+    EXPERIMENTAL_BANDGAPS,
+    DFT_UV_BANDGAPS
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Calculate band gap using SQD method"
+    )
+    parser.add_argument(
+        '--material', 
+        type=str, 
+        default='hafnium_2',
+        help='Material name (default: hafnium_2 for HfO2)'
+    )
+    parser.add_argument(
+        '--results_path',
+        type=str,
+        default=None,
+        help='Path to SQD results folder'
+    )
+    parser.add_argument(
+        '--ne_neutral',
+        type=int,
+        default=24,
+        help='Number of electrons in neutral system (default: 24 for HfO2)'
+    )
+    parser.add_argument(
+        '--sampling',
+        type=str,
+        default='hardware',
+        help='Sampling method: hardware, ffsim (default: hardware)'
+    )
+    
+    args = parser.parse_args()
+    
+    # Map material names to experimental values
+    material_map = {
+        'hafnium_2': 'HfO2',
+        'zirconia_2': 'ZrO2',
+    }
+    
+    material_name = material_map.get(args.material, args.material)
+    
+    print(f"=" * 60)
+    print(f"SQD Band Gap Calculation for {material_name}")
+    print(f"=" * 60)
+    
+    if args.results_path:
+        # Load results from specified path
+        results_folder = os.path.join(args.results_path, args.material)
+        
+        energies = {}
+        for ne in [args.ne_neutral - 1, args.ne_neutral, args.ne_neutral + 1]:
+            ne_folder = os.path.join(
+                results_folder, f"{ne}e", 
+                f"results_sqd_{args.sampling}", "dicts"
+            )
+            
+            if not os.path.exists(ne_folder):
+                print(f"Warning: Results folder not found: {ne_folder}")
+                continue
+            
+            files = sorted([f for f in os.listdir(ne_folder) 
+                          if f.startswith("results_dict_")])
+            if files:
+                latest_file = files[-1]
+                with open(os.path.join(ne_folder, latest_file)) as f:
+                    data = json.load(f)
+                energies[ne] = data['sqd_energy']
+                print(f"Loaded {ne}e: E = {energies[ne]:.6f} eV")
+        
+        if len(energies) == 3:
+            ne = args.ne_neutral
+            bandgap = calculate_bandgap(
+                energies[ne - 1], 
+                energies[ne], 
+                energies[ne + 1]
+            )
+        else:
+            print("Error: Could not load all required energies")
+            sys.exit(1)
+    else:
+        # Use pre-computed results from the paper
+        print("\nUsing pre-computed results from the paper...")
+        
+        if args.material == 'hafnium_2':
+            # HfO2 results from quantum hardware
+            energies = {
+                23: -389.5372901561972,  # Ne - 1
+                24: -389.4330963086967,  # Ne
+                25: -383.66675745876273  # Ne + 1
+            }
+        elif args.material == 'zirconia_2':
+            # ZrO2 results (placeholder - would need actual data)
+            print("ZrO2 results not available in this demo")
+            sys.exit(1)
+        else:
+            print(f"Unknown material: {args.material}")
+            sys.exit(1)
+        
+        for ne, e in energies.items():
+            print(f"  {ne}e: E = {e:.6f} eV")
+        
+        ne = args.ne_neutral
+        bandgap = calculate_bandgap(
+            energies[ne - 1], 
+            energies[ne], 
+            energies[ne + 1]
+        )
+    
+    # Print band gap calculation
+    print(f"\n{'=' * 60}")
+    print("Band Gap Calculation")
+    print(f"{'=' * 60}")
+    print(f"Formula: Eg = E[Ne-1] + E[Ne+1] - 2*E[Ne]")
+    print(f"       = {energies[ne-1]:.6f} + {energies[ne+1]:.6f} - 2*{energies[ne]:.6f}")
+    print(f"       = {bandgap:.4f} eV")
+    
+    # Compare with experimental and DFT values
+    print(f"\n{'=' * 60}")
+    print("Comparison with Reference Values")
+    print(f"{'=' * 60}")
+    
+    exp_bandgap = EXPERIMENTAL_BANDGAPS.get(material_name)
+    dft_bandgap = DFT_UV_BANDGAPS.get(material_name)
+    
+    if exp_bandgap:
+        comparison = compare_with_experiment(bandgap, exp_bandgap, dft_bandgap)
+        
+        print(f"\nSummary:")
+        print(f"  SQD achieves {comparison['sqd_error_percent']:.1f}% error vs experiment")
+        if dft_bandgap:
+            print(f"  DFT+U+V has {comparison['dft_error_percent']:.1f}% error vs experiment")
+            print(f"  SQD reduces error by {comparison['improvement_percent']:.1f}%")
+    
+    print(f"\n{'=' * 60}")
+    print("Calculation Complete")
+    print(f"{'=' * 60}")
+    
+    return bandgap
+
+
+if __name__ == "__main__":
+    main()

--- a/sqd_bandgap/sqd.py
+++ b/sqd_bandgap/sqd.py
@@ -1,0 +1,195 @@
+"""
+SQD (Sample-based Quantum Diagonalization) Module
+
+This module implements the SQD algorithm:
+1. Process quantum measurement counts
+2. Subsample and postselect configurations
+3. Perform classical diagonalization in the sampled subspace
+"""
+
+import numpy as np
+from typing import Dict, Tuple, List, Optional, Any
+
+
+def make_hf_bitstring(nelec: Tuple[int, int], num_orbitals: int) -> str:
+    """
+    Create Hartree-Fock reference bitstring.
+    
+    Args:
+        nelec: Tuple of (n_alpha, n_beta) electrons
+        num_orbitals: Number of spatial orbitals
+    
+    Returns:
+        hf_string: Hartree-Fock bitstring
+    """
+    n_alpha, n_beta = nelec
+    alpha_bits = '1' * n_alpha + '0' * (num_orbitals - n_alpha)
+    beta_bits = '1' * n_beta + '0' * (num_orbitals - n_beta)
+    return alpha_bits + beta_bits
+
+
+def process_sqd_batch(batch: np.ndarray,
+                      hcore: np.ndarray,
+                      eri: np.ndarray,
+                      nuclear_repulsion_energy: float,
+                      open_shell: bool,
+                      batch_idx: int,
+                      max_davidson_cycles: int = 800,
+                      hf_string: str = None) -> Tuple[float, np.ndarray, np.ndarray, Tuple]:
+    """
+    Process a single SQD batch using PySCF's selected CI solver.
+    
+    Args:
+        batch: Bitstring matrix for this batch
+        hcore: One-body Hamiltonian
+        eri: Two-electron integrals
+        nuclear_repulsion_energy: Nuclear repulsion energy
+        open_shell: Whether the system is open shell
+        batch_idx: Index of this batch
+        max_davidson_cycles: Maximum Davidson iterations
+        hf_string: Hartree-Fock reference bitstring
+    
+    Returns:
+        energy: Ground state energy
+        occupancies: Orbital occupancies
+        ci_coeffs: CI coefficients
+        addresses: (alpha_addresses, beta_addresses)
+    """
+    try:
+        import pyscf
+        from pyscf import ao2mo
+        from pyscf.fci import direct_spin1
+        from qiskit_addon_sqd.fermion import bitstring_matrix_to_ci_strs
+    except ImportError:
+        raise ImportError("pyscf and qiskit-addon-sqd are required.")
+    
+    # Convert bitstrings to CI strings
+    addresses = bitstring_matrix_to_ci_strs(batch, open_shell=open_shell)
+    
+    num_orbitals = hcore.shape[0]
+    n_alpha = batch.shape[1] // 2
+    n_beta = batch.shape[1] // 2
+    nelec = (n_alpha, n_beta)
+    
+    # Setup selected CI solver
+    myci = pyscf.fci.selected_ci.SelectedCI()
+    
+    # Absorb one-body into two-body
+    h2e_abs = direct_spin1.absorb_h1e(hcore, eri, num_orbitals, nelec, 0.5)
+    h2e_abs = ao2mo.restore(1, h2e_abs, num_orbitals)
+    
+    # Solve in the selected subspace
+    try:
+        e, ci = myci.kernel(hcore, eri, num_orbitals, nelec, 
+                           ci0=None, ecore=nuclear_repulsion_energy,
+                           max_cycle=max_davidson_cycles)
+    except Exception as ex:
+        print(f"Batch {batch_idx} failed: {ex}")
+        return np.inf, np.zeros(2 * num_orbitals), None, addresses
+    
+    # Compute occupancies
+    if ci is not None:
+        dm1 = myci.make_rdm1(ci, num_orbitals, nelec)
+        occupancies = np.diag(dm1)
+    else:
+        occupancies = np.zeros(2 * num_orbitals)
+    
+    return e, occupancies, ci, addresses
+
+
+def run_sqd(counts: Dict[str, int],
+            hcore: np.ndarray,
+            eri: np.ndarray,
+            nelec: Tuple[int, int],
+            samples_per_batch: int = 1000,
+            n_batches: int = 1,
+            recovery_iterations: int = 1,
+            rand_seed: int = 469420) -> Dict[str, Any]:
+    """
+    Run the full SQD algorithm.
+    
+    Args:
+        counts: Quantum measurement counts
+        hcore: One-body Hamiltonian
+        eri: Two-electron integrals
+        nelec: Tuple of (n_alpha, n_beta) electrons
+        samples_per_batch: Number of samples per batch
+        n_batches: Number of batches
+        recovery_iterations: Number of configuration recovery iterations
+        rand_seed: Random seed
+    
+    Returns:
+        results: Dictionary containing energies and other results
+    """
+    try:
+        from qiskit_addon_sqd.counts import counts_to_arrays
+        from qiskit_addon_sqd.configuration_recovery import recover_configurations
+        from qiskit_addon_sqd.subsampling import postselect_and_subsample
+    except ImportError:
+        raise ImportError("qiskit-addon-sqd is required.")
+    
+    num_orbitals = hcore.shape[0]
+    n_alpha, n_beta = nelec
+    open_shell = n_alpha != n_beta
+    
+    hf_string = make_hf_bitstring(nelec, num_orbitals)
+    
+    # Convert counts to arrays
+    bitstring_matrix_full, probs_arr_full = counts_to_arrays(counts)
+    
+    e_hist = np.zeros((recovery_iterations, n_batches))
+    occupancy_hist = np.zeros((recovery_iterations, n_batches, 2 * num_orbitals))
+    occupancies_bitwise = None
+    
+    for i in range(recovery_iterations):
+        print(f"Starting configuration recovery iteration {i}...")
+        
+        if occupancies_bitwise is None:
+            bs_mat_tmp = bitstring_matrix_full
+            probs_arr_tmp = probs_arr_full
+        else:
+            bs_mat_tmp, probs_arr_tmp = recover_configurations(
+                bitstring_matrix_full,
+                probs_arr_full,
+                occupancies_bitwise,
+                n_alpha,
+                n_beta,
+                rand_seed=rand_seed,
+            )
+        
+        # Postselect and subsample
+        batches = postselect_and_subsample(
+            bs_mat_tmp,
+            probs_arr_tmp,
+            hamming_right=n_alpha,
+            hamming_left=n_beta,
+            samples_per_batch=samples_per_batch,
+            num_batches=n_batches,
+            rand_seed=rand_seed,
+        )
+        
+        # Process each batch
+        for j, batch in enumerate(batches):
+            e, occs, ci, addresses = process_sqd_batch(
+                batch, hcore, eri, 0.0, open_shell, j,
+                hf_string=hf_string
+            )
+            e_hist[i, j] = e
+            occupancy_hist[i, j, :len(occs)] = occs
+        
+        # Update occupancies for next iteration
+        best_batch_idx = np.argmin(e_hist[i, :])
+        occupancies_bitwise = occupancy_hist[i, best_batch_idx, :]
+    
+    # Get best result
+    best_iter = recovery_iterations - 1
+    best_batch = np.argmin(e_hist[best_iter, :])
+    best_energy = e_hist[best_iter, best_batch]
+    
+    return {
+        'sqd_energy': best_energy,
+        'e_hist': e_hist,
+        'occupancy_hist': occupancy_hist,
+        'best_batch': best_batch,
+        'best_iteration': best_iter
+    }


### PR DESCRIPTION
# Add SQD band gap calculation package

## Summary
This PR adds a new `sqd_bandgap` package implementing the Sample-based Quantum Diagonalization (SQD) method for computing band gaps of periodic materials, based on arXiv:2503.10901.

The package includes:
- **hamiltonian.py**: Extended Hubbard Hamiltonian construction from DFT+U+V data
- **classical.py**: Classical preprocessing (Hartree-Fock, CCSD) using PySCF
- **circuits.py**: LUCJ ansatz quantum circuit generation using ffsim
- **sqd.py**: SQD algorithm implementation with qiskit-addon-sqd
- **bandgap.py**: Band gap calculation utilities (Eg = E[Ne-1] + E[Ne+1] - 2*E[Ne])
- **run_bandgap_calculation.py**: Demo script with pre-computed HfO2 results

Demo output shows SQD achieves 5.66 eV band gap for HfO2 (0.7% error vs 5.7 eV experimental), compared to DFT+U+V's 4.5 eV (21.1% error).

## Review & Testing Checklist for Human
- [ ] **Verify SQD algorithm correctness**: The `sqd.py` implementation was adapted from the reference repo but not fully tested due to memory constraints (36 qubits for HfO2). Review `process_sqd_batch()` function carefully.
- [ ] **Check hardcoded energy values**: `run_bandgap_calculation.py` contains pre-computed HfO2 energies from the paper. Verify these match the source.
- [ ] **Review LUCJ circuit construction**: The `make_lucj_circuit()` function in `circuits.py` should match the paper's ansatz description.
- [ ] **Test with actual quantum results**: Run with `--results_path` pointing to real SQD results from https://github.com/neumannrf/sqd-band-gaps

**Recommended test plan:**
1. Run `python run_bandgap_calculation.py --material hafnium_2` to verify demo works
2. Clone the reference repo and run with actual results: `python run_bandgap_calculation.py --material hafnium_2 --results_path /path/to/sqd-band-gaps/sqd-lattice/runs`
3. Review the quantum circuit modules if planning to use with real quantum hardware

### Notes
- Full quantum simulation was not possible due to memory constraints (HfO2 requires 36 qubits)
- The package relies on external dependencies: numpy, pyscf, ffsim, qiskit, qiskit-addon-sqd
- No unit tests included - consider adding if this becomes production code

Link to Devin run: https://app.devin.ai/sessions/76618e66a81545e48e45ebfe1e64e683
Requested by: @minimumtone