### PR TITLE
fix: monkey-patch Template.__deepcopy__ to eliminate plotly SIGSEGV

### DIFF
--- a/hea_extrapolation_platform/gui/plotly_charts.py
+++ b/hea_extrapolation_platform/gui/plotly_charts.py
@@ -28,19 +28,34 @@ from sklearn.preprocessing import StandardScaler
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# SIGSEGV Prevention: Set global default template ONCE at import time.
+# SIGSEGV Prevention — disable plotly template deepcopy entirely.
 #
-# Plotly internally ``deepcopy()``s template objects every time
-# ``fig.update_layout(template="plotly_white")`` is called.  After 702 ML
-# runs, the process holds many F-contiguous numpy arrays (pandas 3.0).
-# The deep-copy triggers C-extension constructors (Histogram, Marker,
-# Pattern, etc.) that SIGSEGV on those arrays.
+# Plotly internally ``deepcopy()``s the active template object every time
+# ``fig.update_layout()`` is called — even when **no** ``template=``
+# parameter is passed.  The deep-copy reconstructs C-extension backed
+# validator objects (Histogram, Marker, Pattern, Layout …).  After 702 ML
+# runs the process holds many F-contiguous numpy arrays (pandas 3.0) and
+# the reconstruction path triggers a SIGSEGV inside those C extensions.
 #
-# By setting the default template here and NEVER passing ``template=``
-# to ``update_layout()``, we completely eliminate the per-figure deepcopy
-# code path that causes the crash.
+# Fix:
+#   1. Set the default template to ``plotly_white`` once.
+#   2. Monkey-patch ``Template.__deepcopy__`` so that ``copy.deepcopy()``
+#      returns the *same* object instead of reconstructing it.  The
+#      template is effectively immutable in our usage so sharing one
+#      instance across figures is safe and completely eliminates the
+#      dangerous C-extension reconstruction code path.
 # ---------------------------------------------------------------------------
 pio.templates.default = "plotly_white"
+
+from plotly.graph_objs.layout._template import (  # noqa: E402
+    Template as _PlotlyTemplate,
+)
+
+def _template_no_deepcopy(self: "_PlotlyTemplate", memo: dict) -> "_PlotlyTemplate":
+    """Return *self* instead of deep-copying — prevents SIGSEGV."""
+    return self
+
+_PlotlyTemplate.__deepcopy__ = _template_no_deepcopy  # type: ignore[attr-defined]
 
 
 def _to_list(arr) -> list:

--- a/hea_extrapolation_platform/gui/plotly_charts.py
+++ b/hea_extrapolation_platform/gui/plotly_charts.py
@@ -21,10 +21,26 @@ import numpy as np
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
+import plotly.io as pio
 from sklearn.decomposition import PCA
 from sklearn.preprocessing import StandardScaler
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# SIGSEGV Prevention: Set global default template ONCE at import time.
+#
+# Plotly internally ``deepcopy()``s template objects every time
+# ``fig.update_layout(template="plotly_white")`` is called.  After 702 ML
+# runs, the process holds many F-contiguous numpy arrays (pandas 3.0).
+# The deep-copy triggers C-extension constructors (Histogram, Marker,
+# Pattern, etc.) that SIGSEGV on those arrays.
+#
+# By setting the default template here and NEVER passing ``template=``
+# to ``update_layout()``, we completely eliminate the per-figure deepcopy
+# code path that causes the crash.
+# ---------------------------------------------------------------------------
+pio.templates.default = "plotly_white"
 
 
 def _to_list(arr) -> list:
@@ -180,7 +196,6 @@ def plotly_ood_map(
         title=title,
         xaxis_title=f"PC1 — 第1主成分 ({var_ratio[0]*100:.1f}% 分散説明)",
         yaxis_title=f"PC2 — 第2主成分 ({var_ratio[1]*100:.1f}% 分散説明)",
-        template="plotly_white",
         dragmode="lasso",
         height=600,
     )
@@ -253,7 +268,6 @@ def plotly_validity_ranking(
         title="Feature Set Validity Ranking — 特徴量セット妥当性ランキング",
         xaxis_title="妥当性スコア (Score) — 高いほど良い",
         yaxis_title="特徴量セット (Feature Set)",
-        template="plotly_white",
         height=max(400, len(fs_names) * 80),
         legend=dict(orientation="h", yanchor="bottom", y=-0.3),
     )
