### PR TITLE
feat: add CSV読み込み (Read CSV) button for data preview

### DIFF
--- a/hea_extrapolation_platform/gui/app.py
+++ b/hea_extrapolation_platform/gui/app.py
@@ -1529,20 +1529,6 @@ def create_app() -> gr.Blocks:
                         updated_session,
                     )
 
-                csv_read_btn.click(
-                    fn=_read_csv_preview,
-                    inputs=[
-                        run_csv_upload, run_csv_target, state,
-                    ],
-                    outputs=[
-                        csv_status_html,
-                        summary_stats_md, target_hist_plot,
-                        comp_bar_plot, corr_heatmap_plot,
-                        feature_stats_table,
-                        state,
-                    ],
-                )
-
                 # --- ML Algorithm Selection ---
                 with gr.Accordion(
                     "ML Algorithm Selection (ワークフロー選択)",
@@ -1675,6 +1661,22 @@ def create_app() -> gr.Blocks:
                     fn=_refresh_data_summary,
                     inputs=[state],
                     outputs=summary_outputs,
+                )
+
+                # Wire CSV Read button (defined in Config & Run tab)
+                # to update Data Summary components cross-tab.
+                csv_read_btn.click(
+                    fn=_read_csv_preview,
+                    inputs=[
+                        run_csv_upload, run_csv_target, state,
+                    ],
+                    outputs=[
+                        csv_status_html,
+                        summary_stats_md, target_hist_plot,
+                        comp_bar_plot, corr_heatmap_plot,
+                        feature_stats_table,
+                        state,
+                    ],
                 )
 
 

--- a/hea_extrapolation_platform/gui/app.py
+++ b/hea_extrapolation_platform/gui/app.py
@@ -1317,7 +1317,7 @@ def _run_feature_selection_for_fs(
 # ---------------------------------------------------------------------------
 
 # Current PR / build version tag shown in the GUI title bar.
-_GUI_VERSION_TAG = "PR#125"
+_GUI_VERSION_TAG = "PR#126"
 
 
 def create_app() -> gr.Blocks:
@@ -1379,6 +1379,10 @@ def create_app() -> gr.Blocks:
                         'サンプルデータ自動生成モード（CSVをアップロードすると切替）'
                         '</div>'
                     ),
+                )
+                csv_read_btn = gr.Button(
+                    "\U0001F4D6 CSV読み込み (Read CSV)",
+                    variant="secondary",
                 )
 
                 with gr.Row():
@@ -1445,6 +1449,98 @@ def create_app() -> gr.Blocks:
                     fn=_update_csv_status,
                     inputs=[run_csv_upload],
                     outputs=[csv_status_html],
