### PR TITLE
fix: prevent SIGSEGV in post-processing — remove gc.collect() & convert plotly data to lists

### DIFF
--- a/hea_extrapolation_platform/gui/app.py
+++ b/hea_extrapolation_platform/gui/app.py
@@ -38,7 +38,6 @@ from __future__ import annotations
 
 import datetime
 import faulthandler
-import gc
 import html as html_mod
 import logging
 import queue
@@ -2326,17 +2325,30 @@ def create_app() -> gr.Blocks:
                 scores = _result_holder["scores"]
                 ood_results = _result_holder["ood"]
 
-                # Free thread-local temporaries and consolidate memory
-                # before the heavy post-processing phase that builds
-                # DataFrames for every tab.
+                # Free the thread-local dict (but do NOT call
+                # gc.collect() — forcing a collection cycle can
+                # trigger SIGSEGV when numpy/pandas C-extension
+                # finalizers run on F-contiguous arrays).
                 del _result_holder
-                gc.collect()
 
                 session["runs"] = runs
                 session["validity_scores"] = scores
                 session["ood_results"] = ood_results
                 session["ood_split_indices"] = runner.ood_split_indices
                 session["runner"] = runner
+
+                # Consolidate DataFrames to single C-contiguous
+                # blocks BEFORE the post-processing functions
+                # (plotly charts with PCA/StandardScaler, .corr(),
+                # .describe()) touch them.  Fragmented BlockManager
+                # frames from pandas 3.0 produce F-contiguous
+                # .values that SIGSEGV in BLAS/LAPACK.
+                if features_df is not None and not features_df.empty:
+                    features_df = _consolidate_df(features_df)
+                    session["features_df"] = features_df
+                if comps_df is not None and not comps_df.empty:
+                    comps_df = _consolidate_df(comps_df)
+                    session["compositions_df"] = comps_df
 
                 log(f"Completed: {len(runs)} runs")
 

--- a/hea_extrapolation_platform/gui/plotly_charts.py
+++ b/hea_extrapolation_platform/gui/plotly_charts.py
@@ -27,6 +27,36 @@ from sklearn.preprocessing import StandardScaler
 logger = logging.getLogger(__name__)
 
 
