### PR TITLE
docs: fix feature set names and counts in user manual Section 7.1

### DIFF
--- a/hea_extrapolation_platform/docs/user_manual.md
+++ b/hea_extrapolation_platform/docs/user_manual.md
@@ -656,10 +656,10 @@ python -m hea_extrapolation_platform gui --share
 
 | セット名 | 含まれる特徴量 | 特徴 |
 |----------|-------------|------|
-| **FS_BASE** | VEC, dH_mix, dS_mix, delta_r, Tm_avg, delta_EN, mass_avg, r_avg | 基本的な組成記述子（8特徴量） |
-| **FS_THERMO** | FS_BASE + omega, ss_formation | 熱力学パラメータを追加（10特徴量） |
-| **FS_SIZE** | FS_BASE + mismatch_PGS, elastic_mismatch | サイズ効果パラメータを追加（10特徴量） |
-| **FS_ELECTRON** | FS_BASE + e_per_a, phi_pauling | 電子構造パラメータを追加（10特徴量） |
+| **FS_BASE** | r_avg, delta_r, dS_mix, dH_mix, VEC, delta_EN, Tm_avg, mass_avg | 基本的な組成記述子（8特徴量） |
+| **FS_THERMO** | FS_BASE + omega, ss_formation, phase_sep_risk | 熱力学パラメータを追加（11特徴量） |
+| **FS_SIZE** | FS_BASE + Vm_var, elastic_mismatch | サイズ効果パラメータを追加（10特徴量） |
+| **FS_ELECTRON** | FS_BASE + d_elec_avg, d_elec_std, itinerant_proxy | 電子構造パラメータを追加（11特徴量） |
 | **FS_ALL** | 上記全ての特徴量を統合 | 全特徴量（16特徴量） |
 
 > **使い分けのヒント**: まず FS_ALL で全体像を把握し、次に各サブセット（FS_THERMO, FS_SIZE, FS_ELECTRON）の寄与を比較するのが効率的です。


### PR DESCRIPTION
## Summary

Fixes incorrect feature names and counts in the user manual's Section 7.1 (Feature Sets table). The previous version of the manual listed feature names that don't exist in the codebase (`mismatch_PGS`, `e_per_a`, `phi_pauling`) and had wrong feature counts for FS_THERMO and FS_ELECTRON.

All names and counts now match the actual definitions in `features.py` lines 173–200.

| Set | Before (wrong) | After (correct) |
|-----|----------------|-----------------|
| FS_THERMO | omega, ss_formation (10) | omega, ss_formation, **phase_sep_risk** (11) |
| FS_SIZE | **mismatch_PGS**, elastic_mismatch (10) | **Vm_var**, elastic_mismatch (10) |
| FS_ELECTRON | **e_per_a, phi_pauling** (10) | **d_elec_avg, d_elec_std, itinerant_proxy** (11) |

## Review & Testing Checklist for Human

- [ ] Verify the corrected feature names match `_THERMO_COLS`, `_SIZE_COLS`, and `_ELECTRON_COLS` in `hea_extrapolation_platform/features.py` (lines 185–200)
- [ ] Confirm FS_ALL total of 16 is still correct: 8 (BASE) + 3 (THERMO) + 2 (SIZE) + 3 (ELECTRON) = 16

### Notes
- Link to Devin run: https://app.devin.ai/sessions/a35c3055d9194e26a3ca15a00e41209a
- Requested by: @minimumtone
- This is a follow-up to PR #103 which was already merged with these documentation inaccuracies (flagged by Devin Review)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
