### PR TITLE
fix: DataFrame断片化警告の解消 + SIGSEGV防止

### DIFF
--- a/hea_extrapolation_platform/gui/app.py
+++ b/hea_extrapolation_platform/gui/app.py
@@ -486,18 +486,30 @@ def _refresh_ood_data(
     except (ValueError, KeyError):
         return None, f"Unknown feature set: {fs_key}", pd.DataFrame()
 
-    # Fix #3: use stored train/test indices for correct visualization
+    # Fix #3: use stored train/test indices for correct visualization.
+    # Rebuild from numpy after column-subset + iloc to avoid fragmented
+    # BlockManager that can SIGSEGV in downstream .values / PCA calls.
     split = ood_split_indices.get(fs_key)
     if split is not None:
         train_idx, test_idx = split
-        X_train = features_df[cols].iloc[train_idx]
-        X_query = features_df[cols].iloc[test_idx]
+        X_train = pd.DataFrame(
+            features_df[cols].iloc[train_idx].to_numpy(dtype="float64"),
+            columns=cols,
+        )
+        X_query = pd.DataFrame(
+            features_df[cols].iloc[test_idx].to_numpy(dtype="float64"),
+            columns=cols,
+        )
     else:
         logger.warning("No OOD split indices for %s, using heuristic", fs_key)
-        X_all = features_df[cols]
+        X_all_arr = features_df[cols].to_numpy(dtype="float64")
         n_ood = len(ood_res.composite_scores)
-        X_train = X_all.iloc[:len(X_all) - n_ood]
-        X_query = X_all.iloc[len(X_all) - n_ood:]
+        X_train = pd.DataFrame(
+            X_all_arr[:len(X_all_arr) - n_ood], columns=cols,
+        )
+        X_query = pd.DataFrame(
+            X_all_arr[len(X_all_arr) - n_ood:], columns=cols,
+        )
 
     fig = plotly_ood_map(
         X_train, X_query,

--- a/hea_extrapolation_platform/gui/app.py
+++ b/hea_extrapolation_platform/gui/app.py
@@ -1178,7 +1178,10 @@ def _run_feature_selection_for_fs(
             None, "*Error*", session,
         )
 
-    X = features_df[available_cols].copy()
+    # Rebuild from numpy to get a single contiguous block; column-subset
+    # slicing on a wide DataFrame can create a fragmented BlockManager.
+    _arr = features_df[available_cols].to_numpy(dtype="float64")
+    X = pd.DataFrame(_arr, columns=available_cols)
     y = target.copy()
 
     # Build method list

--- a/hea_extrapolation_platform/gui/plotly_charts.py
+++ b/hea_extrapolation_platform/gui/plotly_charts.py
@@ -79,8 +79,13 @@ def plotly_ood_map(
     # Standardise features before PCA so that no single feature
     # (e.g. atomic weight ~50-200) dominates the variance and
     # causes PC1 ≈ 100%, PC2 ≈ 0%.
+    # Rebuild from numpy to guarantee a single contiguous memory block;
+    # column-subset / iloc slices create fragmented BlockManagers that
+    # can SIGSEGV in the numpy C layer when .values is accessed.
     scaler = StandardScaler()
-    X_scaled = scaler.fit_transform(X_all.values)
+    X_scaled = scaler.fit_transform(
+        X_all.to_numpy(dtype="float64", na_value=np.nan)
+    )
     pca = PCA(n_components=2)
     coords = pca.fit_transform(X_scaled)
     n_train = len(X_train)
@@ -869,7 +874,9 @@ def plotly_pairwise_scatter(
     # Select top-variance features for readability
     variances = features_df.var().sort_values(ascending=False)
     selected = list(variances.head(max_features).index)
-    sub = features_df[selected].copy()
+    # Rebuild from numpy to avoid fragmented BlockManager (SIGSEGV risk)
+    _sub_arr = features_df[selected].to_numpy(dtype="float64", na_value=np.nan)
+    sub = pd.DataFrame(_sub_arr, columns=selected, index=features_df.index)
     n_dim = len(selected)
 
     # Short labels for display

--- a/hea_extrapolation_platform/gui/plotly_charts.py
+++ b/hea_extrapolation_platform/gui/plotly_charts.py
@@ -643,17 +643,22 @@ def plotly_feature_correlation(
         fig.update_layout(title=title)
         return fig
 
-    # Build combined DataFrame: target + top-variance features
-    df = features_df.copy()
-    variances = df.var().sort_values(ascending=False)
+    # Build combined DataFrame: target + top-variance features.
+    # Avoid df.insert() which fragments the BlockManager; instead
+    # build the final DataFrame in one shot via pd.concat.
+    variances = features_df.var().sort_values(ascending=False)
     selected = list(variances.head(max_features).index)
-    df = df[selected]
 
-    if target is not None and len(target) == len(df):
+    if target is not None and len(target) == len(features_df):
         tname = target.name if target.name else "Target"
-        df.insert(0, tname, target.values)
+        df = pd.concat(
+            [target.rename(tname).reset_index(drop=True),
+             features_df[selected].reset_index(drop=True)],
+            axis=1,
+        )
         cols = [tname] + selected
     else:
+        df = features_df[selected].copy()
         cols = selected
 
     n = len(cols)

--- a/hea_extrapolation_platform/runner.py
+++ b/hea_extrapolation_platform/runner.py
@@ -350,9 +350,14 @@ class ExperimentRunner:
                 splitters = self._build_splitters(seed)
 
                 for fs_name in feature_sets:
-                    # Select feature columns for this set
+                    # Select feature columns for this set.
+                    # Rebuild from numpy to get a single contiguous block;
+                    # column-subset slicing on a wide DataFrame (150+ cols)
+                    # creates a fragmented BlockManager that triggers
+                    # PerformanceWarning and can SIGSEGV downstream.
                     cols = FeatureCatalog.columns(fs_name)
-                    X_fs = features_all[cols].copy()
+                    _arr = features_all[cols].to_numpy(dtype="float64")
+                    X_fs = pd.DataFrame(_arr, columns=cols, index=features_all.index)
 
                     for sp_name, splitter in splitters.items():
                         fold_idx = 0

--- a/hea_extrapolation_platform/runner.py
+++ b/hea_extrapolation_platform/runner.py
@@ -364,8 +364,18 @@ class ExperimentRunner:
                         for train_idx, test_idx in splitter.split(
                             X_fs, target, compositions=compositions_df
                         ):
-                            X_train = X_fs.iloc[train_idx].reset_index(drop=True)
-                            X_test = X_fs.iloc[test_idx].reset_index(drop=True)
+                            # Rebuild from numpy after iloc to guarantee
+                            # a single contiguous memory block; iloc on a
+                            # wide DataFrame creates fragmented views that
+                            # SIGSEGV when .values is accessed downstream.
+                            X_train = pd.DataFrame(
+                                X_fs.iloc[train_idx].to_numpy(dtype="float64"),
+                                columns=cols,
+                            )
+                            X_test = pd.DataFrame(
+                                X_fs.iloc[test_idx].to_numpy(dtype="float64"),
+                                columns=cols,
+                            )
                             y_train = target.iloc[train_idx].reset_index(drop=True)
                             y_test = target.iloc[test_idx].reset_index(drop=True)
 
@@ -478,8 +488,17 @@ class ExperimentRunner:
                 X_fs, target, compositions=compositions_df
             ))
             ood_train_idx, ood_test_idx = ood_folds[0]  # first fold
-            X_train_ood = X_fs.iloc[ood_train_idx]
-            X_test_ood = X_fs.iloc[ood_test_idx]
+            # Rebuild from numpy after iloc to avoid fragmented
+            # BlockManager that can SIGSEGV in .values calls.
+            _cols = X_fs.columns
+            X_train_ood = pd.DataFrame(
+                X_fs.iloc[ood_train_idx].to_numpy(dtype="float64"),
+                columns=_cols,
+            )
+            X_test_ood = pd.DataFrame(
+                X_fs.iloc[ood_test_idx].to_numpy(dtype="float64"),
+                columns=_cols,
+            )
 
             detector = OODDetector(k=10)
             detector.fit(X_train_ood)

--- a/hea_extrapolation_platform/visualization.py
+++ b/hea_extrapolation_platform/visualization.py
@@ -95,7 +95,12 @@ def plot_ood_map_pca(
 
     pca = PCA(n_components=2)
     X_all = pd.concat([X_train, X_query], axis=0, ignore_index=True)
-    coords = pca.fit_transform(X_all.values)
+    # Rebuild from numpy to guarantee a single contiguous block;
+    # column-subset / iloc slices create fragmented BlockManagers
+    # that SIGSEGV when .values is accessed in the C layer.
+    coords = pca.fit_transform(
+        X_all.to_numpy(dtype="float64", na_value=np.nan)
+    )
     n_train = len(X_train)
 
     fig, ax = plt.subplots(figsize=(12, 9))
@@ -162,7 +167,10 @@ def plot_ood_map_umap(
 
     reducer = UMAP(n_components=2, random_state=42, n_neighbors=15)
     X_all = pd.concat([X_train, X_query], axis=0, ignore_index=True)
-    coords = reducer.fit_transform(X_all.values)
+    # Rebuild from numpy to avoid fragmented BlockManager SIGSEGV
+    coords = reducer.fit_transform(
+        X_all.to_numpy(dtype="float64", na_value=np.nan)
+    )
     n_train = len(X_train)
 
     fig, ax = plt.subplots(figsize=(12, 9))


### PR DESCRIPTION
# fix: eliminate DataFrame fragmentation warnings & prevent SIGSEGV

## Summary

Fixes the `PerformanceWarning: DataFrame is highly fragmented` warning **and** the `Segmentation fault (コアダンプ)` crash that occurs after OOD detection completes (~460 runs). The root cause is pandas' BlockManager creating one internal block per column when DataFrames are built via `df.insert()`, column-subset slicing, or `.iloc[]` row slicing on wide frames (150+ columns). The numpy C layer can SIGSEGV when `.values` is called on such fragmented frames during PCA, StandardScaler, or model fitting.

**10 sites fixed across 4 files:**

| File | Function / Site | Before | After |
|---|---|---|---|
| `plotly_charts.py` | `plotly_feature_correlation` | `df.insert(0, tname, target.values)` | `pd.concat([target, features], axis=1)` |
| `plotly_charts.py` | `plotly_ood_map` | `X_all.values` | `.to_numpy(dtype="float64")` |
| `plotly_charts.py` | `plotly_pairwise_scatter` | `features_df[selected].copy()` | numpy rebuild |
| `runner.py` | feature set column selection | `features_all[cols].copy()` | `.to_numpy()` → `pd.DataFrame()` |
| `runner.py` | train/test iloc splits (main loop) | `X_fs.iloc[idx].reset_index()` | `.to_numpy()` → `pd.DataFrame()` |
| `runner.py` | `_run_ood_detection` iloc splits | `X_fs.iloc[idx]` | `.to_numpy()` → `pd.DataFrame()` |
| `gui/app.py` | `_refresh_ood_data` | `features_df[cols].iloc[idx]` | `.to_numpy()` → `pd.DataFrame()` |
| `gui/app.py` | `_run_feature_selection_for_fs` | `features_df[cols].copy()` | `.to_numpy()` → `pd.DataFrame()` |
| `visualization.py` | `plot_ood_map_pca` | `X_all.values` | `.to_numpy(dtype="float64")` |
| `visualization.py` | `plot_ood_map_umap` | `X_all.values` | `.to_numpy(dtype="float64")` |

## Review & Testing Checklist for Human

- [ ] **SIGSEGV reproduction**: Run a full analysis (default settings, ~460 runs) end-to-end and confirm no `Segmentation fault` after OOD detection completes. This was the primary crash reported.
- [ ] **dtype coercion safety**: All 10 sites now force `dtype="float64"` via `.to_numpy()`. If any non-numeric column ever enters the feature DataFrame, this will raise `ValueError` rather than silently passing. Verify this is acceptable (it should be — all features are numeric).
- [ ] **Index alignment in `plotly_charts.py`**: The `pd.concat` in `plotly_feature_correlation` uses `reset_index(drop=True)` on both sides. Verify that `target` and `features_df` always share the same row count and implicit ordering.
- [ ] **Memory overhead**: `.to_numpy()` creates a temporary copy. For very large datasets (10k+ samples × 150+ features), confirm no OOM during the training loop where this is called per feature-set × per fold.
- [ ] **End-to-end test**: Load a CSV with 150+ feature columns, run a full analysis, and confirm (a) no `PerformanceWarning` in console, (b) feature correlation heatmap renders correctly, (c) OOD map renders correctly, (d) no SIGSEGV crash.

### Notes
- Requested by: @minimumtone
- [Link to Devin run](https://app.devin.ai/sessions/a35c3055d9194e26a3ca15a00e41209a)
- **No CI or automated tests**: Only `python -m py_compile` was run. Manual end-to-end testing is critical.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->