@@ -322,7 +336,6 @@ def plotly_heatmap(
         title=f"パフォーマンスヒートマップ: {metric_display}",
         xaxis_title="分割方法 (Split Policy)",
         yaxis_title="特徴量セット (Feature Set)",
-        template="plotly_white",
         height=max(400, len(pivot) * 60 + 200),
     )
     return fig
@@ -407,7 +420,6 @@ def plotly_parity(
         title=title,
         xaxis_title="実測値 (True Value)",
         yaxis_title="予測値 (Predicted Value)",
-        template="plotly_white",
         height=600,
         width=600,
     )
@@ -457,7 +469,6 @@ def plotly_uncertainty_ood(
         title="予測不確実性 vs OODスコア",
         xaxis_title="OODスコア — 高いほど分布外",
         yaxis_title="予測不確実性 (std) — 高いほどばらつきが大きい",
-        template="plotly_white",
         height=500,
     )
     return fig
@@ -506,7 +517,6 @@ def plotly_feature_frequency(
         xaxis_title="出現論文数 (Count) — 多いほど有効性が高い",
         yaxis_title="記述子 (Feature)",
         yaxis=dict(autorange="reversed"),
-        template="plotly_white",
         height=max(300, len(names) * 30 + 100),
     )
     return fig
@@ -584,7 +594,6 @@ def plotly_target_histogram(
         title=title,
         xaxis_title=target.name or "Value",
         yaxis_title="Count",
-        template="plotly_white",
         height=350,
     )
     return fig
@@ -638,7 +647,6 @@ def plotly_composition_heatmap(
         title=title,
         xaxis_title="Element",
         yaxis_title="Mean Atomic Fraction",
-        template="plotly_white",
         height=350,
     )
     return fig
@@ -854,7 +862,6 @@ def plotly_feature_correlation(
                 "</span>"
             ),
         ),
-        template="plotly_white",
         height=max(700, total),
         width=max(700, total),
         showlegend=False,
@@ -1003,7 +1010,6 @@ def plotly_pairwise_scatter(
                                  title_font_size=9, tickfont_size=7)
 
     fig.update_layout(
-        template="plotly_white",
         title=title,
         height=max(500, n_dim * 110 + 80),
         width=max(600, n_dim * 120 + 80),
@@ -1161,7 +1167,6 @@ def plotly_fs_radar(
             radialaxis=dict(visible=True, range=[0, 1]),
         ),
         title="特徴量セット比較レーダーチャート — FS Comparison Radar",
-        template="plotly_white",
         height=550,
         legend=dict(orientation="h", yanchor="bottom", y=-0.25),
     )
@@ -1246,7 +1251,6 @@ def plotly_fs_boxplot(
         title=f"特徴量セット別メトリクス分布 — {metric_display}",
         yaxis_title=metric_display,
         xaxis_title="特徴量セット (Feature Set)",
-        template="plotly_white",
         height=500,
         showlegend=False,
     )
@@ -1319,7 +1323,6 @@ def plotly_fs_grouped_bar(
         title=f"特徴量セット × 分割方法 — {metric_display}",
         xaxis_title="特徴量セット (Feature Set)",
         yaxis_title=metric_display,
-        template="plotly_white",
         height=500,
         legend=dict(orientation="h", yanchor="bottom", y=-0.2),
     )
@@ -1548,7 +1551,6 @@ def plotly_fs_train_vs_test(
         title=f"Train vs Test {label} — 対角線から離れるほど過学習の兆候",
         xaxis_title=f"{label} (Train)",
         yaxis_title=f"{label} (Test)",
-        template="plotly_white",
         height=500,
         legend=dict(orientation="h", yanchor="bottom", y=-0.25),
     )
