### PR TITLE
fix: follow-up robustness fixes (dataset RNG + warnings + ss_formation)

### DIFF
--- a/hea_extrapolation_platform/dataset.py
+++ b/hea_extrapolation_platform/dataset.py
@@ -55,8 +55,7 @@ def _random_composition(
 
 def _yield_strength_proxy(
     feat: Dict[str, float],
-    rng: np.random.Generator,
-    noise_std: float = 50.0,
+    noise: float,
 ) -> float:
     """Compute a synthetic yield strength (MPa) using a simplified
     solid-solution strengthening model.
@@ -65,6 +64,9 @@ def _yield_strength_proxy(
     ----------
     feat:
         Pre-computed feature dict (from FS_ALL).
+    noise:
+        Pre-drawn noise value (MPa). This is drawn during composition
+        generation to preserve the exact RNG draw order for a given seed.
 
     Notes
     -----
@@ -85,8 +87,8 @@ def _yield_strength_proxy(
         - 2.0 * feat["phase_sep_risk"]
         + 0.5 * feat["elastic_mismatch"]
     )
-    # Add noise
-    ys += rng.normal(0.0, noise_std)
+    # Add pre-drawn noise
+    ys += noise
     return max(ys, 50.0)  # floor at 50 MPa
 
 
@@ -133,6 +135,7 @@ def generate_hea_dataset(
     common_pool = [e for e in common_pool if e in available]
 
     compositions: List[Dict[str, float]] = []
+    noise_values: List[float] = []
     all_elements_set: set = set()
 
     # Compute targets after feature computation to avoid recomputing
@@ -151,7 +154,8 @@ def generate_hea_dataset(
         comp = _random_composition(chosen, rng)
         compositions.append(comp)
         all_elements_set.update(chosen)
-        # target is computed after feature computation (avoid double feature calc)
+        # Draw noise here to preserve RNG draw order for a given seed.
+        noise_values.append(float(rng.normal(0.0, noise_std)))
 
     # Build composition DataFrame (sparse: NaN -> 0)
     all_elems_sorted = sorted(all_elements_set)
@@ -165,9 +169,10 @@ def generate_hea_dataset(
     features_df = compute_features(compositions, FeatureSetName.FS_ALL)
 
     # Compute target from the *already computed* FS_ALL features
+    features_records = features_df.to_dict(orient="records")
     targets = [
-        _yield_strength_proxy(f, rng, noise_std=noise_std)
-        for f in features_df.to_dict(orient="records")
+        _yield_strength_proxy(f, noise)
+        for f, noise in zip(features_records, noise_values)
     ]
     target = pd.Series(targets, name="yield_strength_MPa")
 

--- a/hea_extrapolation_platform/evaluation.py
+++ b/hea_extrapolation_platform/evaluation.py
@@ -103,6 +103,14 @@ class FeatureValidityEvaluator:
         # Identify baseline (FS_BASE) performance
         base_key = FeatureSetName.FS_BASE.value
         base_rmse = self._mean_test_rmse(fs_runs.get(base_key, []))
+        if base_rmse <= 0:
+            # FS_BASE has no runs or all-zero RMSE — cannot compute meaningful
+            # effect sizes so every feature set will get 0.
+            logger.warning(
+                "Baseline (FS_BASE) RMSE is 0 or has no runs; "
+                "effect_size for all feature sets will be 0. "
+                "Check that FS_BASE experiments completed successfully."
+            )
 
         scores: List[ValidityScore] = []
         for fs_name, fs_run_list in fs_runs.items():
@@ -113,13 +121,6 @@ class FeatureValidityEvaluator:
             if base_rmse > 0:
                 vs.effect_size = max(0.0, (base_rmse - fs_rmse) / base_rmse)
             else:
-                # FS_BASE has no runs or all-zero RMSE — cannot compute
-                # meaningful effect sizes so every feature set gets 0.
-                logger.warning(
-                    "Baseline (FS_BASE) RMSE is 0 or has no runs; "
-                    "effect_size for all feature sets will be 0. "
-                    "Check that FS_BASE experiments completed successfully."
-                )
                 vs.effect_size = 0.0
 
             # 2. Stability (inverse of coefficient of variation of RMSE across runs)

--- a/hea_extrapolation_platform/features.py
+++ b/hea_extrapolation_platform/features.py
@@ -308,14 +308,12 @@ def compute_features_single(
     # downstream numerical issues (e.g. ss_formation = omega * dS_mix).
     _OMEGA_MAX = 100.0
     if abs_dH > 1e-6:
-        omega_raw = Tm_avg * dS_mix / abs_dH
-        omega = min(omega_raw, _OMEGA_MAX)
+        omega = min(Tm_avg * dS_mix / abs_dH, _OMEGA_MAX)
     else:
-        omega_raw = _OMEGA_MAX
         omega = _OMEGA_MAX
-    # Use the *unclipped* omega for ss_formation so that the thermodynamic
-    # relationship is preserved even when omega itself is capped for display.
-    ss_formation = omega_raw * dS_mix  # higher -> more likely solid-solution
+    # Use the clipped omega for ss_formation to avoid extreme feature values
+    # when abs_dH is very small (numerical stability for downstream ML).
+    ss_formation = omega * dS_mix  # higher -> more likely solid-solution
     # Phase separation risk: positive dH + low omega -> higher risk
     phase_sep_risk = max(0.0, dH_mix) / (omega + 1.0)
 


### PR DESCRIPTION
# fix: follow-up robustness (dataset RNG, baseline warning, omega stability)

## Summary
Small follow-up fixes based on post-merge review findings:

- **`hea_extrapolation_platform/dataset.py`**: Preserve the **exact RNG draw order per seed** while still avoiding double feature computation. Noise is now drawn during the composition loop (`noise_values.append(rng.normal(...))`) and later applied when building targets from the already-computed `FS_ALL` feature table.
- **`hea_extrapolation_platform/evaluation.py`**: Move the “baseline RMSE is 0” warning **out of the per-feature-set loop**, so it is emitted **once** instead of spamming logs.
- **`hea_extrapolation_platform/features.py`**: Make `ss_formation` use the **clipped** `omega` again to avoid extreme feature magnitudes when `|dH_mix|` is very small (better numerical stability for downstream ML).

## Review & Testing Checklist for Human
- [ ] **Dataset reproducibility**: For a fixed `(seed, n_samples)`, confirm `generate_hea_dataset()` produces stable outputs across repeated calls, and (if you have a prior reference) confirm the RNG ordering behavior matches expectations.
- [ ] **Dataset semantics**: Sanity-check that target values still look reasonable (no systematic shift / unexpected floors at 50 MPa).
- [ ] **Feature stability**: Spot-check `omega` / `ss_formation` ranges for a few random compositions; ensure no extreme outliers appear that could dominate scaling/fit.
- [ ] **Validity evaluation logs**: Run a case where FS_BASE is missing and confirm the warning appears once and effect sizes remain 0 as intended.

### Notes
- Link to Devin run: https://app.devin.ai/sessions/a35c3055d9194e26a3ca15a00e41209a
- Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