+                )
+
+                # --- CSV Read button handler ---
+                # Reads the uploaded CSV and updates Data Summary
+                # tab without running the full analysis.
+                def _read_csv_preview(
+                    file_obj: Any,
+                    target_col: str,
+                    session: Dict[str, Any],
+                ) -> Tuple:
+                    """Read CSV and preview in Data Summary tab."""
+                    if file_obj is None:
+                        no_file_html = (
+                            '<div style="padding:8px 12px; '
+                            'background:#fff3e0; '
+                            'border-left:4px solid #FF9800; '
+                            'border-radius:4px; '
+                            'margin:4px 0; font-size:14px;">'
+                            '\u26a0\ufe0f <b>CSVファイルが選択されて'
+                            'いません</b>: '
+                            'まずCSVファイルをアップロードしてください。'
+                            '</div>'
+                        )
+                        return (
+                            no_file_html,
+                            build_summary_stats_md(None, None, None),
+                            None, None, None, pd.DataFrame(),
+                            session,
+                        )
+                    result = _handle_csv_upload(
+                        file_obj, target_col, session,
+                    )
+                    # result = (stats_md, fig, fig, fig, df, session)
+                    updated_session = result[-1]
+                    stats_md = result[0]
+                    # Build status HTML
+                    if updated_session.get("compositions_df") is not None:
+                        n_samples = len(
+                            updated_session["compositions_df"]
+                        )
+                        n_features = (
+                            updated_session["features_df"].shape[1]
+                        )
+                        fname = (
+                            file_obj.name.split("/")[-1]
+                            if hasattr(file_obj, "name")
+                            else "uploaded.csv"
+                        )
+                        status_html = (
+                            '<div style="padding:8px 12px; '
+                            'background:#e8f5e9; '
+                            'border-left:4px solid #4CAF50; '
+                            'border-radius:4px; '
+                            'margin:4px 0; font-size:14px;">'
+                            f'\u2705 <b>CSV読み込み完了</b>: '
+                            f'<code>{html_mod.escape(fname)}</code>'
+                            f' — {n_samples}サンプル, '
+                            f'{n_features}特徴量 '
+                            '（Data Summaryタブで確認できます）'
+                            '</div>'
+                        )
+                    else:
+                        # Error case — stats_md contains the error
+                        status_html = (
+                            '<div style="padding:8px 12px; '
+                            'background:#ffebee; '
+                            'border-left:4px solid #F44336; '
+                            'border-radius:4px; '
+                            'margin:4px 0; font-size:14px;">'
+                            '\u274c <b>CSV読み込みエラー</b>: '
+                            'Data Summaryタブでエラー詳細を確認して'
+                            'ください。'
+                            '</div>'
+                        )
+                    return (
+                        status_html,
+                        *result[:-1],  # stats_md, figs, df
+                        updated_session,
+                    )
+
+                csv_read_btn.click(
+                    fn=_read_csv_preview,
+                    inputs=[
+                        run_csv_upload, run_csv_target, state,
+                    ],
+                    outputs=[
+                        csv_status_html,
+                        summary_stats_md, target_hist_plot,
+                        comp_bar_plot, corr_heatmap_plot,
+                        feature_stats_table,
+                        state,
+                    ],
                 )
 
                 # --- ML Algorithm Selection ---


### PR DESCRIPTION
# feat: add CSV読み込み (Read CSV) button for data preview

## Summary

Adds a dedicated **"📖 CSV読み込み (Read CSV)"** button to the Config & Run tab that reads an uploaded CSV and immediately populates the **Data Summary** tab with preview statistics and plots — without running the full analysis (~100s, 702 runs).

Previously, the only way to see CSV data was to click "Run Analysis", which executes the entire experiment pipeline. Now users can verify their CSV was parsed correctly (element columns detected, target column found, sample/feature counts) before committing to a full run.

**Changes:**
- New `gr.Button` added below the CSV upload widget and status indicator
- New `_read_csv_preview()` handler that wraps existing `_handle_csv_upload()` and updates 6 Data Summary components cross-tab (stats markdown, 3 Plotly figures, feature stats table, session state)
- Status banner shows success (sample/feature counts), warning (no file selected), or error state
- Version tag bumped to PR#126

## Review & Testing Checklist for Human

- [ ] **Verify output tuple shape**: `_read_csv_preview` returns 7 values matching the 7 outputs wired in `csv_read_btn.click()`. Manually trace the return paths (no-file, success, error from `_handle_csv_upload`) to confirm all 3 branches return exactly 7 elements
- [ ] **Test CSV read in GUI**: Upload `data/HEA_ml_numeric_highconf.csv`, click "CSV読み込み", then navigate to Data Summary tab — verify stats, histogram, composition heatmap, and correlation matrix all render
- [ ] **Test error paths**: Click "CSV読み込み" without uploading a file (should show warning), and upload a malformed CSV (should show error status pointing to Data Summary for details)
- [ ] **Verify Run Analysis still works**: After using "CSV読み込み", click "Run Analysis" and confirm it re-reads the CSV correctly (session is reset in `run_experiment`)

### Notes
- `stats_md = result[0]` on line ~1486 is assigned but unused (dead code, not a bug)
- This PR has **not been GUI-tested** yet — only `py_compile` syntax check passed
- Link to Devin session: https://app.devin.ai/sessions/bca8c5188d2c4cd58e2182d85a0e19ad
- Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
