### PR TITLE
fix: eliminate all remaining .values calls — defense-in-depth SIGSEGV prevention

### DIFF
--- a/hea_extrapolation_platform/gui/plotly_charts.py
+++ b/hea_extrapolation_platform/gui/plotly_charts.py
@@ -545,7 +545,7 @@ def plotly_target_histogram(
     go.Figure
     """
     fig = go.Figure(data=go.Histogram(
-        x=target.values,
+        x=np.ascontiguousarray(target.to_numpy(dtype="float64")),
         nbinsx=30,
         marker_color="#4C72B0",
         hovertemplate="Range: %{x}<br>Count: %{y}<extra></extra>",
@@ -595,7 +595,7 @@ def plotly_composition_heatmap(
 
     fig = go.Figure(data=go.Bar(
         x=list(means.index),
-        y=list(means.values),
+        y=list(means.to_numpy()),
         error_y=dict(
             type="data",
             array=[stds[c] for c in means.index],

--- a/hea_extrapolation_platform/integrations/feast_store.py
+++ b/hea_extrapolation_platform/integrations/feast_store.py
@@ -160,7 +160,7 @@ class _BuiltinFeatureStore:
         result = self._data[available].copy()
 
         if entity_df is not None and "sample_id" in entity_df.columns:
-            ids = entity_df["sample_id"].values
+            ids = np.ascontiguousarray(entity_df["sample_id"].to_numpy())
             result = result.iloc[ids].reset_index(drop=True)
 
         return result

--- a/hea_extrapolation_platform/integrations/mint_adapter.py
+++ b/hea_extrapolation_platform/integrations/mint_adapter.py
@@ -305,11 +305,15 @@ class MIntWorkflowAdapter:
             output_path = tmp / "output.json"
 
             train_df = X_train.copy()
-            train_df["__target__"] = y_train.values
+            train_df["__target__"] = np.ascontiguousarray(
+                y_train.to_numpy(dtype="float64")
+            )
             train_df.to_csv(train_path, index=False)
 
             test_df = X_test.copy()
-            test_df["__target__"] = y_test.values
+            test_df["__target__"] = np.ascontiguousarray(
+                y_test.to_numpy(dtype="float64")
+            )
             test_df.to_csv(test_path, index=False)
 
             # Execute script
@@ -424,9 +428,13 @@ class MIntWorkflowAdapter:
 
         # Prepare payload
         train_data = X_train.copy()
-        train_data["__target__"] = y_train.values
+        train_data["__target__"] = np.ascontiguousarray(
+            y_train.to_numpy(dtype="float64")
+        )
         test_data = X_test.copy()
-        test_data["__target__"] = y_test.values
+        test_data["__target__"] = np.ascontiguousarray(
+            y_test.to_numpy(dtype="float64")
+        )
 
         payload = {
             "train_data": train_data.to_dict(orient="records"),

--- a/hea_extrapolation_platform/splitters.py
+++ b/hea_extrapolation_platform/splitters.py
@@ -234,7 +234,9 @@ class ElementExclusionSplitter(BaseSplitter):
                     "Element '%s' not found in composition columns – skipping", elem
                 )
                 continue
-            test_mask = compositions[elem].values > 0
+            test_mask = np.ascontiguousarray(
+                compositions[elem].to_numpy(dtype="float64")
+            ) > 0
             n_test = int(test_mask.sum())
             n_train = int((~test_mask).sum())
             if n_test < self._min_test_size:


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up to PR #123. Replaces **every remaining `.values`** accessor on pandas Series objects with explicit `.to_numpy()` (+ `np.ascontiguousarray()` where arrays flow toward C extensions). This eliminates the last surface area where pandas 3.0's BlockManager could theoretically produce non-C-contiguous arrays.

**All replaced call sites were on 1-D Series (not DataFrames), so they were likely safe in practice.** This PR hardens them as a precaution so that no `.values` calls remain anywhere in the platform.

Changed files:
- `splitters.py` — `ElementExclusionSplitter` boolean mask construction
- `gui/plotly_charts.py` — target histogram and composition bar chart data
- `integrations/mint_adapter.py` — local/remote MInt target serialization (4 sites)
- `integrations/feast_store.py` — entity ID extraction for `.iloc[]`

## Review & Testing Checklist for Human

- [ ] **Verify `dtype="float64"` coercion is safe in `mint_adapter.py`**: The original `y_train.values` preserved native dtype; the replacement forces `float64`. Confirm target columns are always numeric floats, not integers or categoricals that would lose information.
- [ ] **Verify `feast_store.py` integer indexing still works**: `sample_id` values are used as `.iloc[]` indices. The `np.ascontiguousarray()` wrapper shouldn't change dtype, but confirm integer IDs pass through correctly.
- [ ] **Run the full 702-run end-to-end test** (`python -m hea_extrapolation_platform ...`) with pandas 3.0+ to confirm no regressions. The prior test validated PR #123 but not these additional changes.

### Notes

- The previous end-to-end test (702 runs, exit code 0, no SIGSEGV) validated the core fixes in PR #123. This PR only touches peripheral code paths (visualization, MInt integration, feature store, element-exclusion splitter).
- After this PR, `rg '\.values[^(]'` returns only docstring/comment references — zero live `.values` usage remains.

Link to Devin session: https://app.devin.ai/sessions/bca8c5188d2c4cd58e2182d85a0e19ad
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
