### PR TITLE
feat: improve dataset generation with FCC/BCC pools, stability filter, omega unit fix

### DIFF
--- a/hea_extrapolation_platform/dataset.py
+++ b/hea_extrapolation_platform/dataset.py
@@ -223,6 +223,7 @@ def generate_hea_dataset(
     all_elements_set: set = set()
     rejected_total = 0
     reject_limit = _MAX_REJECT_RATIO * n_samples
+    filter_relaxed = False
 
     for pool, n_pool, label in [
         (pool_fcc, n_fcc, "FCC"),
@@ -240,22 +241,40 @@ def generate_hea_dataset(
             # Draw noise *before* the filter check to preserve RNG order
             noise_val = float(rng.standard_normal())
 
-            # Stability filter
+            # Stability filter (disabled once reject limit is exceeded)
             try:
                 feat = compute_features_single(comp)
             except Exception:
                 rejected_total += 1
-                if rejected_total > reject_limit:
-                    break
+                if rejected_total > reject_limit and not filter_relaxed:
+                    filter_relaxed = True
+                    logger.warning(
+                        "Reject limit (%d) reached at %s pool; "
+                        "disabling stability filter for remaining samples",
+                        reject_limit, label,
+                    )
                 continue
 
-            if _passes_stability_filter(feat) or rejected_total > reject_limit:
+            if filter_relaxed or _passes_stability_filter(feat):
                 compositions.append(comp)
                 noise_values.append(noise_val)
                 all_elements_set.update(chosen)
                 accepted += 1
             else:
                 rejected_total += 1
+                if rejected_total > reject_limit and not filter_relaxed:
+                    filter_relaxed = True
+                    logger.warning(
+                        "Reject limit (%d) reached at %s pool; "
+                        "disabling stability filter for remaining samples",
+                        reject_limit, label,
+                    )
+
+    if len(compositions) < n_samples:
+        logger.warning(
+            "Generated %d / %d requested samples (shortfall due to "
+            "feature computation errors)", len(compositions), n_samples,
+        )
 
     logger.info(
         "Composition generation: %d accepted, %d rejected by stability filter",

--- a/hea_extrapolation_platform/dataset.py
+++ b/hea_extrapolation_platform/dataset.py
@@ -2,18 +2,26 @@
 HEA Dataset Generation Module
 HEAデータセット生成モジュール
 
-Generates a synthetic HEA dataset with ~200 compositions (5+ element systems)
-and a literature-inspired yield-strength proxy based on solid-solution
-strengthening models (Toda-Caraballo & Rivera-Diaz-del-Castillo, Acta Mat 2015).
+Generates a synthetic HEA dataset with compositions drawn from
+metallurgically realistic element pools (FCC / BCC / mixed-phase).
+A structure-aware yield-strength proxy distinguishes FCC-type
+(Cantor-family) from BCC-type (refractory) alloys.
 
-The proxy is intentionally noisy to simulate real experimental scatter.
+Solid-solution stability filters (delta < 8 %, dH_mix range, dS_mix
+floor, fraction bounds) reject unphysical compositions before they
+enter the dataset.
+
+References:
+  - Yang & Zhang, Mater. Chem. Phys. 132 (2012) 233
+  - Guo et al., J. Appl. Phys. 109 (2011) 103505  (VEC phase boundary)
+  - Toda-Caraballo & Rivera-Diaz-del-Castillo, Acta Mat. 85 (2015) 14
+  - Senkov et al., J. Alloys Compd. 509 (2011) 6043
 """
 
 from __future__ import annotations
 
 import logging
-from itertools import combinations
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 import numpy as np
 import pandas as pd
@@ -21,76 +29,136 @@ import pandas as pd
 from hea_extrapolation_platform.features import (
     _ElementDB,
     compute_features,
+    compute_features_single,
     FeatureSetName,
 )
 
 logger = logging.getLogger(__name__)
 
-# Common HEA element pools
-_POOL_3D = ["Ti", "V", "Cr", "Mn", "Fe", "Co", "Ni", "Cu"]
-_POOL_REFRACTORY = ["Ti", "V", "Cr", "Zr", "Nb", "Mo", "Hf", "Ta", "W"]
-# Elements for lightweight-containing HEAs (includes light elements Mg, Al, Si, Sc
-# alongside common 3d transition metals for realistic alloy generation).
-_POOL_LIGHT_CONTAINING = ["Mg", "Al", "Si", "Sc", "Ti", "V", "Cr", "Mn", "Fe", "Co", "Ni"]
+# ---------------------------------------------------------------------------
+# Element pools split by expected crystal structure
+# ---------------------------------------------------------------------------
 
+# FCC-type: Cantor-family + Al extension (VEC >= ~8 when equimolar)
+_POOL_FCC = ["Co", "Cr", "Fe", "Mn", "Ni", "Cu", "Al"]
+
+# BCC-type: refractory HEAs (VEC < ~6.87 when equimolar)
+_POOL_BCC = ["Mo", "Nb", "Ta", "Ti", "V", "W", "Hf", "Zr", "Cr"]
+
+# Mixed-phase candidates: elements that appear in both families
+_POOL_MIXED = ["Al", "Co", "Cr", "Fe", "Mn", "Ni", "Ti", "V", "Cu",
+               "Mo", "Nb", "Hf"]
+
+# ---------------------------------------------------------------------------
+# Solid-solution stability filter constants (Yang & Zhang 2012)
+# ---------------------------------------------------------------------------
+_DELTA_R_MAX = 8.0          # atomic radius mismatch (%)
+_DH_MIX_MIN = -20.0         # mixing enthalpy lower bound (kJ/mol)
+_DH_MIX_MAX = 5.0           # mixing enthalpy upper bound (kJ/mol)
+_DS_MIX_MIN = 12.0          # minimum mixing entropy (J/mol K)
+_FRAC_MIN = 0.05            # minimum atomic fraction per element
+_FRAC_MAX = 0.35            # maximum atomic fraction per element
+_MAX_REJECT_RATIO = 200     # max rejected / n_samples before relaxing
+
+
+# ---------------------------------------------------------------------------
+# Composition generation with stability filter
+# ---------------------------------------------------------------------------
 
 def _random_composition(
     elements: List[str],
     rng: np.random.Generator,
-    min_frac: float = 0.05,
+    min_frac: float = _FRAC_MIN,
+    max_frac: float = _FRAC_MAX,
 ) -> Dict[str, float]:
-    """Generate a random composition for the given elements.
+    """Generate a random composition with fraction bounds.
 
-    Uses a Dirichlet distribution to ensure fractions sum to 1, with a
-    minimum fraction constraint to avoid trace-level components.
+    Uses a Dirichlet distribution and rejects samples where any
+    fraction falls outside [min_frac, max_frac].
     """
     n = len(elements)
     while True:
         fracs = rng.dirichlet(np.ones(n) * 2.0)
-        if np.all(fracs >= min_frac):
+        if np.all(fracs >= min_frac) and np.all(fracs <= max_frac):
             break
-    comp = {e: float(f) for e, f in zip(elements, fracs)}
-    return comp
+    return {e: float(f) for e, f in zip(elements, fracs)}
 
+
+def _passes_stability_filter(feat: Dict[str, float]) -> bool:
+    """Return True if the composition satisfies solid-solution criteria.
+
+    Criteria (Yang & Zhang 2012, relaxed for synthetic data):
+      - delta_r < 8 %
+      - -20 <= dH_mix <= 5 kJ/mol
+      - dS_mix >= 12 J/mol K
+    """
+    if feat["delta_r"] >= _DELTA_R_MAX:
+        return False
+    if feat["dH_mix"] < _DH_MIX_MIN or feat["dH_mix"] > _DH_MIX_MAX:
+        return False
+    if feat["dS_mix"] < _DS_MIX_MIN:
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Structure-aware yield-strength proxy
+# ---------------------------------------------------------------------------
 
 def _yield_strength_proxy(
     feat: Dict[str, float],
     noise: float,
 ) -> float:
-    """Compute a synthetic yield strength (MPa) using a simplified
-    solid-solution strengthening model.
+    """Compute a synthetic yield strength (MPa) with FCC/BCC-aware model.
+
+    The VEC-based phase boundary follows Guo et al. (2011):
+      VEC >= 8.0   -> FCC  (Cantor-type, 600-1000 MPa range)
+      VEC <  6.87  -> BCC  (refractory, 900-2000 MPa range)
+      otherwise    -> mixed phase
 
     Parameters
     ----------
-    feat:
+    feat : dict
         Pre-computed feature dict (from FS_ALL).
-    noise:
-        Pre-drawn noise value (MPa). This is drawn during composition
-        generation to preserve the exact RNG draw order for a given seed.
-
-    Notes
-    -----
-    YS ~ base + k1 * delta_r * sqrt(VEC) + k2 * |dH_mix| + k3 * dS_mix
-         + k4 * Tm_avg / 1000 + noise
-
-    This is deliberately an *approximate* physics-inspired proxy, not a
-    real predictive model.  The noise term simulates experimental scatter.
+    noise : float
+        Pre-drawn standard-normal value.  Actual noise is proportional
+        to predicted strength (7 % coefficient of variation).
     """
-    base = 200.0
+    vec = feat["VEC"]
+
+    if vec >= 8.0:
+        # FCC regime: lower base, moderate lattice-strain hardening
+        base = 300.0
+        k_lattice = 18.0
+        k_Tm = 50.0
+    elif vec < 6.87:
+        # BCC regime: high base, strong lattice-strain hardening
+        base = 600.0
+        k_lattice = 35.0
+        k_Tm = 150.0
+    else:
+        # Mixed-phase regime
+        base = 450.0
+        k_lattice = 26.0
+        k_Tm = 100.0
+
     ys = (
         base
-        + 15.0 * feat["delta_r"] * np.sqrt(max(feat["VEC"], 1.0))
+        + k_lattice * feat["delta_r"] * np.sqrt(max(vec, 1.0))
         + 3.0 * abs(feat["dH_mix"])
-        + 0.02 * feat["dS_mix"]
-        + 80.0 * feat["Tm_avg"] / 1000.0
-        + 5.0 * feat["d_elec_avg"]
-        - 2.0 * feat["phase_sep_risk"]
-        + 0.5 * feat["elastic_mismatch"]
+        + k_Tm * feat["Tm_avg"] / 1000.0
+        + 5.0 * feat["elastic_mismatch"]
     )
-    # Add pre-drawn noise
-    ys += noise
-    return max(ys, 50.0)  # floor at 50 MPa
 
+    # Proportional noise: high-strength alloys have larger scatter
+    noise_std = 0.07 * ys
+    ys += noise * noise_std
+    return max(ys, 100.0)
+
+
+# ---------------------------------------------------------------------------
+# Main dataset generator
+# ---------------------------------------------------------------------------
 
 def generate_hea_dataset(
     n_samples: int = 200,
@@ -99,7 +167,16 @@ def generate_hea_dataset(
     max_elements: int = 7,
     noise_std: float = 50.0,
 ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.Series]:
-    """Generate a synthetic HEA dataset.
+    """Generate a synthetic HEA dataset with realistic compositions.
+
+    Sampling strategy:
+      - 40 % FCC-pool (Cantor-family)
+      - 40 % BCC-pool (refractory)
+      - 20 % mixed-phase pool
+
+    Each candidate composition is checked against solid-solution
+    stability filters; unphysical compositions are rejected and
+    re-sampled (up to ``_MAX_REJECT_RATIO * n_samples`` attempts).
 
     Parameters
     ----------
@@ -112,7 +189,8 @@ def generate_hea_dataset(
     max_elements : int
         Maximum number of constituent elements per alloy.
     noise_std : float
-        Standard deviation of Gaussian noise added to yield strength.
+        Kept for API compatibility; strength noise is now proportional
+        to predicted YS (7 % coefficient of variation).
 
     Returns
     -------
@@ -129,35 +207,62 @@ def generate_hea_dataset(
         n_samples, seed, min_elements, max_elements,
     )
 
-    available = _ElementDB.available_elements()
-    # Bias toward common HEA elements
-    common_pool = list(set(_POOL_3D + _POOL_REFRACTORY + _POOL_LIGHT_CONTAINING))
-    common_pool = [e for e in common_pool if e in available]
+    # Pre-filter pools to only include elements in the database
+    available = set(_ElementDB.available_elements())
+    pool_fcc = [e for e in _POOL_FCC if e in available]
+    pool_bcc = [e for e in _POOL_BCC if e in available]
+    pool_mix = [e for e in _POOL_MIXED if e in available]
+
+    # Determine how many samples from each pool
+    n_fcc = int(n_samples * 0.4)
+    n_bcc = int(n_samples * 0.4)
+    n_mix = n_samples - n_fcc - n_bcc
 
     compositions: List[Dict[str, float]] = []
     noise_values: List[float] = []
     all_elements_set: set = set()
+    rejected_total = 0
+    reject_limit = _MAX_REJECT_RATIO * n_samples
 
-    # Compute targets after feature computation to avoid recomputing
-    # compute_features_single twice per sample.
+    for pool, n_pool, label in [
+        (pool_fcc, n_fcc, "FCC"),
+        (pool_bcc, n_bcc, "BCC"),
+        (pool_mix, n_mix, "MIXED"),
+    ]:
+        accepted = 0
+        while accepted < n_pool:
+            n_elems = int(rng.integers(min_elements, max_elements + 1))
+            if len(pool) < n_elems:
+                n_elems = len(pool)
+            chosen = list(rng.choice(pool, size=n_elems, replace=False))
+            comp = _random_composition(chosen, rng)
 
-    for i in range(n_samples):
-        n_elems = rng.integers(min_elements, max_elements + 1)
-        # 80% chance to pick from common pool, 20% from full available
-        if rng.random() < 0.8:
-            pool = common_pool
-        else:
-            pool = available
-        if len(pool) < n_elems:
-            pool = available
-        chosen = list(rng.choice(pool, size=n_elems, replace=False))
-        comp = _random_composition(chosen, rng)
-        compositions.append(comp)
-        all_elements_set.update(chosen)
-        # Draw noise here to preserve RNG draw order for a given seed.
-        noise_values.append(float(rng.normal(0.0, noise_std)))
+            # Draw noise *before* the filter check to preserve RNG order
+            noise_val = float(rng.standard_normal())
 
-    # Build composition DataFrame (sparse: NaN -> 0)
+            # Stability filter
+            try:
+                feat = compute_features_single(comp)
+            except Exception:
+                rejected_total += 1
+                if rejected_total > reject_limit:
+                    break
+                continue
+
+            if _passes_stability_filter(feat) or rejected_total > reject_limit:
+                compositions.append(comp)
+                noise_values.append(noise_val)
+                all_elements_set.update(chosen)
+                accepted += 1
+            else:
+                rejected_total += 1
+
+    logger.info(
+        "Composition generation: %d accepted, %d rejected by stability filter",
+        len(compositions), rejected_total,
+    )
+
+    # Build composition DataFrame (sparse: missing element -> 0)
     all_elems_sorted = sorted(all_elements_set)
     comp_records = []
     for comp in compositions:
@@ -171,13 +276,15 @@ def generate_hea_dataset(
     # Compute target from the *already computed* FS_ALL features
     features_records = features_df.to_dict(orient="records")
     targets = [
-        _yield_strength_proxy(f, noise)
-        for f, noise in zip(features_records, noise_values)
+        _yield_strength_proxy(f, n)
+        for f, n in zip(features_records, noise_values)
     ]
     target = pd.Series(targets, name="yield_strength_MPa")
 
     logger.info(
-        "Dataset generated: %d samples, %d elements, features shape %s",
+        "Dataset generated: %d samples, %d elements, features shape %s, "
+        "YS range [%.0f, %.0f] MPa",
         len(target), len(all_elems_sorted), features_df.shape,
+        target.min(), target.max(),
     )
     return compositions_df, features_df, target

--- a/hea_extrapolation_platform/dataset.py
+++ b/hea_extrapolation_platform/dataset.py
@@ -74,14 +74,31 @@ def _random_composition(
     """Generate a random composition with fraction bounds.
 
     Uses a Dirichlet distribution and rejects samples where any
-    fraction falls outside [min_frac, max_frac].
+    fraction falls outside [min_frac, max_frac].  When the bounds
+    are infeasible for the given number of elements (e.g. n=2 with
+    max_frac=0.35), ``max_frac`` is automatically relaxed so that
+    the constraint is satisfiable.
     """
     n = len(elements)
+    # Feasibility guard: n * max_frac must be >= 1.0 for fractions
+    # that sum to 1.0 to exist within [min_frac, max_frac].
+    effective_max = max_frac
+    if n * max_frac < 1.0:
+        effective_max = 1.0  # relax max_frac for small n
+    _MAX_ITER = 10_000
+    for _ in range(_MAX_ITER):
+        fracs = rng.dirichlet(np.ones(n) * 2.0)
+        if np.all(fracs >= min_frac) and np.all(fracs <= effective_max):
+            return {e: float(f) for e, f in zip(elements, fracs)}
+    # Fallback: accept last draw with only min_frac constraint
+    logger.warning(
+        "Composition sampling did not converge in %d iterations for "
+        "%d elements; relaxing max_frac constraint", _MAX_ITER, n,
+    )
     while True:
         fracs = rng.dirichlet(np.ones(n) * 2.0)
-        if np.all(fracs >= min_frac) and np.all(fracs <= max_frac):
-            break
-    return {e: float(f) for e, f in zip(elements, fracs)}
+        if np.all(fracs >= min_frac):
+            return {e: float(f) for e, f in zip(elements, fracs)}
 
 
 def _passes_stability_filter(feat: Dict[str, float]) -> bool:

--- a/hea_extrapolation_platform/features.py
+++ b/hea_extrapolation_platform/features.py
@@ -97,27 +97,81 @@ class _ElementDB:
                "mass": 88.91, "d_elec": 1, "B": 41, "Vm": 19.9},
     }
 
-    # Simplified Miedema binary mixing enthalpies (kJ/mol)
+    # Miedema binary mixing enthalpies (kJ/mol).
+    # Sources: de Boer et al. (1988), Takeuchi & Inoue (2005).
+    # Coverage expanded from 52 to ~120 pairs for common HEA elements.
     _DELTA_H_BINARY: Dict[tuple, float] = {
+        # --- 3d transition metal pairs ---
         ("Co", "Cr"): -4, ("Co", "Fe"): -1, ("Co", "Mn"): -5,
         ("Co", "Ni"): 0,  ("Cr", "Fe"): -1, ("Cr", "Mn"): 2,
         ("Cr", "Ni"): -7, ("Fe", "Mn"): 0,  ("Fe", "Ni"): -2,
-        ("Mn", "Ni"): -8, ("Ti", "V"): -2,  ("Ti", "Cr"): -7,
-        ("Ti", "Fe"): -17, ("Ti", "Ni"): -35, ("Ti", "Co"): -28,
-        ("V", "Cr"): -2,  ("V", "Fe"): -7,  ("V", "Ni"): -18,
-        ("Cu", "Ni"): 4,  ("Cu", "Co"): 6,  ("Cu", "Fe"): 13,
-        ("Cu", "Mn"): 4,  ("Cu", "Cr"): 12,
+        ("Mn", "Ni"): -8, ("Co", "V"): -14, ("Cr", "V"): -2,
+        ("Fe", "V"): -7,  ("Mn", "V"): -1,  ("Ni", "V"): -18,
+        ("Co", "Cu"): 6,  ("Cr", "Cu"): 12, ("Fe", "Cu"): 13,
+        ("Mn", "Cu"): 4,  ("Ni", "Cu"): 4,  ("V", "Cu"): 5,
+        # --- Ti binary pairs ---
+        ("Ti", "V"): -2,  ("Ti", "Cr"): -7, ("Ti", "Mn"): -8,
+        ("Ti", "Fe"): -17, ("Ti", "Co"): -28, ("Ti", "Ni"): -35,
+        ("Ti", "Cu"): -9, ("Ti", "Zn"): -15,
+        # --- Al binary pairs ---
         ("Al", "Co"): -19, ("Al", "Cr"): -10, ("Al", "Fe"): -11,
         ("Al", "Mn"): -19, ("Al", "Ni"): -22, ("Al", "Ti"): -30,
-        ("Al", "Cu"): -1,  ("Al", "Zr"): -44,
-        ("Zr", "Ti"): 0,  ("Zr", "Ni"): -49, ("Zr", "Cu"): -23,
-        ("Zr", "Co"): -41, ("Zr", "Fe"): -25,
-        ("Nb", "Ti"): 2,  ("Nb", "Zr"): 4,  ("Mo", "Ti"): -4,
-        ("Ta", "Ti"): 1,  ("W", "Ti"): -6,
-        ("Hf", "Ti"): 0,  ("Hf", "Ni"): -42, ("Hf", "Co"): -35,
-        ("Nb", "Ni"): -30, ("Mo", "Ni"): -7,  ("Ta", "Ni"): -29,
-        ("W", "Ni"): -3,   ("Nb", "Co"): -25, ("Mo", "Co"): -5,
-        ("Nb", "Fe"): -16, ("Mo", "Fe"): -2,
+        ("Al", "Cu"): -1,  ("Al", "V"): -16, ("Al", "Zr"): -44,
+        ("Al", "Nb"): -18, ("Al", "Mo"): -5, ("Al", "Hf"): -39,
+        ("Al", "Ta"): -19, ("Al", "W"): -2,  ("Al", "Si"): -4,
+        ("Al", "Mg"): -2,  ("Al", "Sc"): -38,
+        # --- Refractory pairs (4d/5d) ---
+        ("Nb", "Ti"): 2,   ("Nb", "Zr"): 4,   ("Nb", "Hf"): 4,
+        ("Nb", "Ta"): 0,   ("Nb", "Mo"): -6,  ("Nb", "W"): -8,
+        ("Nb", "V"): -1,   ("Nb", "Cr"): -7,  ("Nb", "Mn"): -4,
+        ("Nb", "Fe"): -16, ("Nb", "Co"): -25, ("Nb", "Ni"): -30,
+        ("Nb", "Cu"): 3,
+        ("Mo", "Ti"): -4,  ("Mo", "Zr"): -6,  ("Mo", "Hf"): -4,
+        ("Mo", "Ta"): -5,  ("Mo", "W"): 0,    ("Mo", "V"): -1,
+        ("Mo", "Cr"): 0,   ("Mo", "Mn"): -5,  ("Mo", "Fe"): -2,
+        ("Mo", "Co"): -5,  ("Mo", "Ni"): -7,  ("Mo", "Cu"): 19,
+        ("Ta", "Ti"): 1,   ("Ta", "Zr"): 3,   ("Ta", "Hf"): 3,
+        ("Ta", "V"): -1,   ("Ta", "Cr"): -7,  ("Ta", "Mn"): -5,
+        ("Ta", "Fe"): -15, ("Ta", "Co"): -24, ("Ta", "Ni"): -29,
+        ("Ta", "Cu"): 2,   ("Ta", "W"): -7,
+        ("W", "Ti"): -6,   ("W", "Zr"): -9,   ("W", "Hf"): -6,
+        ("W", "V"): -1,    ("W", "Cr"): 1,    ("W", "Mn"): -4,
+        ("W", "Fe"): -1,   ("W", "Co"): -1,   ("W", "Ni"): -3,
+        ("W", "Cu"): 22,
+        ("Hf", "Ti"): 0,   ("Hf", "Zr"): 0,   ("Hf", "V"): -2,
+        ("Hf", "Cr"): -9,  ("Hf", "Mn"): -12, ("Hf", "Fe"): -21,
+        ("Hf", "Co"): -35, ("Hf", "Ni"): -42, ("Hf", "Cu"): -17,
+        ("Zr", "Ti"): 0,   ("Zr", "V"): -4,   ("Zr", "Cr"): -12,
+        ("Zr", "Mn"): -15, ("Zr", "Fe"): -25, ("Zr", "Co"): -41,
+        ("Zr", "Ni"): -49, ("Zr", "Cu"): -23,
+        # --- Mg pairs (important: many are positive/near-zero) ---
+        ("Mg", "Ti"): -4,  ("Mg", "V"): 0,    ("Mg", "Cr"): 2,
+        ("Mg", "Mn"): -3,  ("Mg", "Fe"): 4,   ("Mg", "Co"): 3,
+        ("Mg", "Ni"): -4,  ("Mg", "Cu"): -3,  ("Mg", "Zn"): -4,
+        ("Mg", "Al"): -2,  ("Mg", "Si"): -3,  ("Mg", "Sc"): -7,
+        ("Mg", "Zr"): -6,  ("Mg", "Nb"): 3,   ("Mg", "Mo"): 10,
+        ("Mg", "Hf"): -4,  ("Mg", "Ta"): 13,  ("Mg", "W"): 13,
+        # --- Si pairs ---
+        ("Si", "Ti"): -66, ("Si", "V"): -48,  ("Si", "Cr"): -37,
+        ("Si", "Mn"): -37, ("Si", "Fe"): -35, ("Si", "Co"): -38,
+        ("Si", "Ni"): -40, ("Si", "Cu"): -19, ("Si", "Zr"): -84,
+        ("Si", "Nb"): -56, ("Si", "Mo"): -35, ("Si", "Hf"): -80,
+        # --- Sc pairs ---
+        ("Sc", "Ti"): -4,  ("Sc", "V"): -4,   ("Sc", "Cr"): -4,
+        ("Sc", "Fe"): -15, ("Sc", "Co"): -22, ("Sc", "Ni"): -27,
+        # --- Precious/rare (Re, Pd, Pt, Au, Ag, Y) ---
+        ("Re", "Ti"): -8,  ("Re", "Cr"): -6,  ("Re", "Fe"): -1,
+        ("Re", "Ni"): -9,  ("Re", "W"): -3,   ("Re", "Mo"): -2,
+        ("Pd", "Ti"): -52, ("Pd", "Cr"): -3,  ("Pd", "Fe"): -4,
+        ("Pd", "Co"): -1,  ("Pd", "Ni"): 0,   ("Pd", "Cu"): -14,
+        ("Pt", "Ti"): -74, ("Pt", "Cr"): -12, ("Pt", "Fe"): -6,
+        ("Pt", "Ni"): -5,  ("Pt", "Cu"): -12,
+        ("Au", "Ti"): -48, ("Au", "Cr"): 3,   ("Au", "Fe"): 3,
+        ("Au", "Ni"): -9,  ("Au", "Cu"): -9,  ("Au", "Al"): -22,
+        ("Ag", "Ti"): -15, ("Ag", "Cr"): 15,  ("Ag", "Fe"): 15,
+        ("Ag", "Ni"): 15,  ("Ag", "Cu"): 2,   ("Ag", "Al"): -4,
+        ("Y", "Ti"): 5,    ("Y", "Cr"): 2,    ("Y", "Fe"): -1,
+        ("Y", "Ni"): -31,  ("Y", "Al"): -38,
     }
 
     @classmethod
@@ -304,11 +358,12 @@ def compute_features_single(
 
     # ---- FS_THERMO ----
     abs_dH = abs(dH_mix)
-    # Omega parameter: clip to a sensible maximum instead of 1e6 to avoid
-    # downstream numerical issues (e.g. ss_formation = omega * dS_mix).
-    _OMEGA_MAX = 100.0
+    # Omega parameter (Yang & Zhang 2012): Ω = Tm * ΔS_mix / |ΔH_mix|
+    # Units: dS_mix is J/(mol·K), dH_mix is kJ/mol → convert kJ to J (*1000).
+    # Typical real-HEA Ω ∈ [1, 50]; clip at 10 to keep it a useful discriminator.
+    _OMEGA_MAX = 10.0
     if abs_dH > 1e-6:
-        omega = min(Tm_avg * dS_mix / abs_dH, _OMEGA_MAX)
+        omega = min(Tm_avg * dS_mix / (abs_dH * 1000.0), _OMEGA_MAX)
     else:
         omega = _OMEGA_MAX
     # Use the clipped omega for ss_formation to avoid extreme feature values


### PR DESCRIPTION
## Summary

Addresses 5 quantitative problems in the synthetic HEA dataset generator by introducing structure-aware composition sampling and physically grounded filters.

**`dataset.py` (rewritten):**
- Element pools split into FCC (Cantor-family), BCC (refractory), and Mixed, sampled at 40/40/20 ratio
- Yield-strength proxy is now VEC-dependent: FCC base ≈ 300 MPa, BCC base ≈ 600 MPa (Guo et al. 2011 phase boundary at VEC = 6.87 / 8.0)
- Solid-solution stability rejection filter enforces δ < 8%, −20 ≤ ΔH_mix ≤ 5 kJ/mol, ΔS_mix ≥ 12 J/mol·K, fractions ∈ [0.05, 0.35]
- Noise model changed from additive Gaussian to proportional (7% CV)

**`features.py`:**
- **Omega unit bug fix**: `dS_mix` is J/(mol·K) but `dH_mix` is kJ/mol — added `* 1000` conversion in denominator
- Omega clip reduced from 100 → 10 (realistic range per Yang & Zhang 2012)
- Miedema ΔH_binary DB expanded from ~25 to ~120 pairs (refractory, Mg, Si, Sc, precious metals)

**Verified test output (seed=42, n=200):**
| Metric | Before | After |
|---|---|---|
| Omega range | all saturated at 100 | [1.17, 10.0], mean 6.22 |
| YS FCC | indistinguishable | [485, 839] MPa (mean 640) |
| YS BCC | indistinguishable | [1252, 2104] MPa (mean 1659) |
| δ > 8% | present | 0 samples (filter) |
| ΔH_mix outside [-20, 5] | present | 0 samples (filter) |
| ΔS_mix < 12 | present | 0 samples (filter) |

### Updates since last revision

**Fix for silent under-count bug (commit 22ec421):**
- Replaced `break` on reject-limit with a `filter_relaxed` flag that disables the stability filter globally for all remaining samples
- Added post-loop warning if `len(compositions) < n_samples` (only possible from repeated `compute_features_single` exceptions)
- Verified with `n_samples=1000, seed=123` — returns exactly 1000 samples

**Fix for infinite loop in `_random_composition` (commit 3fbccb8):**
- When `n * max_frac < 1.0` (e.g. n=2 elements with max_frac=0.35), the Dirichlet rejection sampling is mathematically infeasible
- Added feasibility guard that auto-relaxes `max_frac` for small element counts
- Added 10k iteration safeguard with fallback to min_frac-only constraint
- Verified with n=1, n=2, n=5 — all return immediately

## Review & Testing Checklist for Human

- [ ] **CRITICAL: Verify omega unit fix is correct** — Check that `Tm * dS_mix / (abs_dH * 1000)` produces physically reasonable Ω values (should be ~1–10 for typical HEAs). This is a **breaking change**: all seeds produce entirely different datasets and all downstream feature values change.
- [ ] **Spot-check Miedema DB values** — Verify a few key pairs (e.g., Mg-W: 13, Mo-W: 0, Ti-Ni: -35, Mg-Ta: 13) against de Boer et al. (1988) or Takeuchi & Inoue (2005). ~70 new pairs were manually transcribed; transcription errors would silently corrupt ΔH_mix.
- [ ] **Verify stability filter thresholds** — Run `generate_hea_dataset(n_samples=1000, seed=123)` and check rejection rate. If rejection rate is unexpectedly high (>30%), the hardcoded thresholds may be too strict for these element pools.
- [ ] **Test edge cases for `_random_composition`** — Verify that `generate_hea_dataset(min_elements=1, max_elements=2)` completes without hanging (tests the feasibility guard).
- [ ] **Verify `filter_relaxed` behavior** — The flag is global: once the reject limit is hit in any pool, the stability filter is disabled for ALL remaining samples across all pools. Check that this doesn't let through too many unphysical compositions.

### Test Plan
```python
from hea_extrapolation_platform.dataset import generate_hea_dataset
comp, feat, target = generate_hea_dataset(n_samples=200, seed=42)
assert len(target) == 200, "Under-count bug"
assert feat['omega'].max() <= 10.0, "Omega clip"
assert (feat['delta_r'] < 8.0).all(), "Stability filter"
assert ((feat['dH_mix'] >= -20) & (feat['dH_mix'] <= 5)).all()
assert (feat['dS_mix'] >= 12).all()
print(f"FCC samples (VEC>=8): {(feat['VEC'] >= 8.0).sum()}")
print(f"BCC samples (VEC<6.87): {(feat['VEC'] < 6.87).sum()}")

# Test edge case: small element counts
comp2, feat2, target2 = generate_hea_dataset(n_samples=50, seed=99, min_elements=1, max_elements=2)
assert len(target2) == 50, "Edge case failed"
```

### Notes
- `noise_std` parameter is kept for API compatibility but now silently ignored (noise is proportional to predicted YS)
- All seeds will produce completely different datasets due to RNG order changes — **no backward compatibility**
- Integration test passed: `ExperimentRunner` works with new dataset
- The `filter_relaxed` flag is global: once the reject limit is reached in any pool, the stability filter is disabled for all remaining samples across all pools

Link to Devin run: https://app.devin.ai/sessions/a35c3055d9194e26a3ca15a00e41209a  
Requested by: @minimumtone

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>