@@ -1713,7 +1715,6 @@ def plotly_knowledge_graph(
 
     fig.update_layout(
         title="知識グラフ — Knowledge Graph",
-        template="plotly_white",
         showlegend=True,
         legend=dict(orientation="h", yanchor="bottom", y=-0.15),
         height=650,


### PR DESCRIPTION
## Summary

Fixes a recurring SIGSEGV crash in `plotly_charts.py` that occurs after a 702-run GUI experiment completes. The crash happens inside `fig.update_layout()` → plotly internal `deepcopy()` of template objects → C-extension validator reconstruction (Histogram, Marker, Pattern, Layout…), which segfaults on F-contiguous numpy arrays held in process memory by pandas 3.0.

**Root cause:** Plotly internally `deepcopy()`s the active template object every time `fig.update_layout()` is called — **even when no `template=` parameter is passed**. After 702 ML runs, the process holds many F-contiguous arrays; the deepcopy reconstruction path invokes C-extension code that crashes on these arrays.

**Fix (two-part):**
1. Set `pio.templates.default = "plotly_white"` once at module import time and remove `template="plotly_white"` from all 15 `update_layout()` calls.
2. **Monkey-patch `Template.__deepcopy__`** to return `self` instead of performing a real deepcopy. This is the critical addition — removing the `template=` parameter alone was insufficient because plotly still deepcopies the default template internally during `update_layout()`.

The template is effectively immutable in our usage, so sharing one instance across figures is safe and completely eliminates the dangerous C-extension reconstruction code path.

Note: This builds on top of PR #128 which already converted numpy arrays to Python lists before passing data to plotly. That fix was necessary but insufficient — the template deepcopy path crashes independently of the figure's data payload.

### Updates since last revision

The initial commit (global default template + removing `template=`) still crashed on @minimumtone's local machine. Stack trace confirmed `deepcopy` was still triggered internally by `update_layout()` even without a `template=` argument. Added second commit (`d69b8c9`) that monkey-patches `Template.__deepcopy__` at the class level to return `self`, preventing the deepcopy entirely.

### Devin test results

702-run GUI experiment completed in 107.4 sec, no SIGSEGV, all tabs rendered (Dashboard, Results, OOD Map, FS Comparison, Report). Server process remained alive after completion.


![Dashboard with charts rendered](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfdExrYm9FVm1sOFJxZzFZMSIsInVzZXJfaWQiOiJnb29nbGUtb2F1dGgyfDEwOTI1MjE4MTI3Mzk5NzAzOTk1MCIsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ190TGtib0VWbWw4UnFnMVkxLzQxMTBkMjFlLWNmZjItNDA2OS05NzljLTczYmZmMDQwNDNkZiIsImlhdCI6MTc3MjU1NDU0OCwiZXhwIjoxNzczMTU5MzQ4fQ.ofJtDzyPIuvVXrNb8YuZWXWCME90Jk9y3ZVBSMQeX_c)

**⚠️ Important caveat:** PR #128's `.tolist()` fix and this PR's first commit (global template default) both passed Devin's test environment but still crashed on @minimumtone's local machine. This environment may not reproduce the exact pandas 3.0 / Python 3.12 memory layout that triggers the SIGSEGV. Local verification on the user's machine is essential.

## Review & Testing Checklist for Human

- [ ] **Critical: Run the full 702-run GUI experiment on your local machine** (pandas 3.0 + Python 3.12 environment). Previous fixes passed Devin's test environment but failed on your machine. This is the only reliable way to verify the SIGSEGV is resolved. Run with: 200 samples, seeds "42 123 456", all 3 workflows, Quick Mode ON, all 3 split policies.
- [ ] **Verify all plotly charts still render with the `plotly_white` theme.** The visual appearance should be identical — white background, light gridlines. Check Dashboard (validity ranking, heatmap), OOD Map, Feature Correlation, and FS Comparison tabs.
- [ ] **Check for subtle rendering issues caused by the monkey-patch.** Since all figures now share the same template instance (not a copy), verify that figures in different tabs don't interfere with each other's styling.
- [ ] **If SIGSEGV persists**, check the stack trace location — if it's no longer in `deepcopy`/template code, the fix is working but there may be another crash vector to address.

### Notes
- The change is mechanical: 27 lines added (template setup + monkey-patch), 15 lines removed (`template="plotly_white"` from each `update_layout()` call). No logic changes to chart generation.
- This is the third SIGSEGV fix iteration. PR #123/#124 addressed sklearn C-extensions; PR #128 addressed plotly data arrays; this PR addresses plotly template deepcopy. Each targets a different crash vector.
- The monkey-patch is a global side effect that affects all Template instances in the process. If any other code in the project uses plotly templates and expects deepcopy to work, it will break.
- [Devin Session](https://app.devin.ai/sessions/bca8c5188d2c4cd58e2182d85a0e19ad) — requested by @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
