### PR TITLE
fix: Mahalanobis距離のNaNクランプ追加（浮動小数点ノイズ対策）

### DIFF
--- a/hea_extrapolation_platform/ood.py
+++ b/hea_extrapolation_platform/ood.py
@@ -223,6 +223,13 @@ class OODDetector:
         dists = np.array([
             mahalanobis(x, self._mean, self._cov_inv) for x in X_scaled
         ])
+        # scipy.mahalanobis computes np.sqrt(dot(dot(delta, VI), delta))
+        # without clamping the inner product.  Floating-point noise can
+        # make the quadratic form slightly negative (e.g. -1e-15),
+        # especially with 150+ features or pseudo-inverse cov_inv,
+        # producing NaN from sqrt.  Clamp to zero to prevent silent
+        # NaN propagation into composite scores.
+        np.maximum(dists, 0.0, out=dists)
         return dists
 
     def _knn_batch_train(self, X_scaled: np.ndarray) -> np.ndarray:

--- a/hea_extrapolation_platform/ood.py
+++ b/hea_extrapolation_platform/ood.py
@@ -227,9 +227,9 @@ class OODDetector:
         # without clamping the inner product.  Floating-point noise can
         # make the quadratic form slightly negative (e.g. -1e-15),
         # especially with 150+ features or pseudo-inverse cov_inv,
-        # producing NaN from sqrt.  Clamp to zero to prevent silent
-        # NaN propagation into composite scores.
-        np.maximum(dists, 0.0, out=dists)
+        # producing NaN from sqrt.  np.maximum(NaN, 0) still returns NaN,
+        # so we must use nan_to_num to replace any NaN with 0.0.
+        np.nan_to_num(dists, nan=0.0, copy=False)
         return dists
 
     def _knn_batch_train(self, X_scaled: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
# fix: clamp Mahalanobis distances to prevent NaN from floating-point noise

## Summary

Adds a `np.nan_to_num(dists, nan=0.0, copy=False)` safety clamp after the per-row `scipy.spatial.distance.mahalanobis` call in `_mahalanobis_batch()`. This restores the floating-point safety guard that was present in the previous vectorized `einsum` implementation (removed in PR #118) which used `np.maximum(..., 0.0)` before the `sqrt`.

The concern: with 150+ features or when `np.linalg.pinv` is used for a rank-deficient covariance matrix, the quadratic form inside `mahalanobis` can evaluate to a tiny negative value (e.g. `-1e-15`). `np.sqrt` of a negative number returns `NaN`, which silently propagates through `min()`/`max()` normalization and composite score calculation, causing affected samples to never be flagged as OOD.

### Updates since last revision

- Replaced `np.maximum(dists, 0.0, out=dists)` with `np.nan_to_num(dists, nan=0.0, copy=False)`. The original `np.maximum` does **not** handle NaN (NaN propagates through `maximum`), so it would not have caught the stated failure mode. `nan_to_num` correctly replaces NaN values with 0.0.

## Review & Testing Checklist for Human

- [ ] **NaN → 0.0 semantics**: When a NaN Mahalanobis distance is replaced with 0.0, that sample appears to be at zero distance from the training mean — i.e., maximally in-distribution. If the negative-quadratic-form scenario occurs on a genuinely OOD sample, it will be silently classified as in-distribution. Consider whether logging a warning when NaN is encountered would be preferable, or whether a large sentinel value (e.g. `np.nanmax(dists)`) would be a better replacement.
- [ ] **End-to-end test**: Run a full analysis with 150+ feature columns through OOD detection. Confirm no NaN values appear in `OODResult.mahalanobis_scores` or `composite_scores`.
- [ ] **Verify the fix is necessary**: Check if the negative-inner-product scenario actually occurs in practice. Add a temporary `assert not np.any(np.isnan(dists))` *before* the `nan_to_num` line and run a full analysis to see if it ever triggers.

### Notes
- Requested by: @minimumtone
- [Link to Devin run](https://app.devin.ai/sessions/a35c3055d9194e26a3ca15a00e41209a)
- This addresses a Devin Review finding on PR #118 (comment ID: 3871855753)
- No automated tests exist for this module; manual end-to-end testing is the only verification path.