### PR TITLE
fix: GUI review followup — theme in gr.Blocks() + seeds validation

### DIFF
--- a/hea_extrapolation_platform/__main__.py
+++ b/hea_extrapolation_platform/__main__.py
@@ -313,11 +313,11 @@ def cmd_gui(args: argparse.Namespace) -> None:
         sys.exit(1)
 
     app = create_app()
+    # theme is set in gr.Blocks() inside create_app()
     app.launch(
         server_name="0.0.0.0",
         server_port=args.port,
         share=args.share,
-        theme=gr.themes.Soft(),
     )
 
 

--- a/hea_extrapolation_platform/gui/app.py
+++ b/hea_extrapolation_platform/gui/app.py
@@ -260,10 +260,10 @@ def _refresh_report_data(session: Dict[str, Any]) -> Tuple:
 
 def create_app() -> gr.Blocks:
     """Build and return the Gradio Blocks app."""
-    # Fix #5: theme placement — Gradio 6.0+ expects theme in launch(),
-    # but we store it so create_app() callers can pass it to launch().
+    # Fix #5: theme passed to gr.Blocks() constructor
     with gr.Blocks(
         title="Extrapolation Discovery Platform",
+        theme=gr.themes.Soft(),
     ) as app:
         gr.Markdown(
             "# Extrapolation Discovery Platform\n"
@@ -664,11 +664,21 @@ def create_app() -> gr.Blocks:
                 log("Starting experiment...")
                 yield _yield_progress("\n".join(log_lines))
 
-                seeds = [
-                    int(s.strip())
-                    for s in seeds_str.split()
-                    if s.strip()
-                ]
+                # Validate seeds input
+                try:
+                    seeds = [
+                        int(s.strip())
+                        for s in seeds_str.split()
+                        if s.strip()
+                    ]
+                except ValueError:
+                    log(
+                        "Error: Seeds must be space-separated integers "
+                        "(e.g. 42 123 456). Got: " + repr(seeds_str)
+                    )
+                    yield _yield_progress("\n".join(log_lines))
+                    return
+
                 excl = [
                     e.strip()
                     for e in excl_str.split()
@@ -676,7 +686,10 @@ def create_app() -> gr.Blocks:
                 ]
 
                 if not seeds:
-                    log("Error: No valid seeds provided.")
+                    log(
+                        "Error: No valid seeds provided. "
+                        "Enter space-separated integers (e.g. 42 123 456)."
+                    )
                     yield _yield_progress("\n".join(log_lines))
                     return
 
@@ -888,9 +901,8 @@ def create_app() -> gr.Blocks:
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     application = create_app()
-    # Fix #5: theme passed to launch() (Gradio 6.0+ API)
+    # Fix #5: theme is set in gr.Blocks() constructor above
     application.launch(
         server_name="0.0.0.0",
         server_port=7860,
-        theme=gr.themes.Soft(),
     )


### PR DESCRIPTION
## Summary

Three small followup fixes from the GUI re-review:

1. **Fix #5 (theme placement)**: Moved `theme=gr.themes.Soft()` into the `gr.Blocks()` constructor and removed it from all `launch()` call sites (`app.py` direct launch, `__main__.py` CLI launch). This is the correct Gradio API per reviewer feedback.

2. **Seeds input validation**: Wrapped seeds parsing in `try/except ValueError` so entering non-integer input (e.g. `"abc 42"`) shows a clear error in the progress log instead of a raw stack trace.

3. **Improved empty-seeds error message**: Changed from `"No valid seeds provided."` to `"Enter space-separated integers (e.g. 42 123 456)."`.

## Review & Testing Checklist for Human

- [ ] **Theme actually applies**: Gradio 6.x emits a `UserWarning` that `theme` has moved to `launch()`, but the theme is passed to `gr.Blocks()` per your review. Launch the GUI (`python -m hea_extrapolation_platform gui`) and verify the Soft theme renders correctly despite the warning.
- [ ] **Seeds validation**: In the Config tab, type `abc def` in the Seeds field and click Run Experiment — verify the progress log shows the friendly error, not a traceback.
- [ ] **No theme duplication**: Confirm `theme=` no longer appears in any `launch()` call (only in `gr.Blocks()`). Search: `grep -rn 'theme=' hea_extrapolation_platform/`

### Notes

- Gradio 6.6.0 (installed on dev machine) warns that `theme` should be in `launch()`, not `gr.Blocks()`. This contradicts the reviewer's instruction. The code follows the reviewer's explicit guidance. If the warning is unacceptable, the fix can be reverted to use `launch()` instead.
- Import test passes; no end-to-end GUI test was performed.

**Link to Devin run:** https://app.devin.ai/sessions/a35c3055d9194e26a3ca15a00e41209a
**Requested by:** @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/94" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