+def _to_list(arr) -> list:
+    """Convert any array-like to a plain Python list.
+
+    Plotly internally deep-copies template objects (including Histogram,
+    Marker, Pattern, etc.) when ``update_layout(template=...)`` is called.
+    If *any* numpy array is attached to the figure at that moment, the
+    deep-copy can trigger C-extension finalizers on F-contiguous arrays
+    produced by pandas 3.0, causing a SIGSEGV.
+
+    By converting every data payload to a plain Python ``list`` *before*
+    it reaches Plotly, we guarantee that Plotly never holds a reference
+    to a numpy array and the deep-copy path stays in pure-Python land.
+    """
+    if arr is None:
+        return []
+    if isinstance(arr, np.ndarray):
+        return arr.tolist()
+    if isinstance(arr, pd.Series):
+        return arr.tolist()
+    if isinstance(arr, pd.Index):
+        return arr.tolist()
+    if isinstance(arr, list):
+        return arr
+    # Fallback — try generic conversion
+    try:
+        return list(arr)
+    except TypeError:
+        return [arr]
+
+
 def _records_to_df(records: List[Dict[str, Any]]) -> pd.DataFrame:
     """Build a DataFrame from a list-of-dicts using columnar construction.
 
@@ -94,8 +124,8 @@ def plotly_ood_map(
 
     # Training points
     fig.add_trace(go.Scatter(
-        x=coords[:n_train, 0],
-        y=coords[:n_train, 1],
+        x=_to_list(coords[:n_train, 0]),
+        y=_to_list(coords[:n_train, 1]),
         mode="markers",
         marker=dict(color="grey", opacity=0.3, size=6),
         name="Train",
@@ -110,11 +140,11 @@ def plotly_ood_map(
     # In-distribution query points
     if in_dist_mask.any():
         fig.add_trace(go.Scatter(
-            x=query_x[in_dist_mask],
-            y=query_y[in_dist_mask],
+            x=_to_list(query_x[in_dist_mask]),
+            y=_to_list(query_y[in_dist_mask]),
             mode="markers",
             marker=dict(
-                color=composite_scores[in_dist_mask],
+                color=_to_list(composite_scores[in_dist_mask]),
                 colorscale="RdYlGn_r",
                 size=8,
                 colorbar=dict(title="OOD Score"),
@@ -130,11 +160,11 @@ def plotly_ood_map(
     # OOD query points — red ring markers
     if is_ood.any():
         fig.add_trace(go.Scatter(
-            x=query_x[is_ood],
-            y=query_y[is_ood],
+            x=_to_list(query_x[is_ood]),
+            y=_to_list(query_y[is_ood]),
             mode="markers",
             marker=dict(
-                color=composite_scores[is_ood],
+                color=_to_list(composite_scores[is_ood]),
                 colorscale="RdYlGn_r",
                 size=12,
                 line=dict(width=2, color="red"),
@@ -265,11 +295,11 @@ def plotly_heatmap(
     )
 
     fig = go.Figure(data=go.Heatmap(
-        z=pivot_arr,
+        z=_to_list(pivot_arr),
         x=list(pivot.columns),
         y=list(pivot.index),
         colorscale="YlOrRd",
-        text=np.round(pivot_arr, 2),
+        text=np.round(pivot_arr, 2).tolist(),
         texttemplate="%{text}",
         hovertemplate=(
             "Feature Set: %{y}<br>Split: %{x}<br>"
@@ -406,11 +436,11 @@ def plotly_uncertainty_ood(
     go.Figure
     """
     fig = go.Figure(data=go.Scatter(
-        x=ood_scores,
-        y=uncertainties,
+        x=_to_list(ood_scores),
+        y=_to_list(uncertainties),
         mode="markers",
         marker=dict(
-            color=np.abs(errors),
+            color=_to_list(np.abs(errors)),
             colorscale="Hot",
             size=8,
             colorbar=dict(title="|Error|"),
@@ -545,7 +575,7 @@ def plotly_target_histogram(
     go.Figure
     """
     fig = go.Figure(data=go.Histogram(
-        x=np.ascontiguousarray(target.to_numpy(dtype="float64")),
+        x=target.to_numpy(dtype="float64").tolist(),
         nbinsx=30,
         marker_color="#4C72B0",
         hovertemplate="Range: %{x}<br>Count: %{y}<extra></extra>",
@@ -595,10 +625,10 @@ def plotly_composition_heatmap(
 
     fig = go.Figure(data=go.Bar(
         x=list(means.index),
-        y=list(means.to_numpy()),
+        y=means.to_numpy().tolist(),
         error_y=dict(
             type="data",
-            array=[stds[c] for c in means.index],
+            array=[float(stds[c]) for c in means.index],
             visible=True,
         ),
         marker_color="#55A868",
@@ -713,12 +743,14 @@ def plotly_feature_correlation(
             col = j + 1
             xi = np.ascontiguousarray(df[cols[j]].to_numpy(dtype="float64"))
             yi = np.ascontiguousarray(df[cols[i]].to_numpy(dtype="float64"))
+            xi_list = xi.tolist()
+            yi_list = yi.tolist()
 
             if i == j:
                 # --- Diagonal: histogram ---
                 fig.add_trace(
                     go.Histogram(
-                        x=xi, nbinsx=30,
+                        x=xi_list, nbinsx=30,
                         marker_color="#4C72B0",
                         opacity=0.75,
                         showlegend=False,
@@ -738,7 +770,7 @@ def plotly_feature_correlation(
                     xi_s, yi_s = xi, yi
                 fig.add_trace(
                     go.Histogram2dContour(
-                        x=xi_s, y=yi_s,
+                        x=_to_list(xi_s), y=_to_list(yi_s),
                         colorscale="Blues",
                         showscale=False,
                         ncontours=8,
@@ -921,7 +953,7 @@ def plotly_pairwise_scatter(
                 # Diagonal — histogram
                 fig.add_trace(
                     go.Histogram(
-                        x=np.ascontiguousarray(sub[xi].to_numpy()),
+                        x=sub[xi].to_numpy().tolist(),
                         nbinsx=30,
                         marker_color="rgba(76, 114, 176, 0.6)",
                         showlegend=False,
@@ -932,8 +964,8 @@ def plotly_pairwise_scatter(
                 # Off-diagonal — 2D density contour (lightweight)
                 fig.add_trace(
                     go.Histogram2dContour(
-                        x=np.ascontiguousarray(sub[xi].to_numpy()),
-                        y=np.ascontiguousarray(sub[yi].to_numpy()),
+                        x=sub[xi].to_numpy().tolist(),
+                        y=sub[yi].to_numpy().tolist(),
                         colorscale="Blues",
                         showscale=False,
                         ncontours=10,
@@ -943,14 +975,14 @@ def plotly_pairwise_scatter(
                 )
                 # Scatter overlay (subsampled)
                 scatter_kw: dict = dict(
-                    x=np.ascontiguousarray(sub.loc[idx, xi].to_numpy()),
-                    y=np.ascontiguousarray(sub.loc[idx, yi].to_numpy()),
+                    x=sub.loc[idx, xi].to_numpy().tolist(),
+                    y=sub.loc[idx, yi].to_numpy().tolist(),
                     mode="markers",
                     showlegend=False,
                 )
                 if color_arr is not None:
                     scatter_kw["marker"] = dict(
-                        size=2, color=color_arr, colorscale="Viridis",
+                        size=2, color=_to_list(color_arr), colorscale="Viridis",
                         opacity=0.5,
                         showscale=(i == 0 and j == 1),
                         colorbar=dict(title=color_label)
@@ -1200,7 +1232,7 @@ def plotly_fs_boxplot(
         subset = df[df["feature_set"] == fs]
         color = _colors[i % len(_colors)]
         fig.add_trace(go.Box(
-            y=subset[metric],
+            y=_to_list(subset[metric]),
             name=fs,
             marker_color=color,
             boxpoints="all",
@@ -1275,7 +1307,7 @@ def plotly_fs_grouped_bar(
         color = _split_colors.get(sp_col, "#8C8C8C")
         fig.add_trace(go.Bar(
             x=list(pivot.index),
-            y=np.ascontiguousarray(pivot[sp_col].to_numpy(dtype="float64")),
+            y=pivot[sp_col].to_numpy(dtype="float64").tolist(),
             name=sp_col,
             marker_color=color,
             hovertemplate=f"{sp_col}<br>%{{x}}: %{{y:.3f}}<extra></extra>",


### PR DESCRIPTION
## Summary

Fixes SIGSEGV crashes that occur in the GUI after a successful 702-run experiment completes. Two separate crash vectors were identified and fixed:

### 1. Remove `gc.collect()` + consolidate DataFrames (original commit)

The explicit GC call at the transition between experiment completion and post-processing forces deallocation of numpy/pandas objects containing F-contiguous arrays — their C-extension finalizers (sklearn, scipy BLAS/LAPACK) segfault on these layouts. Normal Python refcount cleanup is sufficient. Additionally, `features_df` and `comps_df` are rebuilt into single C-contiguous memory blocks via `_consolidate_df()` *before* the `_refresh_*` functions run.

### 2. Convert all numpy arrays to Python lists before passing to Plotly (follow-up commit)

After the first fix, the user reported the crash persisted — this time inside `plotly_target_histogram()` → `fig.update_layout(template="plotly_white")`. Root cause: Plotly internally `deepcopy()`s template objects (Histogram, Marker, Pattern constructors) when applying a template. If any numpy array (especially F-contiguous from pandas 3.0) is attached to the figure, the deep-copy triggers C-extension finalizers that SIGSEGV.

**Fix:** Added a `_to_list()` helper and applied it across all ~15 plotly chart functions in `plotly_charts.py`. Every numpy array, pandas Series, and Index is converted to a plain Python `list` before reaching Plotly, ensuring the deep-copy path stays in pure-Python land.

**Affected functions:** `plotly_ood_map`, `plotly_heatmap`, `plotly_uncertainty_ood`, `plotly_target_histogram`, `plotly_composition_heatmap`, `plotly_feature_correlation`, `plotly_pairwise_scatter`, `plotly_fs_boxplot`, `plotly_fs_grouped_bar`.

### Test result

702-run GUI experiment (200 samples, seeds 42/123/456, all 3 workflows, Quick Mode) completed in ~101 seconds with **no SIGSEGV**. All tabs (Dashboard KPI, Results, OOD Map, Report) populated correctly. Server remained alive after completion.

![702 runs completed, 100% progress, no crash](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfdExrYm9FVm1sOFJxZzFZMSIsInVzZXJfaWQiOiJnb29nbGUtb2F1dGgyfDEwOTI1MjE4MTI3Mzk5NzAzOTk1MCIsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ190TGtib0VWbWw4UnFnMVkxLzFlNGRmNmI0LTMwNWMtNGFkYS1iZmIxLWVjYjJjMGM4YWVlZCIsImlhdCI6MTc3MjU1Mjg3OSwiZXhwIjoxNzczMTU3Njc5fQ.rJPFDXwqoF0EudVRWnpluu8gUT3sgjG6x8H75nw5GaM)
![Dashboard with plotly charts rendering correctly](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfdExrYm9FVm1sOFJxZzFZMSIsInVzZXJfaWQiOiJnb29nbGUtb2F1dGgyfDEwOTI1MjE4MTI3Mzk5NzAzOTk1MCIsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ190TGtib0VWbWw4UnFnMVkxLzhkOWU5NDNjLTQ5NjMtNDRkOC05MTA5LWNjNTY4MThhZGFiNyIsImlhdCI6MTc3MjU1Mjg3OSwiZXhwIjoxNzczMTU3Njc5fQ.JRUNut4itpW9CDcehtO88r3u7BKrEkMheoznPQsIFpI)

## Review & Testing Checklist for Human

- [ ] **Run the full GUI experiment with your CSV** (`HEA_ml_numeric_highconf2.csv`, 287 samples, all 3 workflows, all seeds) — this is the exact path that crashed twice. Verify it completes without SIGSEGV and all tabs populate correctly. This is critical because the first fix attempt (gc.collect removal only) was insufficient on your machine.
- [ ] **Spot-check plotly chart correctness** — the `_to_list()` conversion should be lossless, but verify that histogram bin counts, heatmap values, OOD map scatter positions, and parity plot points look numerically correct (not shifted, truncated, or empty).
- [ ] **Verify Data Summary tab data integrity** — after the experiment completes, check that sample count, feature count, and summary statistics match expectations (consolidation should not drop data).
- [ ] **Confirm no memory regression** — the removed `gc.collect()` was intended to free memory. Monitor RSS during a full run to ensure it stays reasonable (~320 MB).

### Notes
- The first fix (gc.collect removal + consolidation) was **not sufficient** on the user's machine — SIGSEGV moved to `plotly_target_histogram` → `fig.update_layout`. The `_to_list()` approach addresses this by eliminating numpy arrays from Plotly's object graph entirely.
- Plotly should handle Python lists correctly for all visualizations; lists are the recommended input format in Plotly's API docs. Performance impact should be negligible for visualization-scale data.
- [Devin Session](https://app.devin.ai/sessions/bca8c5188d2c4cd58e2182d85a0e19ad) — requested by @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
