### PR TITLE
fix: round-3 review (11 core fixes) + 12 GUI review fixes

### DIFF
--- a/hea_extrapolation_platform/__main__.py
+++ b/hea_extrapolation_platform/__main__.py
@@ -103,14 +103,20 @@ def cmd_run(args: argparse.Namespace) -> None:
         )
         figure_paths["Parity Plot"] = plot_parity(runs, fig_dir)
 
-        # OOD maps per feature set
+        # OOD maps per feature set — use actual train/test split indices
+        # stored by the runner to avoid size mismatch with ood_res.is_ood.
         for fs_key, ood_res in ood_results.items():
             from hea_extrapolation_platform.features import FeatureCatalog, FeatureSetName
             try:
                 fs_enum = FeatureSetName(fs_key)
                 cols = FeatureCatalog.columns(fs_enum)
-                X_train_vis = features_df[cols]
-                X_test_vis = features_df[cols]
+                split_indices = runner.ood_split_indices.get(fs_key)
+                if split_indices is None:
+                    logger.warning("No OOD split indices for %s, skipping plot", fs_key)
+                    continue
+                train_idx_vis, test_idx_vis = split_indices
+                X_train_vis = features_df[cols].iloc[train_idx_vis]
+                X_test_vis = features_df[cols].iloc[test_idx_vis]
                 fig_path = plot_ood_map_pca(
                     X_train_vis, X_test_vis, ood_res, fig_dir,
                     filename=f"ood_map_pca_{fs_key}.png",

--- a/hea_extrapolation_platform/evaluation.py
+++ b/hea_extrapolation_platform/evaluation.py
@@ -40,8 +40,12 @@ class ValidityScore:
     def total(self) -> float:
         """Weighted total score (higher = better).
 
-        Positive weights sum to 1.0 (0.30 + 0.20 + 0.30 + 0.20).
-        leak_penalty is subtracted as a penalty term.
+        Positive-direction weights: 0.30 + 0.20 + 0.30 + 0.20 = 1.00.
+        leak_penalty is subtracted with weight 0.15.
+
+        Score range:
+          - Best case (all 1.0, no leak):  1.00
+          - Worst case (all 0.0, max leak): -0.15
         """
         return (
             0.30 * self.effect_size
@@ -168,14 +172,17 @@ class FeatureValidityEvaluator:
         block_rmse = float(np.mean([r.rmse_test for r in block_runs]))
         rand_improve = (base_rmse - rand_rmse) / base_rmse
         block_improve = (base_rmse - block_rmse) / base_rmse
-        # Both improve -> high score; divergent -> low
-        if rand_improve > 0 and block_improve > 0:
+        # Both improve -> high score; divergent -> low.
+        # Use a small tolerance for "no change" to avoid dead-code with
+        # exact floating-point zero comparisons.
+        _eps = 1e-9
+        if rand_improve > _eps and block_improve > _eps:
             return min(1.0, 0.5 + 0.5 * min(rand_improve, block_improve))
-        elif rand_improve < 0 and block_improve < 0:
+        elif rand_improve < -_eps and block_improve < -_eps:
             # Both degrade -> low but not worst
             return 0.3
-        elif rand_improve == 0 and block_improve == 0:
-            # Zero improvement is neutral
+        elif abs(rand_improve) <= _eps and abs(block_improve) <= _eps:
+            # Negligible change from baseline is neutral
             return 0.5
         else:
             return 0.1  # divergent (one improves, other degrades)

--- a/hea_extrapolation_platform/features.py
+++ b/hea_extrapolation_platform/features.py
@@ -156,11 +156,17 @@ class _ElementDB:
 # ---------------------------------------------------------------------------
 
 class FeatureSetName(str, Enum):
-    """Enumeration of feature set identifiers."""
+    """Enumeration of feature set identifiers.
+
+    Every non-base set *includes* FS_BASE columns by design (base is
+    always a prerequisite).  The ``value`` is a simple identifier used
+    as a dict key throughout the platform; see :class:`FeatureCatalog`
+    for the actual column lists.
+    """
     FS_BASE = "FS_BASE"
-    FS_THERMO = "FS_BASE+FS_THERMO"
-    FS_SIZE = "FS_BASE+FS_SIZE"
-    FS_ELECTRON = "FS_BASE+FS_ELECTRON"
+    FS_THERMO = "FS_THERMO"
+    FS_SIZE = "FS_SIZE"
+    FS_ELECTRON = "FS_ELECTRON"
     FS_ALL = "FS_ALL"
 
 

--- a/hea_extrapolation_platform/gui/app.py
+++ b/hea_extrapolation_platform/gui/app.py
@@ -1,28 +1,42 @@
 """
 Gradio Dashboard for Extrapolation Discovery Platform
-Gradioダッシュボード
+Gradio dashboard
 
 Launch::
 
     python -m hea_extrapolation_platform gui --port 7860
 
 Tab-based layout:
-  1. Dashboard  – KPI cards + validity ranking + performance heatmap
-  2. Config     – Parameter UI + run button + progress log
-  3. Results    – Run results table + filters + parity plot
-  4. OOD Map    – Interactive PCA scatter + OOD candidates table
-  5. Literature – Query UI + filters + feature frequency
-  6. Report     – Markdown preview + download
+  1. Dashboard  - KPI cards + validity ranking + performance heatmap
+  2. Config     - Parameter UI + run button + streaming progress log
+  3. Results    - Run results table + filters + parity plot
+  4. OOD Map    - Interactive PCA scatter + OOD candidates table
+  5. Literature - Query UI + filters + feature frequency
+  6. Report     - Markdown preview + download
+
+Design decisions (GUI review fixes):
+  - gr.State replaces module-global _SESSION for multi-user isolation (#1)
+  - Slider value cast to int to avoid TypeError (#2)
+  - OOD Map uses actual split indices from runner (#3)
+  - InputScope filter choices match schema enum values (#4)
+  - theme= passed to gr.Blocks(), not launch() (#5)
+  - app.queue() enables async execution (#6)
+  - run_experiment is a generator that yields progress (#7)
+  - Experiment completion auto-refreshes all tabs (#8)
+  - Literature index is built once and cached in state (#9)
+  - Parity plot de-duplicates per unique sample index (#10)
+  - Filter choices are generated dynamically from run data (#11)
+  - Output directory uses timestamp-based subdirectories (#12)
 """
 
 from __future__ import annotations
 
-import io
+import datetime
 import logging
 import time
 import traceback
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Generator, List, Optional, Tuple
 
 import gradio as gr
 import numpy as np
@@ -41,609 +55,203 @@ from hea_extrapolation_platform.gui.plotly_charts import (
 
 logger = logging.getLogger(__name__)
 
+
 # ---------------------------------------------------------------------------
-# Session State — shared across tabs
+# Session helpers (gr.State-backed, per-user)  -- Fix #1
 # ---------------------------------------------------------------------------
 
-_SESSION: Dict[str, Any] = {
-    "runs": [],
-    "validity_scores": [],
-    "ood_results": {},
-    "compositions_df": None,
-    "features_df": None,
-    "target": None,
-    "report_path": None,
-    "literature_results": None,
-    "feature_recommendation": None,
-    "feature_counts": None,
-}
-
-
-def _clear_session() -> None:
-    for key in _SESSION:
-        if isinstance(_SESSION[key], list):
-            _SESSION[key] = []
-        elif isinstance(_SESSION[key], dict):
-            _SESSION[key] = {}
-        else:
-            _SESSION[key] = None
+def _empty_session() -> Dict[str, Any]:
+    """Return a fresh session dict (one per browser tab)."""
+    return {
+        "runs": [],
+        "validity_scores": [],
+        "ood_results": {},
+        "ood_split_indices": {},
+        "compositions_df": None,
+        "features_df": None,
+        "target": None,
+        "runner": None,
+        "report_path": None,
+        "literature_engine": None,
+        "literature_results": None,
+        "feature_recommendation": None,
+        "feature_counts": None,
+    }
 
 
 # ---------------------------------------------------------------------------
-# Tab 1: Dashboard
+# Literature index (lazy, cached per session) -- Fix #9
 # ---------------------------------------------------------------------------
 
-def _build_dashboard_tab() -> None:
-    gr.Markdown("## Dashboard — KPIs & Feature Validity")
-    gr.Markdown(
-        "Run an experiment from the **Config** tab first, then refresh "
-        "this page to see results."
+def _get_literature_engine(session: Dict[str, Any]) -> Any:
+    """Build or return the cached literature search engine."""
+    if session.get("literature_engine") is not None:
+        return session["literature_engine"]
+
+    from hea_extrapolation_platform.literature_graph.seed_data import (
+        get_seed_papers, get_seed_workflows,
+    )
+    from hea_extrapolation_platform.literature_graph.workflow_text import (
+        generate_workflow_text,
+    )
+    from hea_extrapolation_platform.literature_graph.vector_index import (
+        build_index,
+    )
+    from hea_extrapolation_platform.literature_graph.search import (
+        LiteratureSearchEngine,
     )
 
-    with gr.Row():
-        kpi_runs = gr.Textbox(label="Total Runs", value="0", interactive=False)
-        kpi_best_fs = gr.Textbox(label="Best Feature Set", value="—", interactive=False)
-        kpi_best_score = gr.Textbox(label="Best Total Score", value="—", interactive=False)
-        kpi_ood_count = gr.Textbox(label="OOD Samples", value="—", interactive=False)
+    papers = get_seed_papers()
+    workflows = get_seed_workflows()
+    wf_texts = [generate_workflow_text(w) for w in workflows]
+    wf_ids = [w.workflow_id for w in workflows]
+    index = build_index(wf_ids, wf_texts, use_faiss=True)
 
-    validity_plot = gr.Plot(label="Feature Validity Ranking")
-    heatmap_plot = gr.Plot(label="Performance Heatmap (RMSE Test)")
-    heatmap_metric = gr.Dropdown(
-        choices=["rmse_test", "rmse_train", "mae_test", "mae_train", "r2_test", "r2_train"],
-        value="rmse_test",
-        label="Heatmap Metric",
+    engine = LiteratureSearchEngine(
+        index=index, workflows=workflows, papers=papers,
     )
-
-    def refresh_dashboard(metric: str) -> Tuple:
-        runs = _SESSION["runs"]
-        scores = _SESSION["validity_scores"]
-        ood_results = _SESSION["ood_results"]
-
-        n_runs = str(len(runs))
-        best_fs = scores[0].feature_set if scores else "—"
-        best_score = f"{scores[0].total:.4f}" if scores else "—"
-
-        total_ood = sum(r.n_ood for r in ood_results.values()) if ood_results else 0
-        ood_str = str(total_ood) if ood_results else "—"
-
-        validity_fig = plotly_validity_ranking(scores) if scores else None
-        heatmap_fig = plotly_heatmap(runs, metric=metric) if runs else None
-
-        return n_runs, best_fs, best_score, ood_str, validity_fig, heatmap_fig
-
-    refresh_btn = gr.Button("Refresh Dashboard", variant="primary")
-    refresh_btn.click(
-        fn=refresh_dashboard,
-        inputs=[heatmap_metric],
-        outputs=[kpi_runs, kpi_best_fs, kpi_best_score, kpi_ood_count,
-                 validity_plot, heatmap_plot],
-    )
-    heatmap_metric.change(
-        fn=refresh_dashboard,
-        inputs=[heatmap_metric],
-        outputs=[kpi_runs, kpi_best_fs, kpi_best_score, kpi_ood_count,
-                 validity_plot, heatmap_plot],
-    )
+    session["literature_engine"] = engine
+    return engine
 
 
 # ---------------------------------------------------------------------------
-# Tab 2: Config & Run
+# Helpers for cross-tab refresh  -- Fix #8
 # ---------------------------------------------------------------------------
 
-def _build_config_tab() -> None:
-    gr.Markdown("## Experiment Configuration & Execution")
+def _refresh_dashboard_data(
+    metric: str, session: Dict[str, Any],
+) -> Tuple[str, str, str, str, Any, Any]:
+    runs = session.get("runs", [])
+    scores = session.get("validity_scores", [])
+    ood_results = session.get("ood_results", {})
 
-    with gr.Row():
-        with gr.Column():
-            seeds_input = gr.Textbox(
-                label="Seeds (space-separated)",
-                value="42 123 456",
-                info="Random seeds for reproducibility",
-            )
-            n_samples = gr.Slider(
-                minimum=50, maximum=1000, value=200, step=50,
-                label="Number of Samples",
-            )
-            quick_mode = gr.Checkbox(
-                label="Quick Mode (reduced HPO)",
-                value=True,
-                info="Use reduced hyperparameter grids for faster execution",
-            )
-        with gr.Column():
-            exclude_elements = gr.Textbox(
-                label="Exclude Elements (space-separated)",
-                value="Co Ni Ti",
-                info="Elements for ElementExclusion splits",
-            )
-            skip_literature = gr.Checkbox(
-                label="Skip Literature Search",
-                value=False,
-            )
-            skip_plots = gr.Checkbox(
-                label="Skip Static Plots (matplotlib)",
-                value=True,
-                info="Skip PNG generation (Plotly charts are always available)",
-            )
+    n_runs = str(len(runs))
+    best_fs = scores[0].feature_set if scores else "--"
+    best_score = f"{scores[0].total:.4f}" if scores else "--"
 
-    run_btn = gr.Button("Run Experiment", variant="primary", size="lg")
-    progress_log = gr.Textbox(
-        label="Progress Log",
-        lines=15,
-        interactive=False,
+    total_ood = (
+        sum(r.n_ood for r in ood_results.values()) if ood_results else 0
     )
+    ood_str = str(total_ood) if ood_results else "--"
 
-    def run_experiment(
-        seeds_str: str,
-        n_samp: int,
-        quick: bool,
-        excl_str: str,
-        skip_lit: bool,
-        skip_plt: bool,
-    ) -> str:
-        log_lines: List[str] = []
+    validity_fig = plotly_validity_ranking(scores) if scores else None
+    heatmap_fig = plotly_heatmap(runs, metric=metric) if runs else None
 
-        def log(msg: str) -> None:
-            log_lines.append(f"[{time.strftime('%H:%M:%S')}] {msg}")
+    return n_runs, best_fs, best_score, ood_str, validity_fig, heatmap_fig
 
-        try:
-            _clear_session()
-            log("Starting experiment...")
 
-            seeds = [int(s.strip()) for s in seeds_str.split() if s.strip()]
-            excl = [e.strip() for e in excl_str.split() if e.strip()]
+def _refresh_results_data(
+    wf_filter: str, fs_filter: str, sp_filter: str,
+    session: Dict[str, Any],
+) -> Tuple:
+    runs = session.get("runs", [])
+    scores = session.get("validity_scores", [])
 
-            if not seeds:
-                return "Error: No valid seeds provided."
+    # Fix #11: dynamic filter choices from actual run data
+    wf_choices = ["All"] + sorted({r.workflow for r in runs})
+    fs_choices = ["All"] + sorted({r.feature_set for r in runs})
+    sp_choices = ["All"] + sorted({r.split_policy for r in runs})
 
-            # 1. Dataset generation
-            from hea_extrapolation_platform.dataset import generate_hea_dataset
-            log(f"Generating dataset: n={n_samp}, seed={seeds[0]}")
-            comps_df, features_df, target = generate_hea_dataset(
-                n_samples=n_samp, seed=seeds[0],
-            )
-            _SESSION["compositions_df"] = comps_df
-            _SESSION["features_df"] = features_df
-            _SESSION["target"] = target
-            log(f"Dataset: {len(target)} samples, {features_df.shape[1]} features")
+    v_df = validity_scores_to_dataframe(scores) if scores else pd.DataFrame()
 
-            # 2. Run experiments
-            from hea_extrapolation_platform.runner import ExperimentRunner
-            log(f"Running experiments: seeds={seeds}, quick={quick}")
-            runner = ExperimentRunner(
-                seeds=seeds, quick=quick, exclude_elements=excl,
-            )
-            runs, scores, ood_results = runner.run(comps_df, features_df, target)
+    filtered = runs
+    if wf_filter != "All":
+        filtered = [r for r in filtered if r.workflow == wf_filter]
+    if fs_filter != "All":
+        filtered = [r for r in filtered if r.feature_set == fs_filter]
+    if sp_filter != "All":
+        filtered = [r for r in filtered if r.split_policy == sp_filter]
 
-            _SESSION["runs"] = runs
-            _SESSION["validity_scores"] = scores
-            _SESSION["ood_results"] = ood_results
+    r_df = runs_to_dataframe(filtered) if filtered else pd.DataFrame()
+    parity_fig = plotly_parity(filtered) if filtered else None
 
-            log(f"Completed: {len(runs)} runs")
-            if scores:
-                log(f"Best feature set: {scores[0].feature_set} "
-                    f"(score={scores[0].total:.4f})")
-
-            for fs_key, ood_res in ood_results.items():
-                log(f"OOD [{fs_key}]: {ood_res.n_ood}/{ood_res.n_total} "
-                    f"({ood_res.ood_ratio:.1%})")
-
-            # 3. Export registry
-            out_dir = Path("results")
-            out_dir.mkdir(parents=True, exist_ok=True)
-            runner.export(out_dir)
-            log(f"Run registry exported to {out_dir / 'run_registry.json'}")
-
-            # 4. Static plots (optional)
-            figure_paths: Dict[str, Path] = {}
-            if not skip_plt:
-                from hea_extrapolation_platform.visualization import (
-                    plot_validity_ranking,
-                    plot_performance_heatmap,
-                    plot_parity,
-                )
-                fig_dir = out_dir / "figures"
-                figure_paths["Validity"] = plot_validity_ranking(scores, fig_dir)
-                figure_paths["Heatmap"] = plot_performance_heatmap(runs, fig_dir)
-                figure_paths["Parity"] = plot_parity(runs, fig_dir)
-                log("Static plots saved.")
-
-            # 5. Literature search (optional)
-            if not skip_lit:
-                try:
-                    from hea_extrapolation_platform.literature_graph.seed_data import (
-                        get_seed_papers, get_seed_workflows,
-                    )
-                    from hea_extrapolation_platform.literature_graph.workflow_text import (
-                        generate_workflow_text,
-                    )
-                    from hea_extrapolation_platform.literature_graph.vector_index import (
-                        build_index,
-                    )
-                    from hea_extrapolation_platform.literature_graph.search import (
-                        LiteratureSearchEngine, StructuredFilter,
-                    )
-                    from hea_extrapolation_platform.literature_graph.feature_recommender import (
-                        LiteratureFeatureRecommender,
-                    )
-
-                    papers = get_seed_papers()
-                    workflows = get_seed_workflows()
-                    wf_texts = [generate_workflow_text(w) for w in workflows]
-                    wf_ids = [w.workflow_id for w in workflows]
-                    index = build_index(wf_ids, wf_texts, use_faiss=True)
-
-                    engine = LiteratureSearchEngine(
-                        index=index, workflows=workflows, papers=papers,
-                    )
-                    query = "composition only yield strength HEA"
-                    sf = StructuredFilter(materials_domain="HEA", task="yield_strength")
-                    lit_results = engine.search(query, structured_filter=sf, top_n=5)
-                    _SESSION["literature_results"] = lit_results
-
-                    recommender = LiteratureFeatureRecommender(engine)
-                    rec = recommender.recommend(query, structured_filter=sf)
-                    _SESSION["feature_recommendation"] = rec
-                    log(f"Literature search: {len(lit_results)} results found")
-                except Exception as exc:
-                    log(f"Literature search failed (non-fatal): {exc}")
-
-            # 6. Report generation
-            from hea_extrapolation_platform.report import ReportGenerator
-            gen = ReportGenerator(out_dir=out_dir)
-            best_ood = None
-            if scores and ood_results:
-                best_ood = ood_results.get(scores[0].feature_set)
-
-            report_path = gen.generate(
-                runs=runs,
-                validity_scores=scores,
-                ood_result=best_ood,
-                compositions_df=comps_df,
-                figure_paths=figure_paths,
-                literature_results=_SESSION.get("literature_results"),
-                feature_recommendation=_SESSION.get("feature_recommendation"),
-            )
-            _SESSION["report_path"] = report_path
-            log(f"Report: {report_path}")
-
-            log("Experiment complete. Switch to other tabs to explore results.")
-
-        except Exception:
-            log(f"ERROR:\n{traceback.format_exc()}")
-
-        return "\n".join(log_lines)
-
-    run_btn.click(
-        fn=run_experiment,
-        inputs=[seeds_input, n_samples, quick_mode, exclude_elements,
-                skip_literature, skip_plots],
-        outputs=[progress_log],
+    return (
+        gr.update(choices=wf_choices, value=wf_filter if wf_filter in wf_choices else "All"),
+        gr.update(choices=fs_choices, value=fs_filter if fs_filter in fs_choices else "All"),
+        gr.update(choices=sp_choices, value=sp_filter if sp_filter in sp_choices else "All"),
+        v_df, r_df, parity_fig,
     )
 
 
-# ---------------------------------------------------------------------------
-# Tab 3: Results
-# ---------------------------------------------------------------------------
+def _refresh_ood_data(
+    fs_key: str, session: Dict[str, Any],
+) -> Tuple:
+    ood_results = session.get("ood_results", {})
+    features_df = session.get("features_df")
+    comps_df = session.get("compositions_df")
+    ood_split_indices = session.get("ood_split_indices", {})
 
-def _build_results_tab() -> None:
-    gr.Markdown("## Experiment Results — Run Table & Parity Plot")
+    if not ood_results or features_df is None:
+        return None, "No OOD results. Run experiment first.", pd.DataFrame()
 
-    with gr.Row():
-        filter_wf = gr.Dropdown(
-            choices=["All", "WF-LIN", "WF-XGB", "WF-ENS"],
-            value="All",
-            label="Workflow Filter",
-        )
-        filter_fs = gr.Dropdown(
-            choices=["All", "FS_BASE", "FS_THERMO",
-                     "FS_SIZE", "FS_ELECTRON", "FS_ALL"],
-            value="All",
-            label="Feature Set Filter",
-        )
-        filter_sp = gr.Dropdown(
-            choices=["All", "RandomCV", "CompositionBlock", "ElementExclusion"],
-            value="All",
-            label="Split Policy Filter",
+    ood_res = ood_results.get(fs_key)
+    if ood_res is None:
+        available = list(ood_results.keys())
+        return (
+            None,
+            f"No OOD for {fs_key}. Available: {available}",
+            pd.DataFrame(),
         )
 
-    validity_table = gr.Dataframe(label="Feature Validity Ranking")
-    results_table = gr.Dataframe(label="Run Results")
-    parity_plot = gr.Plot(label="Parity Plot")
+    from hea_extrapolation_platform.features import FeatureCatalog, FeatureSetName
+    try:
+        fs_enum = FeatureSetName(fs_key)
+        cols = FeatureCatalog.columns(fs_enum)
+    except (ValueError, KeyError):
+        return None, f"Unknown feature set: {fs_key}", pd.DataFrame()
 
-    def refresh_results(wf_filter: str, fs_filter: str, sp_filter: str) -> Tuple:
-        runs = _SESSION["runs"]
-        scores = _SESSION["validity_scores"]
-
-        # Validity table
-        v_df = validity_scores_to_dataframe(scores) if scores else pd.DataFrame()
-
-        # Apply filters
-        filtered = runs
-        if wf_filter != "All":
-            filtered = [r for r in filtered if r.workflow == wf_filter]
-        if fs_filter != "All":
-            filtered = [r for r in filtered if r.feature_set == fs_filter]
-        if sp_filter != "All":
-            filtered = [r for r in filtered if r.split_policy == sp_filter]
-
-        r_df = runs_to_dataframe(filtered) if filtered else pd.DataFrame()
-        parity_fig = plotly_parity(filtered) if filtered else None
-
-        return v_df, r_df, parity_fig
-
-    refresh_btn = gr.Button("Refresh Results", variant="primary")
-    refresh_btn.click(
-        fn=refresh_results,
-        inputs=[filter_wf, filter_fs, filter_sp],
-        outputs=[validity_table, results_table, parity_plot],
-    )
-    # Auto-refresh on filter change
-    for dropdown in [filter_wf, filter_fs, filter_sp]:
-        dropdown.change(
-            fn=refresh_results,
-            inputs=[filter_wf, filter_fs, filter_sp],
-            outputs=[validity_table, results_table, parity_plot],
-        )
-
-
-# ---------------------------------------------------------------------------
-# Tab 4: OOD Map
-# ---------------------------------------------------------------------------
-
-def _build_ood_tab() -> None:
-    gr.Markdown("## OOD (Out-of-Distribution) Map & Candidates")
-
-    fs_selector = gr.Dropdown(
-        choices=["FS_BASE", "FS_THERMO",
-                 "FS_SIZE", "FS_ELECTRON", "FS_ALL"],
-        value="FS_ALL",
-        label="Feature Set for OOD Map",
-    )
-
-    ood_plot = gr.Plot(label="OOD Map (PCA)")
-
-    with gr.Row():
-        ood_summary = gr.Textbox(label="OOD Summary", interactive=False)
-
-    ood_candidates = gr.Dataframe(label="Top OOD Candidates")
-
-    def refresh_ood(fs_key: str) -> Tuple:
-        ood_results = _SESSION["ood_results"]
-        features_df = _SESSION["features_df"]
-        comps_df = _SESSION["compositions_df"]
-
-        if not ood_results or features_df is None:
-            return None, "No OOD results. Run experiment first.", pd.DataFrame()
-
-        ood_res = ood_results.get(fs_key)
-        if ood_res is None:
-            available = list(ood_results.keys())
-            return (None,
-                    f"No OOD for {fs_key}. Available: {available}",
-                    pd.DataFrame())
-
-        # Get feature columns for the selected set
-        from hea_extrapolation_platform.features import FeatureCatalog, FeatureSetName
-        try:
-            fs_enum = FeatureSetName(fs_key)
-            cols = FeatureCatalog.columns(fs_enum)
-        except (ValueError, KeyError):
-            return None, f"Unknown feature set: {fs_key}", pd.DataFrame()
-
+    # Fix #3: use stored train/test indices for correct visualization
+    split = ood_split_indices.get(fs_key)
+    if split is not None:
+        train_idx, test_idx = split
+        X_train = features_df[cols].iloc[train_idx]
+        X_query = features_df[cols].iloc[test_idx]
+    else:
+        logger.warning("No OOD split indices for %s, using heuristic", fs_key)
         X_all = features_df[cols]
-        # Split based on last fold (use full dataset as both train & query for vis)
-        # In reality, we'd want the actual train/test split; for now,
-        # we visualize the entire dataset with OOD scores overlaid.
-        n_total = len(X_all)
-        n_ood_scores = len(ood_res.composite_scores)
+        n_ood = len(ood_res.composite_scores)
+        X_train = X_all.iloc[:len(X_all) - n_ood]
+        X_query = X_all.iloc[len(X_all) - n_ood:]
 
-        # If OOD scores cover only a subset, we need to handle this
-        if n_ood_scores < n_total:
-            X_train = X_all.iloc[:n_total - n_ood_scores]
-            X_query = X_all.iloc[n_total - n_ood_scores:]
-        else:
-            # Scores cover full dataset
-            X_train = X_all.iloc[:n_total // 2]
-            X_query = X_all.iloc[n_total // 2:]
-            # Trim OOD scores to match query size
-            ood_scores_vis = ood_res.composite_scores[:len(X_query)]
-            is_ood_vis = ood_res.is_ood[:len(X_query)]
-
-        if n_ood_scores < n_total:
-            ood_scores_vis = ood_res.composite_scores
-            is_ood_vis = ood_res.is_ood
-
-        fig = plotly_ood_map(
-            X_train, X_query,
-            composite_scores=ood_scores_vis,
-            is_ood=is_ood_vis,
-            title=f"OOD Map (PCA) — {fs_key}",
-        )
-
-        summary = (
-            f"Total query: {ood_res.n_total} | "
-            f"OOD: {ood_res.n_ood} ({ood_res.ood_ratio:.1%}) | "
-            f"Threshold: {ood_res.ood_threshold:.4f}"
-        )
-
-        # OOD candidates table
-        cand_df = pd.DataFrame()
-        if comps_df is not None and ood_res.is_ood.any():
-            ood_mask = ood_res.is_ood
-            # Map OOD indices back to composition DataFrame
-            if n_ood_scores <= len(comps_df):
-                offset = len(comps_df) - n_ood_scores
-                ood_global_idx = np.where(ood_mask)[0] + offset
-                ood_global_idx = ood_global_idx[ood_global_idx < len(comps_df)]
-                if len(ood_global_idx) > 0:
-                    cand_df = comps_df.iloc[ood_global_idx].copy()
-                    cand_df["OOD_Score"] = ood_res.composite_scores[
-                        ood_global_idx - offset
-                    ]
-                    cand_df = cand_df.sort_values("OOD_Score", ascending=False).head(20)
-                    cand_df = cand_df.round(3)
-
-        return fig, summary, cand_df
-
-    refresh_btn = gr.Button("Refresh OOD Map", variant="primary")
-    refresh_btn.click(
-        fn=refresh_ood,
-        inputs=[fs_selector],
-        outputs=[ood_plot, ood_summary, ood_candidates],
-    )
-    fs_selector.change(
-        fn=refresh_ood,
-        inputs=[fs_selector],
-        outputs=[ood_plot, ood_summary, ood_candidates],
+    fig = plotly_ood_map(
+        X_train, X_query,
+        composite_scores=ood_res.composite_scores,
+        is_ood=ood_res.is_ood,
+        title=f"OOD Map (PCA) -- {fs_key}",
     )
 
-
-# ---------------------------------------------------------------------------
-# Tab 5: Literature Search
-# ---------------------------------------------------------------------------
-
-def _build_literature_tab() -> None:
-    gr.Markdown("## Literature Search — Embedding + Structured Filters")
-
-    with gr.Row():
-        with gr.Column(scale=2):
-            query_input = gr.Textbox(
-                label="Search Query",
-                value="composition only yield strength HEA",
-                lines=2,
-                info="Natural language or workflow-text-like query",
-            )
-        with gr.Column(scale=1):
-            domain_filter = gr.Textbox(label="Domain", value="HEA")
-            task_filter = gr.Textbox(label="Task", value="yield_strength")
-
-    with gr.Row():
-        inputs_filter = gr.Dropdown(
-            choices=["", "composition_only", "+process", "+calphad", "+microstructure"],
-            value="",
-            label="Inputs Scope",
-        )
-        top_n = gr.Slider(minimum=1, maximum=20, value=10, step=1, label="Top N")
-
-    search_btn = gr.Button("Search Literature", variant="primary")
-
-    results_table = gr.Dataframe(label="Search Results")
-    freq_plot = gr.Plot(label="Feature Frequency")
-    recommendation = gr.Textbox(label="Feature Recommendation", lines=5, interactive=False)
-
-    def do_search(
-        query: str, domain: str, task: str,
-        inputs_scope: str, top: int,
-    ) -> Tuple:
-        try:
-            from hea_extrapolation_platform.literature_graph.seed_data import (
-                get_seed_papers, get_seed_workflows,
-            )
-            from hea_extrapolation_platform.literature_graph.workflow_text import (
-                generate_workflow_text,
-            )
-            from hea_extrapolation_platform.literature_graph.vector_index import (
-                build_index,
-            )
-            from hea_extrapolation_platform.literature_graph.search import (
-                LiteratureSearchEngine, StructuredFilter,
-            )
-            from hea_extrapolation_platform.literature_graph.feature_recommender import (
-                LiteratureFeatureRecommender,
-            )
-
-            papers = get_seed_papers()
-            workflows = get_seed_workflows()
-            wf_texts = [generate_workflow_text(w) for w in workflows]
-            wf_ids = [w.workflow_id for w in workflows]
-            index = build_index(wf_ids, wf_texts, use_faiss=True)
-
-            engine = LiteratureSearchEngine(
-                index=index, workflows=workflows, papers=papers,
-            )
-
-            sf = StructuredFilter(
-                materials_domain=domain if domain.strip() else None,
-                task=task if task.strip() else None,
-                inputs=inputs_scope if inputs_scope.strip() else None,
-            )
-
-            results = engine.search(query, structured_filter=sf, top_n=top)
-            _SESSION["literature_results"] = results
-
-            # Results table
-            records = []
-            for i, r in enumerate(results):
-                wf = r.workflow
-                records.append({
-                    "Rank": i + 1,
-                    "Paper ID": wf.paper_id,
-                    "Model": wf.model_name,
-                    "Family": wf.model_family,
-                    "Inputs": wf.inputs,
-                    "Split": wf.split_policy,
-                    "N": wf.data_size_n,
-                    "Key Features": ", ".join(wf.key_features[:5]),
-                    "Score": round(r.final_score, 4),
-                })
-            r_df = pd.DataFrame(records) if records else pd.DataFrame()
-
-            # Feature frequency
-            _, feature_counts = engine.search_for_features(
-                query, structured_filter=sf, top_n=top,
-            )
-            _SESSION["feature_counts"] = feature_counts
-            freq_fig = plotly_feature_frequency(feature_counts)
-
-            # Feature recommendation
-            recommender = LiteratureFeatureRecommender(engine)
-            rec = recommender.recommend(query, structured_filter=sf)
-            _SESSION["feature_recommendation"] = rec
-
-            rec_text = f"Recommended set: {rec.name}\n"
-            rec_text += f"Base features ({len(rec.base_features)}): {', '.join(rec.base_features)}\n"
-            if rec.added_features:
-                rec_text += f"Added from literature ({len(rec.added_features)}): {', '.join(rec.added_features)}\n"
-            if rec.unregistered_features:
-                rec_text += f"Unregistered features: {', '.join(rec.unregistered_features)}\n"
-
-            return r_df, freq_fig, rec_text
-
-        except Exception:
-            err = traceback.format_exc()
-            return pd.DataFrame(), None, f"Error:\n{err}"
-
-    search_btn.click(
-        fn=do_search,
-        inputs=[query_input, domain_filter, task_filter, inputs_filter, top_n],
-        outputs=[results_table, freq_plot, recommendation],
+    summary = (
+        f"Total query: {ood_res.n_total} | "
+        f"OOD: {ood_res.n_ood} ({ood_res.ood_ratio:.1%}) | "
+        f"Threshold: {ood_res.ood_threshold:.4f}"
     )
 
+    cand_df = pd.DataFrame()
+    if comps_df is not None and ood_res.is_ood.any() and split is not None:
+        _, test_idx_arr = split
+        ood_mask = ood_res.is_ood
+        ood_local = np.where(ood_mask)[0]
+        ood_global = np.asarray(test_idx_arr)[ood_local]
+        ood_global = ood_global[ood_global < len(comps_df)]
+        if len(ood_global) > 0:
+            cand_df = comps_df.iloc[ood_global].copy()
+            cand_df["OOD_Score"] = ood_res.composite_scores[
+                ood_local[:len(ood_global)]
+            ]
+            cand_df = cand_df.sort_values(
+                "OOD_Score", ascending=False,
+            ).head(20)
+            cand_df = cand_df.round(3)
 
-# ---------------------------------------------------------------------------
-# Tab 6: Report
-# ---------------------------------------------------------------------------
+    return fig, summary, cand_df
 
-def _build_report_tab() -> None:
-    gr.Markdown("## Experiment Report — Markdown Preview & Download")
 
-    report_md = gr.Markdown(value="*No report generated yet. Run an experiment first.*")
-    download_btn = gr.File(label="Download Report (.md)")
-
-    def refresh_report() -> Tuple:
-        report_path = _SESSION.get("report_path")
-        if report_path is None or not Path(report_path).exists():
-            return "*No report available.*", None
-
-        content = Path(report_path).read_text(encoding="utf-8")
-        return content, str(report_path)
-
-    refresh_btn = gr.Button("Refresh Report", variant="primary")
-    refresh_btn.click(
-        fn=refresh_report,
-        inputs=[],
-        outputs=[report_md, download_btn],
-    )
+def _refresh_report_data(session: Dict[str, Any]) -> Tuple:
+    report_path = session.get("report_path")
+    if report_path is None or not Path(report_path).exists():
+        return "*No report available.*", None
+    content = Path(report_path).read_text(encoding="utf-8")
+    return content, str(report_path)
 
 
 # ---------------------------------------------------------------------------
@@ -652,27 +260,623 @@ def _build_report_tab() -> None:
 
 def create_app() -> gr.Blocks:
     """Build and return the Gradio Blocks app."""
+    # Fix #5: theme placement — Gradio 6.0+ expects theme in launch(),
+    # but we store it so create_app() callers can pass it to launch().
     with gr.Blocks(
         title="Extrapolation Discovery Platform",
     ) as app:
         gr.Markdown(
             "# Extrapolation Discovery Platform\n"
-            "外挿発見基盤 — Feature Validity Evaluation & OOD Detection Dashboard"
+            "Feature Validity Evaluation & OOD Detection Dashboard"
         )
 
+        # Fix #1: per-user session state via gr.State
+        state = gr.State(_empty_session)
+
         with gr.Tabs():
+            # --- Tab 1: Dashboard ---
             with gr.Tab("Dashboard"):
-                _build_dashboard_tab()
+                gr.Markdown("## Dashboard -- KPIs & Feature Validity")
+                gr.Markdown(
+                    "Run an experiment from the **Config** tab first, "
+                    "then refresh this page to see results."
+                )
+
+                with gr.Row():
+                    kpi_runs = gr.Textbox(
+                        label="Total Runs", value="0", interactive=False,
+                    )
+                    kpi_best_fs = gr.Textbox(
+                        label="Best Feature Set", value="--", interactive=False,
+                    )
+                    kpi_best_score = gr.Textbox(
+                        label="Best Total Score", value="--", interactive=False,
+                    )
+                    kpi_ood_count = gr.Textbox(
+                        label="OOD Samples", value="--", interactive=False,
+                    )
+
+                validity_plot = gr.Plot(label="Feature Validity Ranking")
+                heatmap_plot = gr.Plot(label="Performance Heatmap (RMSE Test)")
+                heatmap_metric = gr.Dropdown(
+                    choices=[
+                        "rmse_test", "rmse_train", "mae_test",
+                        "mae_train", "r2_test", "r2_train",
+                    ],
+                    value="rmse_test",
+                    label="Heatmap Metric",
+                )
+
+                dash_refresh_btn = gr.Button(
+                    "Refresh Dashboard", variant="primary",
+                )
+                dash_outputs = [
+                    kpi_runs, kpi_best_fs, kpi_best_score,
+                    kpi_ood_count, validity_plot, heatmap_plot,
+                ]
+                dash_refresh_btn.click(
+                    fn=_refresh_dashboard_data,
+                    inputs=[heatmap_metric, state],
+                    outputs=dash_outputs,
+                )
+                heatmap_metric.change(
+                    fn=_refresh_dashboard_data,
+                    inputs=[heatmap_metric, state],
+                    outputs=dash_outputs,
+                )
+
+            # --- Tab 2: Config & Run ---
             with gr.Tab("Config & Run"):
-                _build_config_tab()
+                gr.Markdown("## Experiment Configuration & Execution")
+
+                with gr.Row():
+                    with gr.Column():
+                        seeds_input = gr.Textbox(
+                            label="Seeds (space-separated)",
+                            value="42 123 456",
+                            info="Random seeds for reproducibility",
+                        )
+                        n_samples = gr.Slider(
+                            minimum=50, maximum=1000, value=200, step=50,
+                            label="Number of Samples",
+                        )
+                        quick_mode = gr.Checkbox(
+                            label="Quick Mode (reduced HPO)",
+                            value=True,
+                            info="Use reduced hyperparameter grids",
+                        )
+                    with gr.Column():
+                        exclude_elements = gr.Textbox(
+                            label="Exclude Elements (space-separated)",
+                            value="Co Ni Ti",
+                            info="Elements for ElementExclusion splits",
+                        )
+                        skip_literature = gr.Checkbox(
+                            label="Skip Literature Search",
+                            value=False,
+                        )
+                        skip_plots = gr.Checkbox(
+                            label="Skip Static Plots (matplotlib)",
+                            value=True,
+                            info="Skip PNG generation (Plotly always available)",
+                        )
+
+                run_btn = gr.Button(
+                    "Run Experiment", variant="primary", size="lg",
+                )
+                progress_log = gr.Textbox(
+                    label="Progress Log",
+                    lines=15,
+                    interactive=False,
+                )
+
+            # --- Tab 3: Results ---
             with gr.Tab("Results"):
-                _build_results_tab()
+                gr.Markdown("## Experiment Results -- Run Table & Parity Plot")
+
+                with gr.Row():
+                    filter_wf = gr.Dropdown(
+                        choices=["All"], value="All", label="Workflow Filter",
+                    )
+                    filter_fs = gr.Dropdown(
+                        choices=["All"], value="All", label="Feature Set Filter",
+                    )
+                    filter_sp = gr.Dropdown(
+                        choices=["All"], value="All", label="Split Policy Filter",
+                    )
+
+                validity_table = gr.Dataframe(label="Feature Validity Ranking")
+                results_table = gr.Dataframe(label="Run Results")
+                parity_plot = gr.Plot(label="Parity Plot")
+
+                res_refresh_btn = gr.Button(
+                    "Refresh Results", variant="primary",
+                )
+                res_outputs = [
+                    filter_wf, filter_fs, filter_sp,
+                    validity_table, results_table, parity_plot,
+                ]
+                res_refresh_btn.click(
+                    fn=_refresh_results_data,
+                    inputs=[filter_wf, filter_fs, filter_sp, state],
+                    outputs=res_outputs,
+                )
+                for dropdown in [filter_wf, filter_fs, filter_sp]:
+                    dropdown.change(
+                        fn=_refresh_results_data,
+                        inputs=[filter_wf, filter_fs, filter_sp, state],
+                        outputs=res_outputs,
+                    )
+
+            # --- Tab 4: OOD Map ---
             with gr.Tab("OOD Map"):
-                _build_ood_tab()
+                gr.Markdown(
+                    "## OOD (Out-of-Distribution) Map & Candidates",
+                )
+
+                fs_selector = gr.Dropdown(
+                    choices=[
+                        "FS_BASE", "FS_THERMO", "FS_SIZE",
+                        "FS_ELECTRON", "FS_ALL",
+                    ],
+                    value="FS_ALL",
+                    label="Feature Set for OOD Map",
+                )
+                ood_plot = gr.Plot(label="OOD Map (PCA)")
+                with gr.Row():
+                    ood_summary = gr.Textbox(
+                        label="OOD Summary", interactive=False,
+                    )
+                ood_candidates = gr.Dataframe(label="Top OOD Candidates")
+
+                ood_refresh_btn = gr.Button(
+                    "Refresh OOD Map", variant="primary",
+                )
+                ood_outputs = [ood_plot, ood_summary, ood_candidates]
+                ood_refresh_btn.click(
+                    fn=_refresh_ood_data,
+                    inputs=[fs_selector, state],
+                    outputs=ood_outputs,
+                )
+                fs_selector.change(
+                    fn=_refresh_ood_data,
+                    inputs=[fs_selector, state],
+                    outputs=ood_outputs,
+                )
+
+            # --- Tab 5: Literature Search ---
             with gr.Tab("Literature Search"):
-                _build_literature_tab()
+                gr.Markdown(
+                    "## Literature Search -- Embedding + Structured Filters",
+                )
+
+                with gr.Row():
+                    with gr.Column(scale=2):
+                        query_input = gr.Textbox(
+                            label="Search Query",
+                            value="composition only yield strength HEA",
+                            lines=2,
+                            info="Natural language or workflow-text query",
+                        )
+                    with gr.Column(scale=1):
+                        domain_filter = gr.Textbox(
+                            label="Domain", value="HEA",
+                        )
+                        task_filter = gr.Textbox(
+                            label="Task", value="yield_strength",
+                        )
+
+                with gr.Row():
+                    # Fix #4: choices match InputScope enum values
+                    inputs_filter = gr.Dropdown(
+                        choices=[
+                            "",
+                            "composition_only",
+                            "composition+process",
+                            "composition+calphad",
+                            "composition+microstructure",
+                            "full",
+                        ],
+                        value="",
+                        label="Inputs Scope",
+                    )
+                    lit_top_n = gr.Slider(
+                        minimum=1, maximum=20, value=10, step=1,
+                        label="Top N",
+                    )
+
+                search_btn = gr.Button(
+                    "Search Literature", variant="primary",
+                )
+                lit_results_table = gr.Dataframe(label="Search Results")
+                freq_plot = gr.Plot(label="Feature Frequency")
+                lit_recommendation = gr.Textbox(
+                    label="Feature Recommendation",
+                    lines=5,
+                    interactive=False,
+                )
+
+                def do_search(
+                    query: str, domain: str, task: str,
+                    inputs_scope: str, top: float,
+                    session: Dict[str, Any],
+                ) -> Tuple:
+                    try:
+                        from hea_extrapolation_platform.literature_graph.search import (
+                            StructuredFilter,
+                        )
+                        from hea_extrapolation_platform.literature_graph.feature_recommender import (
+                            LiteratureFeatureRecommender,
+                        )
+
+                        # Fix #9: use cached engine
+                        engine = _get_literature_engine(session)
+
+                        sf = StructuredFilter(
+                            materials_domain=domain.strip() or None,
+                            task=task.strip() or None,
+                            inputs=inputs_scope.strip() or None,
+                        )
+
+                        results = engine.search(
+                            query, structured_filter=sf, top_n=int(top),
+                        )
+                        session["literature_results"] = results
+
+                        records = []
+                        for i, r in enumerate(results):
+                            wf = r.workflow
+                            records.append({
+                                "Rank": i + 1,
+                                "Paper ID": wf.paper_id,
+                                "Model": wf.model_name,
+                                "Family": wf.model_family,
+                                "Inputs": wf.inputs,
+                                "Split": wf.split_policy,
+                                "N": wf.data_size_n,
+                                "Key Features": ", ".join(
+                                    wf.key_features[:5],
+                                ),
+                                "Score": round(r.final_score, 4),
+                            })
+                        r_df = (
+                            pd.DataFrame(records)
+                            if records
+                            else pd.DataFrame()
+                        )
+
+                        _, feature_counts = engine.search_for_features(
+                            query, structured_filter=sf, top_n=int(top),
+                        )
+                        session["feature_counts"] = feature_counts
+                        freq_fig_val = plotly_feature_frequency(
+                            feature_counts,
+                        )
+
+                        recommender = LiteratureFeatureRecommender(engine)
+                        rec = recommender.recommend(
+                            query, structured_filter=sf,
+                        )
+                        session["feature_recommendation"] = rec
+
+                        rec_text = f"Recommended set: {rec.name}\n"
+                        rec_text += (
+                            f"Base features ({len(rec.base_features)}): "
+                            f"{', '.join(rec.base_features)}\n"
+                        )
+                        if rec.added_features:
+                            rec_text += (
+                                f"Added from literature "
+                                f"({len(rec.added_features)}): "
+                                f"{', '.join(rec.added_features)}\n"
+                            )
+                        if rec.unregistered_features:
+                            rec_text += (
+                                f"Unregistered features: "
+                                f"{', '.join(rec.unregistered_features)}\n"
+                            )
+
+                        return r_df, freq_fig_val, rec_text, session
+
+                    except Exception:
+                        err = traceback.format_exc()
+                        return (
+                            pd.DataFrame(), None,
+                            f"Error:\n{err}", session,
+                        )
+
+                search_btn.click(
+                    fn=do_search,
+                    inputs=[
+                        query_input, domain_filter, task_filter,
+                        inputs_filter, lit_top_n, state,
+                    ],
+                    outputs=[
+                        lit_results_table, freq_plot,
+                        lit_recommendation, state,
+                    ],
+                )
+
+            # --- Tab 6: Report ---
             with gr.Tab("Report"):
-                _build_report_tab()
+                gr.Markdown(
+                    "## Experiment Report -- Markdown Preview & Download",
+                )
+                report_md = gr.Markdown(
+                    value="*No report generated yet. "
+                    "Run an experiment first.*",
+                )
+                download_btn = gr.File(label="Download Report (.md)")
+
+                rpt_refresh_btn = gr.Button(
+                    "Refresh Report", variant="primary",
+                )
+                rpt_outputs = [report_md, download_btn]
+                rpt_refresh_btn.click(
+                    fn=_refresh_report_data,
+                    inputs=[state],
+                    outputs=rpt_outputs,
+                )
+
+        # ---------------------------------------------------------------
+        # Run experiment generator  -- Fix #7 (streaming progress)
+        # ---------------------------------------------------------------
+
+        def run_experiment(
+            seeds_str: str,
+            n_samp: float,
+            quick: bool,
+            excl_str: str,
+            skip_lit: bool,
+            skip_plt: bool,
+            session: Dict[str, Any],
+        ) -> Generator:
+            """Generator that yields incremental progress + state.
+
+            Using a generator enables Gradio to stream updates to the
+            progress_log while the experiment runs (fix #7).
+            The final yield refreshes all cross-tab components (#8).
+            """
+            log_lines: List[str] = []
+
+            def log(msg: str) -> None:
+                log_lines.append(f"[{time.strftime('%H:%M:%S')}] {msg}")
+
+            # Reset session
+            session = _empty_session()
+
+            # Placeholder outputs for cross-tab components
+            empty_dash = ("0", "--", "--", "--", None, None)
+            empty_res = (
+                gr.update(), gr.update(), gr.update(),
+                pd.DataFrame(), pd.DataFrame(), None,
+            )
+            empty_ood = (None, "", pd.DataFrame())
+            empty_rpt = ("*Running...*", None)
+
+            def _yield_progress(log_text: str) -> Tuple:
+                return (
+                    log_text, session,
+                    *empty_dash, *empty_res, *empty_ood, *empty_rpt,
+                )
+
+            try:
+                log("Starting experiment...")
+                yield _yield_progress("\n".join(log_lines))
+
+                seeds = [
+                    int(s.strip())
+                    for s in seeds_str.split()
+                    if s.strip()
+                ]
+                excl = [
+                    e.strip()
+                    for e in excl_str.split()
+                    if e.strip()
+                ]
+
+                if not seeds:
+                    log("Error: No valid seeds provided.")
+                    yield _yield_progress("\n".join(log_lines))
+                    return
+
+                # Fix #2: cast slider float -> int
+                n_samp_int = int(n_samp)
+
+                # 1. Dataset generation
+                from hea_extrapolation_platform.dataset import (
+                    generate_hea_dataset,
+                )
+                log(f"Generating dataset: n={n_samp_int}, seed={seeds[0]}")
+                yield _yield_progress("\n".join(log_lines))
+
+                comps_df, features_df, target = generate_hea_dataset(
+                    n_samples=n_samp_int, seed=seeds[0],
+                )
+                session["compositions_df"] = comps_df
+                session["features_df"] = features_df
+                session["target"] = target
+                log(
+                    f"Dataset: {len(target)} samples, "
+                    f"{features_df.shape[1]} features"
+                )
+                yield _yield_progress("\n".join(log_lines))
+
+                # 2. Run experiments
+                from hea_extrapolation_platform.runner import (
+                    ExperimentRunner,
+                )
+                log(f"Running experiments: seeds={seeds}, quick={quick}")
+                yield _yield_progress("\n".join(log_lines))
+
+                runner = ExperimentRunner(
+                    seeds=seeds, quick=quick, exclude_elements=excl,
+                )
+                runs, scores, ood_results = runner.run(
+                    comps_df, features_df, target,
+                )
+
+                session["runs"] = runs
+                session["validity_scores"] = scores
+                session["ood_results"] = ood_results
+                session["ood_split_indices"] = runner.ood_split_indices
+                session["runner"] = runner
+
+                log(f"Completed: {len(runs)} runs")
+                if scores:
+                    log(
+                        f"Best feature set: {scores[0].feature_set} "
+                        f"(score={scores[0].total:.4f})"
+                    )
+
+                for fs_key, ood_res in ood_results.items():
+                    log(
+                        f"OOD [{fs_key}]: "
+                        f"{ood_res.n_ood}/{ood_res.n_total} "
+                        f"({ood_res.ood_ratio:.1%})"
+                    )
+                yield _yield_progress("\n".join(log_lines))
+
+                # 3. Export registry  -- Fix #12: timestamp dir
+                ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+                out_dir = Path("results") / ts
+                out_dir.mkdir(parents=True, exist_ok=True)
+                runner.export(out_dir)
+                log(
+                    f"Run registry exported to "
+                    f"{out_dir / 'run_registry.json'}"
+                )
+                yield _yield_progress("\n".join(log_lines))
+
+                # 4. Static plots (optional)
+                figure_paths: Dict[str, Path] = {}
+                if not skip_plt:
+                    from hea_extrapolation_platform.visualization import (
+                        plot_validity_ranking,
+                        plot_performance_heatmap,
+                        plot_parity,
+                    )
+                    fig_dir = out_dir / "figures"
+                    figure_paths["Validity"] = plot_validity_ranking(
+                        scores, fig_dir,
+                    )
+                    figure_paths["Heatmap"] = plot_performance_heatmap(
+                        runs, fig_dir,
+                    )
+                    figure_paths["Parity"] = plot_parity(runs, fig_dir)
+                    log("Static plots saved.")
+                    yield _yield_progress("\n".join(log_lines))
+
+                # 5. Literature search (optional, cached -- fix #9)
+                if not skip_lit:
+                    try:
+                        from hea_extrapolation_platform.literature_graph.search import (
+                            StructuredFilter,
+                        )
+                        from hea_extrapolation_platform.literature_graph.feature_recommender import (
+                            LiteratureFeatureRecommender,
+                        )
+                        log("Building literature index...")
+                        yield _yield_progress("\n".join(log_lines))
+
+                        engine = _get_literature_engine(session)
+                        query = "composition only yield strength HEA"
+                        sf = StructuredFilter(
+                            materials_domain="HEA",
+                            task="yield_strength",
+                        )
+                        lit_results = engine.search(
+                            query, structured_filter=sf, top_n=5,
+                        )
+                        session["literature_results"] = lit_results
+
+                        recommender = LiteratureFeatureRecommender(engine)
+                        rec = recommender.recommend(
+                            query, structured_filter=sf,
+                        )
+                        session["feature_recommendation"] = rec
+                        log(
+                            f"Literature search: "
+                            f"{len(lit_results)} results"
+                        )
+                        yield _yield_progress("\n".join(log_lines))
+                    except Exception as exc:
+                        log(
+                            f"Literature search failed (non-fatal): {exc}"
+                        )
+                        yield _yield_progress("\n".join(log_lines))
+
+                # 6. Report generation
+                from hea_extrapolation_platform.report import (
+                    ReportGenerator,
+                )
+                gen = ReportGenerator(out_dir=out_dir)
+                best_ood = None
+                if scores and ood_results:
+                    best_ood = ood_results.get(scores[0].feature_set)
+
+                report_path = gen.generate(
+                    runs=runs,
+                    validity_scores=scores,
+                    ood_result=best_ood,
+                    compositions_df=comps_df,
+                    figure_paths=figure_paths,
+                    literature_results=session.get("literature_results"),
+                    feature_recommendation=session.get(
+                        "feature_recommendation",
+                    ),
+                )
+                session["report_path"] = report_path
+                log(f"Report: {report_path}")
+                log(
+                    "Experiment complete. All tabs refreshed automatically."
+                )
+
+            except Exception:
+                log(f"ERROR:\n{traceback.format_exc()}")
+
+            # --- Final yield: refresh all tabs (fix #8) ---
+            final_dash = _refresh_dashboard_data("rmse_test", session)
+            final_res = _refresh_results_data("All", "All", "All", session)
+            ood_keys = list(session.get("ood_results", {}).keys())
+            ood_fs = ood_keys[0] if ood_keys else "FS_ALL"
+            final_ood = _refresh_ood_data(ood_fs, session)
+            final_rpt = _refresh_report_data(session)
+
+            yield (
+                "\n".join(log_lines),
+                session,
+                *final_dash,
+                *final_res,
+                *final_ood,
+                *final_rpt,
+            )
+
+        # Wire up the run button to the generator
+        run_btn.click(
+            fn=run_experiment,
+            inputs=[
+                seeds_input, n_samples, quick_mode,
+                exclude_elements, skip_literature, skip_plots, state,
+            ],
+            outputs=[
+                # Config tab
+                progress_log, state,
+                # Dashboard tab (fix #8)
+                kpi_runs, kpi_best_fs, kpi_best_score, kpi_ood_count,
+                validity_plot, heatmap_plot,
+                # Results tab (fix #8)
+                filter_wf, filter_fs, filter_sp,
+                validity_table, results_table, parity_plot,
+                # OOD tab (fix #8)
+                ood_plot, ood_summary, ood_candidates,
+                # Report tab (fix #8)
+                report_md, download_btn,
+            ],
+        )
+
+    # Fix #6: enable queue for async / streaming execution
+    app.queue()
 
     return app
 
@@ -683,8 +887,9 @@ def create_app() -> gr.Blocks:
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
-    app = create_app()
-    app.launch(
+    application = create_app()
+    # Fix #5: theme passed to launch() (Gradio 6.0+ API)
+    application.launch(
         server_name="0.0.0.0",
         server_port=7860,
         theme=gr.themes.Soft(),

--- a/hea_extrapolation_platform/gui/app.py
+++ b/hea_extrapolation_platform/gui/app.py
@@ -335,8 +335,8 @@ def _build_results_tab() -> None:
             label="Workflow Filter",
         )
         filter_fs = gr.Dropdown(
-            choices=["All", "FS_BASE", "FS_BASE+FS_THERMO",
-                     "FS_BASE+FS_SIZE", "FS_BASE+FS_ELECTRON", "FS_ALL"],
+            choices=["All", "FS_BASE", "FS_THERMO",
+                     "FS_SIZE", "FS_ELECTRON", "FS_ALL"],
             value="All",
             label="Feature Set Filter",
         )
@@ -394,8 +394,8 @@ def _build_ood_tab() -> None:
     gr.Markdown("## OOD (Out-of-Distribution) Map & Candidates")
 
     fs_selector = gr.Dropdown(
-        choices=["FS_BASE", "FS_BASE+FS_THERMO",
-                 "FS_BASE+FS_SIZE", "FS_BASE+FS_ELECTRON", "FS_ALL"],
+        choices=["FS_BASE", "FS_THERMO",
+                 "FS_SIZE", "FS_ELECTRON", "FS_ALL"],
         value="FS_ALL",
         label="Feature Set for OOD Map",
     )

--- a/hea_extrapolation_platform/gui/plotly_charts.py
+++ b/hea_extrapolation_platform/gui/plotly_charts.py
@@ -278,13 +278,27 @@ def plotly_parity(
     all_wf: List[str] = []
     all_fs: List[str] = []
 
+    # Fix #10: de-duplicate by (workflow, feature_set, sample_index)
+    # When multiple seeds / folds produce predictions for the same sample,
+    # keep only the first occurrence to avoid misleading scatter density.
+    seen_keys: set = set()
+
     for r in runs:
         if r.y_test_true is not None and r.y_test_pred is not None:
-            n = len(r.y_test_true)
-            all_true.extend(r.y_test_true.tolist())
-            all_pred.extend(r.y_test_pred.tolist())
-            all_wf.extend([r.workflow] * n)
-            all_fs.extend([r.feature_set] * n)
+            test_indices = getattr(r, "test_indices", None)
+            for i in range(len(r.y_test_true)):
+                if test_indices is not None:
+                    key = (r.workflow, r.feature_set, int(test_indices[i]))
+                else:
+                    # Fallback: use (wf, fs, true_value) as rough key
+                    key = (r.workflow, r.feature_set, float(r.y_test_true[i]))
+                if key in seen_keys:
+                    continue
+                seen_keys.add(key)
+                all_true.append(float(r.y_test_true[i]))
+                all_pred.append(float(r.y_test_pred[i]))
+                all_wf.append(r.workflow)
+                all_fs.append(r.feature_set)
 
     fig = go.Figure()
 

--- a/hea_extrapolation_platform/literature_graph/schemas.py
+++ b/hea_extrapolation_platform/literature_graph/schemas.py
@@ -88,6 +88,12 @@ class Paper:
     materials_domain: str = "HEA"
     task: str = "yield_strength"
     notes: str = ""
+    doi_verified: bool = False
+    """Whether ``paper_id`` (DOI) has been verified against CrossRef/DOI.org.
+
+    Seed data is auto-generated and DOIs are *plausible but unverified*.
+    Set to ``True`` only after programmatic or manual verification.
+    """
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)

--- a/hea_extrapolation_platform/ood.py
+++ b/hea_extrapolation_platform/ood.py
@@ -79,6 +79,11 @@ class OODDetector:
         self._fitted = False
         self._train_composite: Optional[np.ndarray] = None
         self._ood_threshold: float = 0.0
+        # Normalization params saved at fit-time for consistent scoring
+        self._maha_min: float = 0.0
+        self._maha_max: float = 1.0
+        self._knn_min: float = 0.0
+        self._knn_max: float = 1.0
 
     # ------------------------------------------------------------------
     # Fit
@@ -109,17 +114,30 @@ class OODDetector:
             logger.warning("Covariance matrix singular – using pseudo-inverse")
             self._cov_inv = np.linalg.pinv(cov)
 
-        # kNN setup
+        # kNN setup — use k+1 neighbours so that when querying training
+        # data we can drop the self-reference (distance-0 hit).
         actual_k = min(self._k, X_scaled.shape[0] - 1)
         if actual_k < 1:
             actual_k = 1
-        self._nn = NearestNeighbors(n_neighbors=actual_k, metric="euclidean")
+        self._nn = NearestNeighbors(n_neighbors=actual_k + 1, metric="euclidean")
         self._nn.fit(X_scaled)
 
-        # Compute training set scores for threshold calibration
+        # Compute training set scores for threshold calibration.
+        # _knn_batch_train excludes self-reference (first column).
         maha_train = self._mahalanobis_batch(X_scaled)
-        knn_train = self._knn_batch(X_scaled)
-        composite_train = self._combine(maha_train, knn_train)
+        knn_train = self._knn_batch_train(X_scaled)
+
+        # Save training min/max for consistent normalization at score-time
+        self._maha_min = float(maha_train.min())
+        self._maha_max = float(maha_train.max())
+        self._knn_min = float(knn_train.min())
+        self._knn_max = float(knn_train.max())
+
+        composite_train = self._combine(
+            maha_train, knn_train,
+            maha_min=self._maha_min, maha_max=self._maha_max,
+            knn_min=self._knn_min, knn_max=self._knn_max,
+        )
         self._train_composite = composite_train
         self._ood_threshold = float(np.quantile(composite_train, self._threshold_q))
 
@@ -151,7 +169,11 @@ class OODDetector:
 
         maha = self._mahalanobis_batch(X_scaled)
         knn = self._knn_batch(X_scaled)
-        composite = self._combine(maha, knn)
+        composite = self._combine(
+            maha, knn,
+            maha_min=self._maha_min, maha_max=self._maha_max,
+            knn_min=self._knn_min, knn_max=self._knn_max,
+        )
 
         is_ood = composite > self._ood_threshold
         n_ood = int(is_ood.sum())
@@ -182,23 +204,51 @@ class OODDetector:
         ])
         return dists
 
-    def _knn_batch(self, X_scaled: np.ndarray) -> np.ndarray:
-        """Compute mean kNN distance for each row."""
+    def _knn_batch_train(self, X_scaled: np.ndarray) -> np.ndarray:
+        """Compute mean kNN distance for training data (excludes self).
+
+        The fitted NearestNeighbors uses k+1 neighbours.  The first
+        column is always the query point itself (distance ≈ 0), so we
+        drop it.
+        """
         dists, _ = self._nn.kneighbors(X_scaled)
-        return dists.mean(axis=1)
+        return dists[:, 1:].mean(axis=1)
+
+    def _knn_batch(self, X_scaled: np.ndarray) -> np.ndarray:
+        """Compute mean kNN distance for query data (no self-reference).
+
+        Query points are not part of the fitted index, so there is no
+        self-reference.  However, the fitted model has k+1 neighbours;
+        we take only the first k columns to keep the same semantics as
+        training.
+        """
+        dists, _ = self._nn.kneighbors(X_scaled)
+        return dists[:, :self._k].mean(axis=1)
 
     @staticmethod
     def _combine(
         maha: np.ndarray,
         knn: np.ndarray,
+        maha_min: float,
+        maha_max: float,
+        knn_min: float,
+        knn_max: float,
         w_maha: float = 0.5,
         w_knn: float = 0.5,
     ) -> np.ndarray:
-        """Normalise and combine Mahalanobis + kNN into [0, 1] composite."""
-        def _norm(arr: np.ndarray) -> np.ndarray:
-            lo, hi = arr.min(), arr.max()
+        """Normalise and combine Mahalanobis + kNN into composite score.
+
+        Normalization uses training-set min/max so that fit() and
+        score() operate on the same scale.  Query scores may exceed
+        [0, 1] when they are further from the training distribution
+        than any training sample – this is intentional.
+        """
+        def _norm(arr: np.ndarray, lo: float, hi: float) -> np.ndarray:
             if hi - lo < 1e-12:
                 return np.zeros_like(arr)
             return (arr - lo) / (hi - lo)
 
-        return w_maha * _norm(maha) + w_knn * _norm(knn)
+        return (
+            w_maha * _norm(maha, maha_min, maha_max)
+            + w_knn * _norm(knn, knn_min, knn_max)
+        )

--- a/hea_extrapolation_platform/requirements.txt
+++ b/hea_extrapolation_platform/requirements.txt
@@ -1,25 +1,36 @@
 # Extrapolation Discovery Platform - Dependencies
 # 外挿発見基盤 依存パッケージ
+#
+# Install core only:  pip install -r requirements.txt
+# Install everything: pip install -r requirements.txt  (uncomment optional lines)
 
-# Core (required)
+# ── Core (required) ──────────────────────────────────────────────────
 numpy>=1.24
 pandas>=2.0
 scikit-learn>=1.3
-scipy>=1.10
+scipy>=1.10            # Mahalanobis distance in ood.py
 matplotlib>=3.7
 
-# Tabular output (required for report markdown tables)
-tabulate>=0.9
+# ── Tabular output (required for report markdown tables) ─────────────
+tabulate>=0.9          # Used by report.py to_markdown(); has try/except fallback
 
-# XGBoost (optional – falls back to sklearn GradientBoosting if absent)
+# ── Optional: XGBoost ────────────────────────────────────────────────
+# Falls back to sklearn GradientBoostingRegressor if absent.
+# Needed by: workflows.py (WorkflowXGB)
 xgboost>=1.7
 
-# GUI – Gradio dashboard + interactive charts
+# ── Optional: GUI (Gradio dashboard + Plotly interactive charts) ─────
+# Needed by: gui/app.py, gui/plotly_charts.py
+# Not required for CLI-only usage.
 gradio>=4.0
 plotly>=5.18
 
-# Literature graph – vector search (optional – falls back to numpy cosine)
+# ── Optional: Literature graph – vector search ───────────────────────
+# Falls back to numpy cosine similarity if absent.
+# Needed by: literature_graph/vector_index.py
 # faiss-cpu>=1.7
 
-# Literature graph – embedding (optional – falls back to TF-IDF)
+# ── Optional: Literature graph – sentence embedding ──────────────────
+# Falls back to TF-IDF bag-of-words if absent.
+# Needed by: literature_graph/vector_index.py
 # sentence-transformers>=2.2

--- a/hea_extrapolation_platform/runner.py
+++ b/hea_extrapolation_platform/runner.py
@@ -130,6 +130,11 @@ class ExperimentRunner:
     def registry(self) -> RunRegistry:
         return self._registry
 
+    @property
+    def ood_split_indices(self) -> Dict[str, Tuple[np.ndarray, np.ndarray]]:
+        """Return {feature_set: (train_indices, test_indices)} used for OOD."""
+        return getattr(self, "_ood_split_indices", {})
+
     def _build_workflows(self) -> Dict[str, BaseWorkflow]:
         return {
             "WF-LIN": WorkflowLIN(),
@@ -186,6 +191,9 @@ class ExperimentRunner:
         )
 
         ood_results: Dict[str, OODResult] = {}
+        # Store the train/test indices used for OOD detection so callers
+        # (e.g. __main__.py visualization) can reconstruct X_train/X_test.
+        self._ood_split_indices: Dict[str, Tuple[np.ndarray, np.ndarray]] = {}
         ood_errors_for_eval: Dict[str, Dict[str, np.ndarray]] = {}
 
         run_count = 0
@@ -234,64 +242,17 @@ class ExperimentRunner:
 
                         fold_idx += 1
 
-                # OOD detection per feature set
-                # We fit on training data and score on test data to avoid
-                # self-scoring leak.  To guarantee index alignment between
-                # OOD flags and ensemble prediction errors, we find an ENS
-                # run that shares the *same* test_indices, rather than relying
-                # on size equality (which could match by coincidence).
+                # OOD detection per feature set (dedicated split).
                 fs_key = fs_name.value
                 if fs_key not in ood_results:
-                    try:
-                        X_train_ood = X_fs.iloc[train_idx]
-                        X_test_ood = X_fs.iloc[test_idx]
-                        ood_test_indices = np.asarray(test_idx)
-
-                        detector = OODDetector(k=10)
-                        detector.fit(X_train_ood)
-                        ood_res = detector.score(X_test_ood)
+                    ood_res = self._run_ood_detection(
+                        X_fs, target, compositions_df, fs_key,
+                    )
+                    if ood_res is not None:
                         ood_results[fs_key] = ood_res
-
-                        # Find an ENS run whose test_indices match the OOD
-                        # partition exactly (same indices, same order).
-                        ens_runs = [
-                            r for r in self._registry.runs
-                            if r.feature_set == fs_key and r.workflow == "WF-ENS"
-                               and r.test_indices is not None
-                        ]
-                        matched_ens = None
-                        for er in reversed(ens_runs):
-                            if np.array_equal(
-                                np.asarray(er.test_indices), ood_test_indices
-                            ):
-                                matched_ens = er
-                                break
-
-                        if matched_ens is not None:
-                            pred_std = np.array(
-                                matched_ens.artifacts.get("pred_std_test", [])
-                            )
-                            if (
-                                matched_ens.y_test_true is not None
-                                and matched_ens.y_test_pred is not None
-                                and len(pred_std) > 0
-                            ):
-                                errors = (
-                                    matched_ens.y_test_true
-                                    - matched_ens.y_test_pred
-                                )
-                                ood_errors_for_eval[fs_key] = {
-                                    "errors": errors,
-                                    "uncertainties": pred_std,
-                                    "is_ood": ood_res.is_ood,
-                                }
-                        else:
-                            logger.info(
-                                "No ENS run with matching test_indices "
-                                "for OOD eval on %s", fs_key,
-                            )
-                    except Exception:
-                        logger.exception("OOD detection failed for %s", fs_key)
+                        self._collect_ood_errors_for_eval(
+                            fs_key, ood_res, ood_errors_for_eval,
+                        )
 
         # Evaluation
         evaluator = FeatureValidityEvaluator()
@@ -308,6 +269,99 @@ class ExperimentRunner:
         )
 
         return self._registry.runs, validity_scores, ood_results
+
+    # ------------------------------------------------------------------
+    # Private helpers extracted from run() for readability
+    # ------------------------------------------------------------------
+
+    def _run_ood_detection(
+        self,
+        X_fs: pd.DataFrame,
+        target: pd.Series,
+        compositions_df: pd.DataFrame,
+        fs_key: str,
+    ) -> Optional[OODResult]:
+        """Run OOD detection on *one* feature set.
+
+        Uses a dedicated RandomCV split (first seed, first fold) so OOD
+        detection is deterministic and independent of the main experiment
+        loop.
+
+        Returns
+        -------
+        OODResult or None if detection failed.
+        """
+        try:
+            ood_splitter = RandomCVSplitter(n_folds=5, seed=self._seeds[0])
+            ood_folds = list(ood_splitter.split(
+                X_fs, target, compositions=compositions_df
+            ))
+            ood_train_idx, ood_test_idx = ood_folds[0]  # first fold
+            X_train_ood = X_fs.iloc[ood_train_idx]
+            X_test_ood = X_fs.iloc[ood_test_idx]
+
+            detector = OODDetector(k=10)
+            detector.fit(X_train_ood)
+            ood_res = detector.score(X_test_ood)
+
+            self._ood_split_indices[fs_key] = (
+                np.asarray(ood_train_idx),
+                np.asarray(ood_test_idx),
+            )
+            return ood_res
+        except Exception:
+            logger.exception("OOD detection failed for %s", fs_key)
+            return None
+
+    def _collect_ood_errors_for_eval(
+        self,
+        fs_key: str,
+        ood_res: OODResult,
+        ood_errors_for_eval: Dict[str, Dict[str, np.ndarray]],
+    ) -> None:
+        """Match an ENS run to the OOD partition and collect prediction errors.
+
+        The matched ENS run must share *exactly* the same ``test_indices``
+        as the OOD split to guarantee a valid comparison.
+        """
+        ood_test_indices = self._ood_split_indices[fs_key][1]
+
+        ens_runs = [
+            r for r in self._registry.runs
+            if r.feature_set == fs_key and r.workflow == "WF-ENS"
+               and r.test_indices is not None
+        ]
+        matched_ens = None
+        for er in reversed(ens_runs):
+            if np.array_equal(
+                np.asarray(er.test_indices), ood_test_indices
+            ):
+                matched_ens = er
+                break
+
+        if matched_ens is not None:
+            pred_std = np.array(
+                matched_ens.artifacts.get("pred_std_test", [])
+            )
+            if (
+                matched_ens.y_test_true is not None
+                and matched_ens.y_test_pred is not None
+                and len(pred_std) > 0
+            ):
+                errors = (
+                    matched_ens.y_test_true
+                    - matched_ens.y_test_pred
+                )
+                ood_errors_for_eval[fs_key] = {
+                    "errors": errors,
+                    "uncertainties": pred_std,
+                    "is_ood": ood_res.is_ood,
+                }
+        else:
+            logger.info(
+                "No ENS run with matching test_indices "
+                "for OOD eval on %s", fs_key,
+            )
 
     def export(self, out_dir: Path) -> None:
         """Export run registry to JSON."""

--- a/hea_extrapolation_platform/workflows.py
+++ b/hea_extrapolation_platform/workflows.py
@@ -156,13 +156,16 @@ class WorkflowLIN(BaseWorkflow):
         train_s = _score(y_train.values, y_train_pred)
         test_s = _score(y_test.values, y_test_pred)
 
-        # Extract standardised coefficients
-        scaler: StandardScaler = pipe.named_steps["scaler"]
+        # Extract standardised coefficients.
+        # Ridge inside the Pipeline sees *already-standardised* X (via the
+        # preceding StandardScaler step).  Therefore ``coef_raw[j]`` already
+        # represents "change in y per 1-std change in X_j".  To express
+        # the coefficient in units of "std_y per std_X", we only divide by
+        # std_y — multiplying by std_X again would double-count scaling.
         model: Ridge = pipe.named_steps["model"]
         coef_raw = model.coef_
-        std_X = scaler.scale_
         std_y = float(np.std(y_train.values)) if np.std(y_train.values) > 0 else 1.0
-        coef_std = coef_raw * std_X / std_y
+        coef_std = coef_raw / std_y
 
         result = RunResult(
             workflow=self.name,


### PR DESCRIPTION
## Summary

This PR addresses **two rounds of code review findings**:

1. **11 core platform fixes** (original scope) — OOD detection, coefficient calculation, split selection, etc.
2. **12 GUI dashboard fixes** (new) — session isolation, streaming progress, async execution, and more.

---

### Core platform fixes (🔴 critical bugs)

| # | File | Issue | Fix |
|---|------|-------|-----|
| 1 | `ood.py` | `_combine()` normalized independently in `fit()` vs `score()`, making threshold comparison meaningless | Persist training min/max at fit-time; reuse in `score()`. Query scores may now exceed [0,1] intentionally. |
| 2 | `ood.py` | kNN included self (distance=0) for training data, artificially lowering OOD threshold | Use `k+1` neighbors; new `_knn_batch_train()` drops column 0 (self); `_knn_batch()` takes first k columns for queries |
| 3 | `__main__.py` | OOD visualization passed full `features_df` as both train/test, ignoring actual split | `runner.ood_split_indices` property exposes stored indices; `__main__.py` slices correctly |
| 4 | `workflows.py` | `coef_raw * std_X / std_y` double-counts scaling since Ridge already receives StandardScaler output | Changed to `coef_raw / std_y` |
| 5 | `runner.py` | OOD detection used whichever `train_idx/test_idx` was in scope from last loop iteration | Dedicated `RandomCVSplitter(seed=seeds[0])` fold 0 — deterministic and loop-independent |

### Core platform fixes (🟡 design + 🟢 minor)

- **#6** `evaluation.py`: Clarified `ValidityScore.total` docstring with explicit score range [-0.15, 1.00]
- **#7** `features.py`: Simplified `FeatureSetName` enum values from `"FS_BASE+FS_THERMO"` → `"FS_THERMO"` (**breaking change** for any serialized data using old string values); updated GUI dropdowns
- **#8** `literature_graph/schemas.py`: Added `doi_verified: bool = False` to `Paper` dataclass
- **#9** `runner.py`: Extracted `_run_ood_detection()` and `_collect_ood_errors_for_eval()` from 230-line `run()` method
- **#10** `evaluation.py`: Replaced exact `== 0` float comparison with `abs() <= 1e-9` tolerance
- **#11** `requirements.txt`: Added usage notes for each dependency (which module needs it, fallback behavior)

---

### GUI fixes (12 items) — `app.py` rewrite + `plotly_charts.py` update

`app.py` was rewritten (~89% changed) to address all 12 GUI review findings:

| # | Priority | Fix | Details |
|---|----------|-----|---------|
| 1 | 🔴 | Session isolation via `gr.State` | Replaced module-global `_SESSION` dict with `gr.State(_empty_session)` — each browser tab gets its own session |
| 2 | 🔴 | Cast `n_samples` slider to `int` | `n_samp_int = int(n_samp)` before passing to `generate_hea_dataset()` |
| 3 | 🟡 | OOD Map uses actual split indices | Reads `runner.ood_split_indices` stored per feature set; falls back to heuristic with warning |
| 4 | 🟡 | InputScope filter choices match enum | Changed from hardcoded list to `["", "composition_only", "composition+process", ...]` |
| 5 | 🟡 | Theme placement (Gradio 6.0+ API) | Moved `theme=gr.themes.Soft()` to `launch()` (Gradio 6.0+ expects it there, not in `gr.Blocks()`) |
| 6 | 🔴 | `app.queue()` for async execution | Added after `gr.Blocks()` definition to enable streaming and prevent UI freeze |
| 7 | 🔴 | Generator-based `run_experiment` | Converted to generator function with `yield` statements for streaming progress log updates |
| 8 | 🟡 | Cross-tab auto-refresh | Final `yield` in `run_experiment` refreshes all 6 tabs (Dashboard, Results, OOD, Report) with latest data |
| 9 | 🟡 | Literature engine caching | `_get_literature_engine(session)` builds FAISS index once per session, not per search |
| 10 | 🟢 | Parity plot de-duplication | `plotly_charts.py`: De-duplicate by `(workflow, feature_set, sample_index)` to avoid misleading scatter density |
| 11 | 🟢 | Dynamic filter choices | Results tab dropdowns populated from actual run data, not hardcoded |
| 12 | 🟢 | Timestamp-based output dirs | `results/{YYYYMMDD_HHMMSS}/` instead of overwriting `results/` |

---

## Review & Testing Checklist for Human

### Critical items (must verify before merge)

- [ ] **End-to-end GUI test** — Launch `python -m hea_extrapolation_platform gui` and run a full experiment:
  - Click "Run Experiment" and verify progress log streams updates in real-time (not frozen)
  - After completion, verify all 6 tabs auto-refresh with correct data
  - Open a second browser tab and verify sessions are isolated (no cross-contamination)
  - Verify no crashes or TypeErrors from slider input
  
- [ ] **Generator output tuple alignment** — The `run_experiment` generator yields a 20-element tuple that must match the `outputs=` list in `run_btn.click()`. Any mismatch will crash at runtime. Verify the tuple structure in lines 846-853 matches the outputs list in lines 862-875.

- [ ] **OOD Map visualization** — In the OOD Map tab, select different feature sets and verify:
  - No index errors or size mismatches
  - Train/test split visualization looks reasonable (not all points in one cluster)
  - OOD candidates table populates correctly

- [ ] **FeatureSetName enum breaking change** — Verify no external systems/configs reference old `"FS_BASE+FS_THERMO"` string values. Check if any JSON exports or saved runs need migration.

### Medium-priority items

- [ ] **Parity plot de-duplication** — Verify the parity plot doesn't show unrealistic density (multiple overlapping points for the same sample). Check that `test_indices` attribute exists on `RunResult` objects.

- [ ] **Literature search caching** — First literature search should take ~2-5s (building FAISS index), subsequent searches should be instant (<100ms). Verify this in the Literature tab.

- [ ] **Cross-browser session isolation** — Open the GUI in two different browsers (or incognito tabs) and run experiments simultaneously. Verify they don't interfere with each other's data.

### Test plan

```bash
# 1. Install dependencies
pip install -r hea_extrapolation_platform/requirements.txt

# 2. Launch GUI
python -m hea_extrapolation_platform gui --port 7860

# 3. In browser (http://localhost:7860):
#    - Config tab: Set n_samples=100, quick_mode=True
#    - Click "Run Experiment"
#    - Watch progress log stream (should update every few seconds)
#    - After completion (~2-3 min), verify all tabs show data
#    - Try OOD Map with different feature sets
#    - Try Literature Search with a query
#    - Download report from Report tab

# 4. CLI test (optional)
python -m hea_extrapolation_platform run --quick --n-samples 100
```

### Notes

- All GUI fixes were tested via Python import/syntax checks, but **not** with a live Gradio server (no end-to-end GUI testing performed)
- The `app.py` rewrite is substantial (89% changed) — treat as new code requiring thorough review
- Gradio 6.0 API change: `theme=` moved to `launch()` (not `gr.Blocks()` as originally suggested in review)
- OOD results will differ from previous runs due to dedicated split (core fix #5) — this is expected and correct
- No CI configured for this repo; all verification is manual

---

**Link to Devin run:** https://app.devin.ai/sessions/a35c3055d9194e26a3ca15a00e41209a  
**Requested by:** @minimumtone