### PR TITLE
fix: MInt workflow KeyError + RunRegistry蓄積バグ修正 (Devin Review PR#120)

### DIFF
--- a/hea_extrapolation_platform/runner.py
+++ b/hea_extrapolation_platform/runner.py
@@ -171,11 +171,19 @@ def _run_job(
     X_fs: np.ndarray,
     feature_cols: List[str],
     y: np.ndarray,
+    mint_configs: Optional[Dict[str, "MIntWorkflowConfig"]] = None,
 ) -> RunResult:
     """Execute a single training run.  Pure function — no side effects.
 
     X_fs must be C-contiguous so that row slices have unit stride, avoiding
     the BLAS SIGSEGV that occurs with F-contiguous (pandas 3.0) layouts.
+
+    Parameters
+    ----------
+    mint_configs : dict, optional
+        Mapping of MInt workflow name → MIntWorkflowConfig.  When the job's
+        ``wf_name`` is not a built-in workflow, the config is used to
+        reconstruct a ``MIntWorkflowAdapter`` in the worker process.
     """
     import pandas as _pd
 
@@ -194,7 +202,16 @@ def _run_job(
             n_members=3 if job.quick else 5, quick=job.quick
         ),
     }
-    wf = wf_map[job.wf_name]
+
+    if job.wf_name in wf_map:
+        wf = wf_map[job.wf_name]
+    elif mint_configs is not None and job.wf_name in mint_configs:
+        wf = MIntWorkflowAdapter(config=mint_configs[job.wf_name])
+    else:
+        raise KeyError(
+            f"Unknown workflow '{job.wf_name}'. "
+            f"Built-in: {list(wf_map)}, MInt: {list(mint_configs or {})}"
+        )
 
     return wf.run(
         X_train, y_train, X_test, y_test,
@@ -304,14 +321,21 @@ class ExperimentRunner:
         """Execute the full experiment grid in 5 phases."""
         t_start = time.time()
 
+        # Reset per-run state so repeated calls don't accumulate stale data.
+        self._registry._runs.clear()
+        self._ood_split_indices.clear()
+
         self._feature_store.store_features(features_all)
 
         all_wf_names = ["WF-LIN", "WF-XGB", "WF-ENS"]
+        mint_configs: Dict[str, MIntWorkflowConfig] = {}
         if self._mint_registry is not None:
             for wf_info in self._mint_registry.list_workflows():
                 wf_name = wf_info["name"]
                 if wf_name not in all_wf_names:
                     all_wf_names.append(wf_name)
+                    cfg = self._mint_registry.get_config(wf_name)
+                    mint_configs[wf_name] = cfg
                     logger.info("Added MInt workflow: %s", wf_name)
         wf_names = (
             [w for w in all_wf_names if w in (selected_workflows or all_wf_names)]
@@ -345,7 +369,8 @@ class ExperimentRunner:
             )
 
             all_results = self._phase3_train(
-                jobs, features_all, feature_sets, y_arr, progress_callback
+                jobs, features_all, feature_sets, y_arr,
+                progress_callback, mint_configs or None,
             )
             self._registry.add_many(all_results)
 
@@ -471,6 +496,7 @@ class ExperimentRunner:
         feature_sets: List[FeatureSetName],
         y_arr: np.ndarray,
         progress_callback: Optional[Any],
+        mint_configs: Optional[Dict[str, MIntWorkflowConfig]] = None,
     ) -> List[RunResult]:
         """Train all jobs, optionally in parallel.
 
@@ -509,7 +535,7 @@ class ExperimentRunner:
             for job in jobs:
                 arr, cols = fs_arrays[job.fs_name]
                 try:
-                    result = _run_job(job, arr, cols, y_arr)
+                    result = _run_job(job, arr, cols, y_arr, mint_configs)
                     all_results.append(result)
                 except Exception:
                     logger.exception(
@@ -538,6 +564,7 @@ class ExperimentRunner:
                         fs_arrays[job.fs_name][0],
                         fs_arrays[job.fs_name][1],
                         y_arr,
+                        mint_configs,
                     ): job
                     for job in jobs
                 }


### PR DESCRIPTION
# fix: MInt workflow KeyError + RunRegistry accumulation in 5-phase runner

## Summary

Addresses two bugs introduced in the 5-phase runner redesign (PR #120):

**1. `_run_job()` KeyError for MInt workflows**

`MIntWorkflowRegistry.create_default()` registers workflows named `"MInt-LIN"`, `"MInt-XGB"`, `"MInt-ENS"`. These names flow through Phase 2 into `_Job` objects, but `_run_job()` only had a hardcoded `wf_map` for the three built-in workflows (`WF-LIN/WF-XGB/WF-ENS`). Since `app.py` hardcodes `use_mint=True`, every GUI run triggered silent KeyError failures for 50% of jobs.

Fix: `run()` now collects `MIntWorkflowConfig` objects (picklable dataclasses) from the registry and passes them through `_phase3_train()` → `_run_job()`. The worker reconstructs a `MIntWorkflowAdapter` from the config when the workflow name isn't built-in.

**2. RunRegistry accumulation on repeated `run()` calls**

PR #120 removed `self._registry.reset()` from the start of `run()`. If the GUI calls `run()` multiple times in one session, results from prior runs accumulate silently in the registry. This causes `_collect_ood_errors()` to potentially match stale ENS runs from a previous execution.

Fix: `run()` now clears `self._registry._runs` and `self._ood_split_indices` at the start of each call.

## Review & Testing Checklist for Human

- [ ] **Private attribute access**: The reset uses `self._registry._runs.clear()` instead of a public method. PR #120 removed the `reset()` method from `RunRegistry`. Consider whether to restore `reset()` as a public method instead of reaching into `_runs` directly.
- [ ] **MIntWorkflowConfig picklability**: `MIntWorkflowConfig` is a `@dataclass` with `Dict` fields (`tags`, `extra_params`). Verify these remain picklable with `ProcessPoolExecutor` (n_workers > 1). Each worker reconstructs `MIntWorkflowAdapter` from the config, which imports and instantiates workflows — confirm this works in a subprocess.
- [ ] **End-to-end GUI test**: Run analysis twice in the same GUI session with `use_mint=True`. Verify (a) MInt jobs succeed (no KeyError in logs), and (b) the second run's registry contains only results from the second run, not accumulated from both.

### Notes

- These fixes were flagged by Devin Review on PR #120 and were already called out in PR #120's description as known risks.
- No new tests added — recommend adding a unit test for `_run_job()` with a mock MInt config.

Link to Devin run: https://app.devin.ai/sessions/a35c3055d9194e26a3ca15a00e41209a
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
