### PR TITLE
fix: round-2 review fixes (⑨ ⑪ ④ root cause)

### DIFF
--- a/hea_extrapolation_platform/dataset.py
+++ b/hea_extrapolation_platform/dataset.py
@@ -29,7 +29,9 @@ logger = logging.getLogger(__name__)
 # Common HEA element pools
 _POOL_3D = ["Ti", "V", "Cr", "Mn", "Fe", "Co", "Ni", "Cu"]
 _POOL_REFRACTORY = ["Ti", "V", "Cr", "Zr", "Nb", "Mo", "Hf", "Ta", "W"]
-_POOL_LIGHT = ["Mg", "Al", "Si", "Sc", "Ti", "V", "Cr", "Mn", "Fe", "Co", "Ni"]
+# Elements for lightweight-containing HEAs (includes light elements Mg, Al, Si, Sc
+# alongside common 3d transition metals for realistic alloy generation).
+_POOL_LIGHT_CONTAINING = ["Mg", "Al", "Si", "Sc", "Ti", "V", "Cr", "Mn", "Fe", "Co", "Ni"]
 
 
 def _random_composition(
@@ -123,7 +125,7 @@ def generate_hea_dataset(
 
     available = _ElementDB.available_elements()
     # Bias toward common HEA elements
-    common_pool = list(set(_POOL_3D + _POOL_REFRACTORY + _POOL_LIGHT))
+    common_pool = list(set(_POOL_3D + _POOL_REFRACTORY + _POOL_LIGHT_CONTAINING))
     common_pool = [e for e in common_pool if e in available]
 
     compositions: List[Dict[str, float]] = []

--- a/hea_extrapolation_platform/report.py
+++ b/hea_extrapolation_platform/report.py
@@ -185,7 +185,10 @@ class ReportGenerator:
                 # Format as table
                 top_ood_display = top_ood.copy()
                 top_ood_display["OOD_score"] = ood_scores_arr[sort_idx]
-                lines.append(top_ood_display.round(3).to_markdown())
+                try:
+                    lines.append(top_ood_display.round(3).to_markdown())
+                except ImportError:
+                    lines.append(top_ood_display.round(3).to_string())
                 lines.append("")
             else:
                 lines.append("No OOD samples detected.")

--- a/hea_extrapolation_platform/runner.py
+++ b/hea_extrapolation_platform/runner.py
@@ -236,57 +236,60 @@ class ExperimentRunner:
 
                 # OOD detection per feature set
                 # We fit on training data and score on test data to avoid
-                # self-scoring leak (Fix #5).
+                # self-scoring leak.  To guarantee index alignment between
+                # OOD flags and ensemble prediction errors, we find an ENS
+                # run that shares the *same* test_indices, rather than relying
+                # on size equality (which could match by coincidence).
                 fs_key = fs_name.value
                 if fs_key not in ood_results:
                     try:
-                        # Use the last split's train/test partition for OOD
-                        # detection so we score held-out data, not training data.
-                        last_train_idx = train_idx
-                        last_test_idx = test_idx
-                        X_train_ood = X_fs.iloc[last_train_idx]
-                        X_test_ood = X_fs.iloc[last_test_idx]
+                        X_train_ood = X_fs.iloc[train_idx]
+                        X_test_ood = X_fs.iloc[test_idx]
+                        ood_test_indices = np.asarray(test_idx)
 
                         detector = OODDetector(k=10)
                         detector.fit(X_train_ood)
                         ood_res = detector.score(X_test_ood)
                         ood_results[fs_key] = ood_res
 
-                        # Collect OOD error data for evaluation
-                        # Use ensemble runs for uncertainty
+                        # Find an ENS run whose test_indices match the OOD
+                        # partition exactly (same indices, same order).
                         ens_runs = [
                             r for r in self._registry.runs
                             if r.feature_set == fs_key and r.workflow == "WF-ENS"
+                               and r.test_indices is not None
                         ]
-                        if ens_runs:
-                            last_ens = ens_runs[-1]
+                        matched_ens = None
+                        for er in reversed(ens_runs):
+                            if np.array_equal(
+                                np.asarray(er.test_indices), ood_test_indices
+                            ):
+                                matched_ens = er
+                                break
+
+                        if matched_ens is not None:
                             pred_std = np.array(
-                                last_ens.artifacts.get("pred_std_test", [])
+                                matched_ens.artifacts.get("pred_std_test", [])
                             )
                             if (
-                                last_ens.y_test_true is not None
-                                and last_ens.y_test_pred is not None
-                                and last_ens.test_indices is not None
+                                matched_ens.y_test_true is not None
+                                and matched_ens.y_test_pred is not None
                                 and len(pred_std) > 0
                             ):
-                                errors = last_ens.y_test_true - last_ens.y_test_pred
-                                # Fix #4: ood_res.is_ood is aligned with the
-                                # test set (X_test_ood), not the full dataset.
-                                # Both errors and is_ood have length = len(test_idx).
-                                n_test = len(last_ens.y_test_true)
-                                n_ood = len(ood_res.is_ood)
-                                if n_test == n_ood:
-                                    ood_errors_for_eval[fs_key] = {
-                                        "errors": errors,
-                                        "uncertainties": pred_std,
-                                        "is_ood": ood_res.is_ood,
-                                    }
-                                else:
-                                    logger.warning(
-                                        "OOD/test size mismatch for %s: "
-                                        "test=%d, ood=%d – skipping eval data",
-                                        fs_key, n_test, n_ood,
-                                    )
+                                errors = (
+                                    matched_ens.y_test_true
+                                    - matched_ens.y_test_pred
+                                )
+                                ood_errors_for_eval[fs_key] = {
+                                    "errors": errors,
+                                    "uncertainties": pred_std,
+                                    "is_ood": ood_res.is_ood,
+                                }
+                        else:
+                            logger.info(
+                                "No ENS run with matching test_indices "
+                                "for OOD eval on %s", fs_key,
+                            )
                     except Exception:
                         logger.exception("OOD detection failed for %s", fs_key)
 


### PR DESCRIPTION
# fix: round-2 review — OOD index alignment, tabulate fallback, pool rename

## Summary

Addresses 3 remaining findings from the second review pass on the Extrapolation Discovery Platform.

**runner.py — OOD/ENS index alignment (④ root cause):**  
The previous fix checked `n_test == n_ood` to guard against misaligned arrays, but size equality between different folds can occur by coincidence. Now the code explicitly searches for an ENS run whose `test_indices` are identical (`np.array_equal`) to the OOD test partition. If no match is found, OOD eval data is skipped with an info log rather than silently producing wrong results.

**report.py — missing `tabulate` fallback (⑨):**  
The OOD candidate table (`top_ood_display.to_markdown()` on former line 188) was the one remaining `to_markdown()` call not wrapped in `try/except ImportError`. Now all three calls in the file have the fallback.

**dataset.py — pool naming (⑪):**  
`_POOL_LIGHT` renamed to `_POOL_LIGHT_CONTAINING` with a docstring clarifying the pool includes both lightweight elements (Mg, Al, Si, Sc) and common 3d transition metals.

## Review & Testing Checklist for Human

- [ ] **runner.py OOD alignment logic**: The OOD detector still uses `train_idx`/`test_idx` from the *last fold of the last splitter* processed for each feature set (due to `if fs_key not in ood_results` guard). Verify this is acceptable for the evaluation design — it means OOD detection is based on a single arbitrary fold, not aggregated across all folds.
- [ ] **Silent skip when no ENS match found**: If no ENS run has matching `test_indices`, the code logs at INFO level and skips OOD error evaluation entirely. Confirm this graceful degradation is preferred over raising/warning.
- [ ] **`_POOL_LIGHT` rename**: If any external code imports `_POOL_LIGHT` from `dataset.py`, this is a breaking change. Search downstream consumers.
- [ ] **End-to-end test**: Run a mini experiment (`seeds=[42]`, `FS_BASE` + `FS_THERMO`, `RandomCV(n_folds=2)`) and verify that OOD eval data is populated (check logs for "No ENS run with matching test_indices" — it should NOT appear if WF-ENS is included).

### Notes

- All changes were verified via source inspection and unit-level assertions; no full integration test was executed.
- d_elec values (⑥) were verified against NIST ground-state configs for all 25 elements — all consistent, no code change needed.

**Link to Devin run:** https://app.devin.ai/sessions/a35c3055d9194e26a3ca15a00e41209a  
**Requested by:** @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/91" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
