### PR TITLE
fix: R script dimnames error - tryCatch visualization, NA guard, restore *.sh in link_files

### DIFF
--- a/calphad/gphase_optimization/dakota.in
+++ b/calphad/gphase_optimization/dakota.in
@@ -53,7 +53,7 @@ interface
   fork
    work_directory named './wd/trial'
      directory_tag directory_save
-     link_files 'Gver.6.53.TDB.temp'  'gphase_all.R' 'exp_data_for_dakota_opti.csv'  '*.tcm' '*.py' 'dprepro'
+     link_files 'Gver.6.53.TDB.temp'  'gphase_all.R' 'exp_data_for_dakota_opti.csv'  '*.tcm' '*.sh' '*.py' 'dprepro'
    parameters_file 'params.in'
    results_file 'error_tot.txt'
    asynchronous evaluation_concurrency 8

--- a/calphad/gphase_optimization/gphase_all.R
+++ b/calphad/gphase_optimization/gphase_all.R
@@ -96,11 +96,11 @@ caldata   <-   c(0,0,0,0,0,0)  # Fe, Ni, Si, Mn, Mo, Cr
 
 for (i in c(1:length(numEXP))){
     moles   <-   system(cmdMoles[i], intern=T)   # for Moles
-    moles_tot   <-   sum(as.numeric(moles))
+    moles_tot   <-   sum(as.numeric(moles), na.rm=TRUE)
     dfs     <-   system(cmdDF[i], intern=T)      # for DF
-    nmoles  <-   which(as.numeric(moles)!=0.0)
+    nmoles  <-   which(!is.na(as.numeric(moles)) & as.numeric(moles)!=0.0)
 # G相が出ていない場合
-    if (moles_tot == 0.0){
+    if (is.na(moles_tot) || moles_tot == 0.0){
         caldata  <-   c(0,0,0,0,0,0)
         }else if (length(nmoles) == 1){
 # G相が一つしか出ていない場合 
@@ -150,6 +150,7 @@ write(error_total, file="error_tot.txt")
 
 
 ### plot each data
+tryCatch({
 par(mfrow=c(1,1))
 par(mar=c(5,5,5,8))
 par(xpd=T)   # 枠外への描画を許可
@@ -160,6 +161,7 @@ par(xpd=T)   # 枠外への描画を許可
 
 color=c("lightblue", "lightcyan", "lavender", "mistyrose", "cornsilk", "lightgreen")
 
+cat("DEBUG: nrow(visdata)=", nrow(visdata), " expected=", 2*length(numEXP), "\n")
 colnames(visdata) <- c("Fe", "Ni", "Si", "Mn", "Mo", "Cr")
 # rownames(visdata) <- rev(numEXP)
 labexp  <-  paste(numEXP,"Exp")
@@ -175,4 +177,7 @@ for (j in 1:ncol(visdata2)) {
         txt <- 1.00*round(visdata2[,j], 3)
         txt[txt=="0"] <- NA; text(yl, xl, txt,cex=0.5)
         }
+}, error = function(e) {
+  cat("WARNING: Visualization error (non-fatal):", conditionMessage(e), "\n")
+})
 

--- a/calphad/gphase_optimization/gphase_all_Ni-Cr-Mn-Mo_normalized.R
+++ b/calphad/gphase_optimization/gphase_all_Ni-Cr-Mn-Mo_normalized.R
@@ -96,11 +96,11 @@ caldata   <-   c(0,0,0,0,0,0)  # Fe, Ni, Si, Mn, Mo, Cr
 
 for (i in c(1:length(numEXP))){
     moles   <-   system(cmdMoles[i], intern=T)   # for Moles
-    moles_tot   <-   sum(as.numeric(moles))
+    moles_tot   <-   sum(as.numeric(moles), na.rm=TRUE)
     dfs     <-   system(cmdDF[i], intern=T)      # for DF
-    nmoles  <-   which(as.numeric(moles)!=0.0)
+    nmoles  <-   which(!is.na(as.numeric(moles)) & as.numeric(moles)!=0.0)
 # G相が出ていない場合
-    if (moles_tot == 0.0){
+    if (is.na(moles_tot) || moles_tot == 0.0){
         caldata  <-   c(0,0,0,0,0,0)
         }else if (length(nmoles) == 1){
 # G相が一つしか出ていない場合 
@@ -150,6 +150,7 @@ write(error_total, file="error_tot.txt")
 
 
 ### plot each data
+tryCatch({
 par(mfrow=c(1,1))
 par(mar=c(5,5,5,8))
 par(xpd=T)   # 枠外への描画を許可
@@ -160,6 +161,7 @@ par(xpd=T)   # 枠外への描画を許可
 
 color=c("lightblue", "lightcyan", "lavender", "mistyrose", "cornsilk", "lightgreen")
 
+cat("DEBUG: nrow(visdata)=", nrow(visdata), " expected=", 2*length(numEXP), "\n")
 colnames(visdata) <- c("Fe", "Ni", "Si", "Mn", "Mo", "Cr")
 # rownames(visdata) <- rev(numEXP)
 labexp  <-  paste(numEXP,"Exp")
@@ -175,4 +177,7 @@ for (j in 1:ncol(visdata2)) {
         txt <- 1.00*round(visdata2[,j], 3)
         txt[txt=="0"] <- NA; text(yl, xl, txt,cex=0.5)
         }
+}, error = function(e) {
+  cat("WARNING: Visualization error (non-fatal):", conditionMessage(e), "\n")
+})
 


### PR DESCRIPTION
# fix: R script robustness - tryCatch visualization, NA guard, restore *.sh in link_files

## Summary

Addresses a `dimnames` / `rownames<-` crash reported when running Dakota optimization after PR #109. The root cause could not be reproduced locally, so this PR applies defensive fixes to prevent the crash and adds diagnostic output.

**Changes:**
- **dakota.in**: Restore `'*.sh'` to `link_files` (removed in #109). Ensures `driver.sh` is linked into Dakota work directories.
- **gphase_all.R / gphase_all_Ni-Cr-Mn-Mo_normalized.R**:
  - Add `na.rm=TRUE` to `sum(as.numeric(moles))` to handle non-numeric PLE output
  - Filter NAs from `nmoles` index vector
  - Add `is.na(moles_tot)` guard on the `if` condition to prevent `if(NA)` crash
  - Wrap post-`error_tot.txt` visualization section (rownames/barplot) in `tryCatch` so plot errors don't prevent Dakota from reading the objective function result
  - Add `DEBUG: nrow(visdata)=` diagnostic print to help identify the dimension mismatch on the user's machine

**Key design decision:** The critical output (`error_tot.txt`) is written at line 149, *before* the visualization section. The `tryCatch` wrapper ensures that even if `rownames(visdata)` fails, the objective function value is still available for Dakota.

## Review & Testing Checklist for Human

- [ ] **Root cause unknown**: The `tryCatch` masks the `rownames` error rather than fixing it. Run a Dakota trial and check if `DEBUG: nrow(visdata)=` output shows a value other than 36. If so, the loop is exiting early for an unknown reason related to actual PLE file content.
- [ ] **Verify `*.sh` restoration works**: Confirm that `driver.sh` appears in `./wd/trial.N/` directories after Dakota starts.
- [ ] **Check `error_tot.txt` is produced**: Even if the visualization `tryCatch` fires, verify that `error_tot.txt` contains a valid numeric value and Dakota processes it correctly.
- [ ] **Remove DEBUG line later**: The `cat("DEBUG: nrow(visdata)=", ...)` line prints to stdout on every evaluation. Remove it once the root cause of the dimension mismatch is identified.

### Recommended test
```bash
cd calphad/gphase_optimization
dakota -i dakota.in -stop_restart 2
# Check a work directory:
ls ./wd/trial.1/driver.sh        # Should exist (*.sh restored)
cat ./wd/trial.1/error_tot.txt   # Should contain numeric value
grep "DEBUG: nrow" ./wd/trial.1/*.log  # Check dimension output
```

### Notes
- Link to Devin run: https://app.devin.ai/sessions/2f4f864d3a63492f9f08009eb48c32bb
- Requested by: @minimumtone
- The `is.na(moles_tot)` guard is technically redundant with `na.rm=TRUE` (which forces the sum to 0, not NA), but kept as belt-and-suspenders defense.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
