### PR TITLE
feat: add WF-LASSO, WF-ARD workflows + PCA dimensionality reduction toggle

### DIFF
--- a/hea_extrapolation_platform/gui/app.py
+++ b/hea_extrapolation_platform/gui/app.py
@@ -1536,12 +1536,22 @@ def create_app() -> gr.Blocks:
                     gr.Markdown(
                         "実行するMLワークフローを選択してください。\n\n"
                         "- **WF-LIN** (Ridge回帰): 特徴量の符号検証・リーク検出に有効\n"
+                        "- **WF-LASSO** (Lasso回帰): L1正則化によるスパース特徴量選択\n"
+                        "- **WF-ARD** (ARD回帰): ベイズ的自動関連度決定\n"
                         "- **WF-XGB** (XGBoost + GridSearchCV): 非線形交互作用を捕捉\n"
                         "- **WF-ENS** (Seed-varied Ensemble): 予測不確実性の定量化"
                     )
                     with gr.Row():
                         wf_lin_check = gr.Checkbox(
                             label="WF-LIN (Ridge Regression)",
+                            value=True,
+                        )
+                        wf_lasso_check = gr.Checkbox(
+                            label="WF-LASSO (Lasso L1)",
+                            value=True,
+                        )
+                        wf_ard_check = gr.Checkbox(
+                            label="WF-ARD (Bayesian ARD)",
                             value=True,
                         )
                         wf_xgb_check = gr.Checkbox(
@@ -1552,6 +1562,22 @@ def create_app() -> gr.Blocks:
                             label="WF-ENS (Ensemble UQ)",
                             value=True,
                         )
+
+                # --- Dimensionality Reduction ---
+                with gr.Accordion(
+                    "Dimensionality Reduction (次元削減)",
+                    open=True,
+                ):
+                    gr.Markdown(
+                        "PCA による次元削減を各ワークフローのパイプラインに組み込みます。\n\n"
+                        "- **ON (デフォルト)**: StandardScaler 後に PCA（分散95%保持）を適用。"
+                        "高次元特徴量の多重共線性を緩和し、学習を安定化します。\n"
+                        "- **OFF**: 次元削減なし。全特徴量をそのまま使用します。"
+                    )
+                    dim_reduction_check = gr.Checkbox(
+                        label="次元削減を行う (Apply PCA Dimensionality Reduction)",
+                        value=True,
+                    )
 
                 # --- Feature Selection Method Selection ---
                 with gr.Accordion(
@@ -2011,8 +2037,11 @@ def create_app() -> gr.Blocks:
             skip_lit: bool,
             skip_plt: bool,
             use_wf_lin: bool,
+            use_wf_lasso: bool,
+            use_wf_ard: bool,
             use_wf_xgb: bool,
             use_wf_ens: bool,
+            use_dim_reduction: bool,
             csv_file: Any,
             csv_target: str,
             session: Dict[str, Any],
@@ -2199,12 +2228,16 @@ def create_app() -> gr.Blocks:
                 selected_wfs: List[str] = []
                 if use_wf_lin:
                     selected_wfs.append("WF-LIN")
+                if use_wf_lasso:
+                    selected_wfs.append("WF-LASSO")
+                if use_wf_ard:
+                    selected_wfs.append("WF-ARD")
                 if use_wf_xgb:
                     selected_wfs.append("WF-XGB")
                 if use_wf_ens:
                     selected_wfs.append("WF-ENS")
                 if not selected_wfs:
-                    selected_wfs = ["WF-LIN", "WF-XGB", "WF-ENS"]
+                    selected_wfs = ["WF-LIN", "WF-LASSO", "WF-ARD", "WF-XGB", "WF-ENS"]
                     log("No workflows selected; using all.")
 
                 log(
@@ -2222,6 +2255,7 @@ def create_app() -> gr.Blocks:
                     use_mlflow=True,
                     use_feast=True,
                     use_mint=True,
+                    dim_reduction=use_dim_reduction,
                 )
 
                 # --- Real-time log capture via threading ---
@@ -2542,7 +2576,9 @@ def create_app() -> gr.Blocks:
             inputs=[
                 seeds_input, n_samples, quick_mode,
                 exclude_elements, skip_literature, skip_plots,
-                wf_lin_check, wf_xgb_check, wf_ens_check,
+                wf_lin_check, wf_lasso_check, wf_ard_check,
+                wf_xgb_check, wf_ens_check,
+                dim_reduction_check,
                 run_csv_upload, run_csv_target,
                 state,
             ],

--- a/hea_extrapolation_platform/runner.py
+++ b/hea_extrapolation_platform/runner.py
@@ -64,7 +64,9 @@ from hea_extrapolation_platform.splitters import (
 from hea_extrapolation_platform.workflows import (
     BaseWorkflow,
     RunResult,
+    WorkflowARD,
     WorkflowENS,
+    WorkflowLASSO,
     WorkflowLIN,
     WorkflowXGB,
 )
@@ -187,6 +189,7 @@ class _Job(NamedTuple):
     train_idx: np.ndarray
     test_idx: np.ndarray
     quick: bool
+    dim_reduction: bool = True
 
 
 # ---------------------------------------------------------------------------
@@ -222,13 +225,17 @@ def _run_job(
     y_test  = _pd.Series(y[job.test_idx])
 
     from hea_extrapolation_platform.workflows import (
-        WorkflowLIN, WorkflowXGB, WorkflowENS,
+        WorkflowARD, WorkflowENS, WorkflowLASSO, WorkflowLIN, WorkflowXGB,
     )
+    _dr = job.dim_reduction
     wf_map: Dict[str, Any] = {
-        "WF-LIN": WorkflowLIN(),
-        "WF-XGB": WorkflowXGB(quick=job.quick),
+        "WF-LIN": WorkflowLIN(dim_reduction=_dr),
+        "WF-LASSO": WorkflowLASSO(dim_reduction=_dr),
+        "WF-ARD": WorkflowARD(dim_reduction=_dr),
+        "WF-XGB": WorkflowXGB(quick=job.quick, dim_reduction=_dr),
         "WF-ENS": WorkflowENS(
-            n_members=3 if job.quick else 5, quick=job.quick
+            n_members=3 if job.quick else 5, quick=job.quick,
+            dim_reduction=_dr,
         ),
     }
 
@@ -287,9 +294,11 @@ class ExperimentRunner:
         use_mlflow: bool = False,
         use_feast: bool = False,
         use_mint: bool = False,
+        dim_reduction: bool = True,
     ) -> None:
         self._seeds = seeds or [42, 123, 456]
         self._quick = quick
+        self._dim_reduction = dim_reduction
         self._exclude_elements = exclude_elements or ["Co", "Ni", "Ti"]
         self._n_workers = n_workers if n_workers is not None else os.cpu_count()
         self._registry = RunRegistry()
@@ -372,7 +381,7 @@ class ExperimentRunner:
 
         self._feature_store.store_features(features_all)
 
-        all_wf_names = ["WF-LIN", "WF-XGB", "WF-ENS"]
+        all_wf_names = ["WF-LIN", "WF-LASSO", "WF-ARD", "WF-XGB", "WF-ENS"]
         mint_configs: Dict[str, MIntWorkflowConfig] = {}
         if self._mint_registry is not None:
             for wf_info in self._mint_registry.list_workflows():
@@ -526,6 +535,7 @@ class ExperimentRunner:
                                 train_idx=train_idx,
                                 test_idx=test_idx,
                                 quick=self._quick,
+                                dim_reduction=self._dim_reduction,
                             ))
         logger.debug("Phase 2: %d jobs", len(jobs))
         return jobs

--- a/hea_extrapolation_platform/workflows.py
+++ b/hea_extrapolation_platform/workflows.py
@@ -18,7 +18,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
-from sklearn.linear_model import Ridge
+from sklearn.decomposition import PCA
+from sklearn.linear_model import ARDRegression, Lasso, LassoCV, Ridge
 from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
 from sklearn.model_selection import GridSearchCV
 from sklearn.pipeline import Pipeline
@@ -140,6 +141,33 @@ class BaseWorkflow(ABC):
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Dimensionality-reduction helper
+# ---------------------------------------------------------------------------
+
+
+def _make_pca_step(
+    n_features: int,
+    dim_reduction: bool,
+    variance_ratio: float = 0.95,
+) -> List[Tuple[str, Any]]:
+    """Return pipeline steps for optional PCA dimensionality reduction.
+
+    When *dim_reduction* is True a PCA step is inserted **after** scaling
+    that retains *variance_ratio* (default 95 %) of total variance.
+    ``n_components`` is capped at ``min(n_samples, n_features)`` by sklearn
+    automatically, so this is safe even for small datasets.
+
+    Returns a list of ``(name, estimator)`` tuples ready for
+    ``Pipeline(steps=[...])``.
+    """
+    if not dim_reduction or n_features <= 2:
+        return []
+    # Keep at most n_features components; PCA will further clamp to
+    # min(n_samples, n_features) internally.
+    return [("pca", PCA(n_components=variance_ratio, svd_solver="full"))]
+
+
 class WorkflowLIN(BaseWorkflow):
     """Linear regression workflow.
 
@@ -153,8 +181,9 @@ class WorkflowLIN(BaseWorkflow):
 
     name = "WF-LIN"
 
-    def __init__(self, alpha: float = 1.0) -> None:
+    def __init__(self, alpha: float = 1.0, dim_reduction: bool = True) -> None:
         self._alpha = alpha
+        self._dim_reduction = dim_reduction
 
     def run(
         self,
@@ -169,10 +198,12 @@ class WorkflowLIN(BaseWorkflow):
         logger.debug("WF-LIN: train=%d, test=%d, features=%d",
                       len(X_train), len(X_test), X_train.shape[1])
 
-        pipe = Pipeline([
+        steps: List[Tuple[str, Any]] = [
             ("scaler", StandardScaler()),
+            *_make_pca_step(X_train.shape[1], self._dim_reduction),
             ("model", Ridge(alpha=self._alpha)),
-        ])
+        ]
+        pipe = Pipeline(steps)
         pipe.fit(_safe_np(X_train), _safe_np(y_train))
 
         y_train_pred = pipe.predict(_safe_np(X_train))
@@ -214,11 +245,226 @@ class WorkflowLIN(BaseWorkflow):
             y_test_true=_safe_np(y_test).copy(),
             y_test_pred=y_test_pred.copy(),
             test_indices=kwargs.get("test_indices"),
-            params={"alpha": self._alpha},
+            params={"alpha": self._alpha, "dim_reduction": self._dim_reduction},
             artifacts={
-                "coef_raw": dict(zip(X_train.columns, coef_raw.tolist())),
-                "coef_std": dict(zip(X_train.columns, coef_std.tolist())),
+                "coef_raw": (
+                    dict(zip(X_train.columns, coef_raw.tolist()))
+                    if len(coef_raw) == X_train.shape[1]
+                    else {f"PC{i}": float(c) for i, c in enumerate(coef_raw)}
+                ),
+                "coef_std": (
+                    dict(zip(X_train.columns, coef_std.tolist()))
+                    if len(coef_std) == X_train.shape[1]
+                    else {f"PC{i}": float(c) for i, c in enumerate(coef_std)}
+                ),
                 "residuals_test": (_safe_np(y_test) - y_test_pred).tolist(),
+                "n_components": (
+                    pipe.named_steps["pca"].n_components_
+                    if "pca" in pipe.named_steps else X_train.shape[1]
+                ),
+            },
+            elapsed_sec=time.time() - t0,
+        )
+        return result
+
+
+# ---------------------------------------------------------------------------
+# WF-LASSO: Lasso regression (L1 regularisation)
+# ---------------------------------------------------------------------------
+
+
+class WorkflowLASSO(BaseWorkflow):
+    """Lasso (L1) regression workflow.
+
+    Purpose:
+    - Sparse feature selection via L1 penalty
+    - Identifies which features can be zeroed out
+    - Complementary to Ridge (L2) for feature importance analysis
+
+    Uses LassoCV to automatically select the best alpha.
+    """
+
+    name = "WF-LASSO"
+
+    def __init__(self, dim_reduction: bool = True) -> None:
+        self._dim_reduction = dim_reduction
+
+    def run(
+        self,
+        X_train: pd.DataFrame,
+        y_train: pd.Series,
+        X_test: pd.DataFrame,
+        y_test: pd.Series,
+        seed: int = 42,
+        **kwargs: Any,
+    ) -> RunResult:
+        t0 = time.time()
+        logger.debug("WF-LASSO: train=%d, test=%d, features=%d",
+                      len(X_train), len(X_test), X_train.shape[1])
+
+        steps: List[Tuple[str, Any]] = [
+            ("scaler", StandardScaler()),
+            *_make_pca_step(X_train.shape[1], self._dim_reduction),
+            ("model", LassoCV(cv=min(5, len(X_train)), random_state=seed, max_iter=10000)),
+        ]
+        pipe = Pipeline(steps)
+        pipe.fit(_safe_np(X_train), _safe_np(y_train))
+
+        y_train_pred = pipe.predict(_safe_np(X_train))
+        y_test_pred = pipe.predict(_safe_np(X_test))
+
+        train_s = _score(_safe_np(y_train), y_train_pred)
+        test_s = _score(_safe_np(y_test), y_test_pred)
+
+        model: LassoCV = pipe.named_steps["model"]
+        coef_raw = model.coef_
+        n_nonzero = int(np.sum(np.abs(coef_raw) > 1e-10))
+
+        if len(y_train) > 1:
+            std_y = float(np.std(_safe_np(y_train), ddof=1))
+        else:
+            std_y = 0.0
+        if std_y < 1e-12:
+            std_y = 1.0
+        coef_std = coef_raw / std_y
+
+        result = RunResult(
+            workflow=self.name,
+            feature_set=kwargs.get("feature_set", ""),
+            split_policy=kwargs.get("split_policy", ""),
+            seed=seed,
+            fold=kwargs.get("fold", 0),
+            rmse_train=train_s["rmse"],
+            rmse_test=test_s["rmse"],
+            mae_train=train_s["mae"],
+            mae_test=test_s["mae"],
+            r2_train=train_s["r2"],
+            r2_test=test_s["r2"],
+            y_test_true=_safe_np(y_test).copy(),
+            y_test_pred=y_test_pred.copy(),
+            test_indices=kwargs.get("test_indices"),
+            params={"alpha": float(model.alpha_), "dim_reduction": self._dim_reduction},
+            artifacts={
+                "coef_raw": (
+                    dict(zip(X_train.columns, coef_raw.tolist()))
+                    if len(coef_raw) == X_train.shape[1]
+                    else {f"PC{i}": float(c) for i, c in enumerate(coef_raw)}
+                ),
+                "coef_std": (
+                    dict(zip(X_train.columns, coef_std.tolist()))
+                    if len(coef_std) == X_train.shape[1]
+                    else {f"PC{i}": float(c) for i, c in enumerate(coef_std)}
+                ),
+                "n_nonzero_features": n_nonzero,
+                "residuals_test": (_safe_np(y_test) - y_test_pred).tolist(),
+                "n_components": (
+                    pipe.named_steps["pca"].n_components_
+                    if "pca" in pipe.named_steps else X_train.shape[1]
+                ),
+            },
+            elapsed_sec=time.time() - t0,
+        )
+        return result
+
+
+# ---------------------------------------------------------------------------
+# WF-ARD: Automatic Relevance Determination (Bayesian sparse regression)
+# ---------------------------------------------------------------------------
+
+
+class WorkflowARD(BaseWorkflow):
+    """ARD (Automatic Relevance Determination) Bayesian regression workflow.
+
+    Purpose:
+    - Bayesian sparse feature importance estimation
+    - Automatic pruning of irrelevant features via per-feature precision
+    - Uncertainty-aware coefficient estimation
+    """
+
+    name = "WF-ARD"
+
+    def __init__(self, dim_reduction: bool = True) -> None:
+        self._dim_reduction = dim_reduction
+
+    def run(
+        self,
+        X_train: pd.DataFrame,
+        y_train: pd.Series,
+        X_test: pd.DataFrame,
+        y_test: pd.Series,
+        seed: int = 42,
+        **kwargs: Any,
+    ) -> RunResult:
+        t0 = time.time()
+        logger.debug("WF-ARD: train=%d, test=%d, features=%d",
+                      len(X_train), len(X_test), X_train.shape[1])
+
+        steps: List[Tuple[str, Any]] = [
+            ("scaler", StandardScaler()),
+            *_make_pca_step(X_train.shape[1], self._dim_reduction),
+            ("model", ARDRegression(max_iter=500)),
+        ]
+        pipe = Pipeline(steps)
+        pipe.fit(_safe_np(X_train), _safe_np(y_train))
+
+        y_train_pred = pipe.predict(_safe_np(X_train))
+        y_test_pred = pipe.predict(_safe_np(X_test))
+
+        train_s = _score(_safe_np(y_train), y_train_pred)
+        test_s = _score(_safe_np(y_test), y_test_pred)
+
+        model: ARDRegression = pipe.named_steps["model"]
+        coef_raw = model.coef_
+        # ARD's lambda_ gives per-feature precision (inverse variance)
+        # Higher lambda_ = less relevant feature
+        relevance = 1.0 / (model.lambda_ + 1e-10)
+        relevance_norm = relevance / relevance.max() if relevance.max() > 0 else relevance
+
+        if len(y_train) > 1:
+            std_y = float(np.std(_safe_np(y_train), ddof=1))
+        else:
+            std_y = 0.0
+        if std_y < 1e-12:
+            std_y = 1.0
+        coef_std = coef_raw / std_y
+
+        result = RunResult(
+            workflow=self.name,
+            feature_set=kwargs.get("feature_set", ""),
+            split_policy=kwargs.get("split_policy", ""),
+            seed=seed,
+            fold=kwargs.get("fold", 0),
+            rmse_train=train_s["rmse"],
+            rmse_test=test_s["rmse"],
+            mae_train=train_s["mae"],
+            mae_test=test_s["mae"],
+            r2_train=train_s["r2"],
+            r2_test=test_s["r2"],
+            y_test_true=_safe_np(y_test).copy(),
+            y_test_pred=y_test_pred.copy(),
+            test_indices=kwargs.get("test_indices"),
+            params={"dim_reduction": self._dim_reduction},
+            artifacts={
+                "coef_raw": (
+                    dict(zip(X_train.columns, coef_raw.tolist()))
+                    if len(coef_raw) == X_train.shape[1]
+                    else {f"PC{i}": float(c) for i, c in enumerate(coef_raw)}
+                ),
+                "coef_std": (
+                    dict(zip(X_train.columns, coef_std.tolist()))
+                    if len(coef_std) == X_train.shape[1]
+                    else {f"PC{i}": float(c) for i, c in enumerate(coef_std)}
+                ),
+                "relevance_scores": (
+                    dict(zip(X_train.columns, relevance_norm.tolist()))
+                    if len(relevance_norm) == X_train.shape[1]
+                    else {f"PC{i}": float(r) for i, r in enumerate(relevance_norm)}
+                ),
+                "residuals_test": (_safe_np(y_test) - y_test_pred).tolist(),
+                "n_components": (
+                    pipe.named_steps["pca"].n_components_
+                    if "pca" in pipe.named_steps else X_train.shape[1]
+                ),
             },
             elapsed_sec=time.time() - t0,
         )
@@ -240,9 +486,10 @@ class WorkflowXGB(BaseWorkflow):
 
     name = "WF-XGB"
 
-    def __init__(self, n_cv: int = 3, quick: bool = False) -> None:
+    def __init__(self, n_cv: int = 3, quick: bool = False, dim_reduction: bool = True) -> None:
         self._n_cv = n_cv
         self._quick = quick
+        self._dim_reduction = dim_reduction
 
     def _get_estimator(self, seed: int) -> Any:
         if _XGB_AVAILABLE:
@@ -283,10 +530,12 @@ class WorkflowXGB(BaseWorkflow):
         logger.debug("WF-XGB: train=%d, test=%d, features=%d",
                       len(X_train), len(X_test), X_train.shape[1])
 
-        pipe = Pipeline([
+        steps: List[Tuple[str, Any]] = [
             ("scaler", StandardScaler()),
+            *_make_pca_step(X_train.shape[1], self._dim_reduction),
             ("model", self._get_estimator(seed)),
-        ])
+        ]
+        pipe = Pipeline(steps)
 
         grid = GridSearchCV(
             pipe,
@@ -364,10 +613,12 @@ class WorkflowENS(BaseWorkflow):
         n_members: int = 5,
         base_workflow: Optional[str] = "xgb",
         quick: bool = False,
+        dim_reduction: bool = True,
     ) -> None:
         self._n_members = n_members
         self._base_workflow = base_workflow
         self._quick = quick
+        self._dim_reduction = dim_reduction
 
     def _make_member(self, seed: int) -> Pipeline:
         if self._base_workflow == "xgb" and _XGB_AVAILABLE:
@@ -390,10 +641,12 @@ class WorkflowENS(BaseWorkflow):
         else:
             # Ridge has no randomness; random_state is not a valid parameter.
             model = Ridge(alpha=1.0)
-        return Pipeline([
+        steps: List[Tuple[str, Any]] = [
             ("scaler", StandardScaler()),
+            *_make_pca_step(132, self._dim_reduction),  # estimate; PCA caps internally
             ("model", model),
-        ])
+        ]
+        return Pipeline(steps)
 
     def run(
         self,
@@ -462,6 +715,8 @@ class WorkflowENS(BaseWorkflow):
 
 WORKFLOW_REGISTRY: Dict[str, type] = {
     "WF-LIN": WorkflowLIN,
+    "WF-LASSO": WorkflowLASSO,
+    "WF-ARD": WorkflowARD,
     "WF-XGB": WorkflowXGB,
     "WF-ENS": WorkflowENS,
 }
@@ -481,4 +736,4 @@ def get_workflow(name: str, **kwargs: Any) -> BaseWorkflow:
         raise ValueError(
             f"Unknown workflow '{name}'. Available: {list(WORKFLOW_REGISTRY.keys())}"
         )
-    return WORKFLOW_REGISTRY[name](**kwargs)
+    return WORKFLOW_REGISTRY[name](**kwargs)  # type: ignore[call-arg]

--- a/hea_extrapolation_platform/workflows.py
+++ b/hea_extrapolation_platform/workflows.py
@@ -305,7 +305,7 @@ class WorkflowLASSO(BaseWorkflow):
         steps: List[Tuple[str, Any]] = [
             ("scaler", StandardScaler()),
             *_make_pca_step(X_train.shape[1], self._dim_reduction),
-            ("model", LassoCV(cv=min(5, len(X_train)), random_state=seed, max_iter=10000)),
+            ("model", LassoCV(cv=max(2, min(5, len(X_train))), random_state=seed, max_iter=10000)),
         ]
         pipe = Pipeline(steps)
         pipe.fit(_safe_np(X_train), _safe_np(y_train))
@@ -558,10 +558,11 @@ class WorkflowXGB(BaseWorkflow):
         # Feature importance from tree model
         model_step = best_pipe.named_steps["model"]
         if hasattr(model_step, "feature_importances_"):
-            fi = dict(zip(
-                X_train.columns,
-                model_step.feature_importances_.tolist(),
-            ))
+            fi_raw = model_step.feature_importances_.tolist()
+            if len(fi_raw) == X_train.shape[1]:
+                fi = dict(zip(X_train.columns, fi_raw))
+            else:
+                fi = {f"PC{i}": float(v) for i, v in enumerate(fi_raw)}
         else:
             fi = {}
 

--- a/hea_extrapolation_platform/workflows.py
+++ b/hea_extrapolation_platform/workflows.py
@@ -249,12 +249,12 @@ class WorkflowLIN(BaseWorkflow):
             artifacts={
                 "coef_raw": (
                     dict(zip(X_train.columns, coef_raw.tolist()))
-                    if len(coef_raw) == X_train.shape[1]
+                    if "pca" not in pipe.named_steps
                     else {f"PC{i}": float(c) for i, c in enumerate(coef_raw)}
                 ),
                 "coef_std": (
                     dict(zip(X_train.columns, coef_std.tolist()))
-                    if len(coef_std) == X_train.shape[1]
+                    if "pca" not in pipe.named_steps
                     else {f"PC{i}": float(c) for i, c in enumerate(coef_std)}
                 ),
                 "residuals_test": (_safe_np(y_test) - y_test_pred).tolist(),
@@ -347,12 +347,12 @@ class WorkflowLASSO(BaseWorkflow):
             artifacts={
                 "coef_raw": (
                     dict(zip(X_train.columns, coef_raw.tolist()))
-                    if len(coef_raw) == X_train.shape[1]
+                    if "pca" not in pipe.named_steps
                     else {f"PC{i}": float(c) for i, c in enumerate(coef_raw)}
                 ),
                 "coef_std": (
                     dict(zip(X_train.columns, coef_std.tolist()))
-                    if len(coef_std) == X_train.shape[1]
+                    if "pca" not in pipe.named_steps
                     else {f"PC{i}": float(c) for i, c in enumerate(coef_std)}
                 ),
                 "n_nonzero_features": n_nonzero,
@@ -447,17 +447,17 @@ class WorkflowARD(BaseWorkflow):
             artifacts={
                 "coef_raw": (
                     dict(zip(X_train.columns, coef_raw.tolist()))
-                    if len(coef_raw) == X_train.shape[1]
+                    if "pca" not in pipe.named_steps
                     else {f"PC{i}": float(c) for i, c in enumerate(coef_raw)}
                 ),
                 "coef_std": (
                     dict(zip(X_train.columns, coef_std.tolist()))
-                    if len(coef_std) == X_train.shape[1]
+                    if "pca" not in pipe.named_steps
                     else {f"PC{i}": float(c) for i, c in enumerate(coef_std)}
                 ),
                 "relevance_scores": (
                     dict(zip(X_train.columns, relevance_norm.tolist()))
-                    if len(relevance_norm) == X_train.shape[1]
+                    if "pca" not in pipe.named_steps
                     else {f"PC{i}": float(r) for i, r in enumerate(relevance_norm)}
                 ),
                 "residuals_test": (_safe_np(y_test) - y_test_pred).tolist(),
@@ -559,7 +559,7 @@ class WorkflowXGB(BaseWorkflow):
         model_step = best_pipe.named_steps["model"]
         if hasattr(model_step, "feature_importances_"):
             fi_raw = model_step.feature_importances_.tolist()
-            if len(fi_raw) == X_train.shape[1]:
+            if "pca" not in best_pipe.named_steps:
                 fi = dict(zip(X_train.columns, fi_raw))
             else:
                 fi = {f"PC{i}": float(v) for i, v in enumerate(fi_raw)}


### PR DESCRIPTION
# feat: add WF-LASSO, WF-ARD workflows + PCA dimensionality reduction toggle

## Summary

Adds two new ML workflow classes (**WF-LASSO** and **WF-ARD**) alongside the existing WF-LIN/WF-XGB/WF-ENS, and introduces an optional PCA dimensionality reduction step (default: ON, 95% variance retained) that can be toggled from the GUI.

**Workflows added:**
- `WorkflowLASSO` — `LassoCV` with automatic alpha selection; reports number of non-zero features and standardised coefficients
- `WorkflowARD` — `ARDRegression` Bayesian sparse regression; reports per-feature relevance scores derived from `lambda_`

**Dimensionality reduction:**
- `_make_pca_step()` helper inserts a `PCA(n_components=0.95)` step into every workflow's sklearn Pipeline between `StandardScaler` and the model, when enabled
- All five workflows (`WF-LIN`, `WF-LASSO`, `WF-ARD`, `WF-XGB`, `WF-ENS`) accept and pass through `dim_reduction: bool`
- When PCA is active, coefficients/importances are reported as `PC0, PC1, …` instead of original feature names (detected via `"pca" in pipe.named_steps`)

**GUI changes:**
- Two new workflow checkboxes (WF-LASSO, WF-ARD) in the "ML Algorithm Selection" accordion
- New "Dimensionality Reduction (次元削減)" accordion with toggle checkbox (default ON)
- The toggle passes `dim_reduction` to `ExperimentRunner`

**Impact on run count:** With all 5 workflows selected (default), total runs increase from 702 → **1170** (5 workflows × 3 seeds × 3 split policies × 6 feature sets × ~13 folds).

## Updates since last revision

**Fixed: PCA-space coefficient labeling (f3efd8f)** — Replaced the `len(coef_raw) == X_train.shape[1]` heuristic with `"pca" not in pipe.named_steps` across all 4 workflows (WF-LIN, WF-LASSO, WF-ARD, WF-XGB). The old heuristic silently mislabeled PCA-rotated coefficients with original feature names when PCA retained all components (common with small decorrelated feature sets like FS_BASE with 8 features). Now consistent with the `"pca" in pipe.named_steps` check already used for the `n_components` artifact.

**Fixed: LassoCV cv guard (e175765)** — Added `max(2, ...)` to `cv=max(2, min(5, len(X_train)))` to prevent `ValueError` when training set has fewer than 2 samples.

**Fixed: WF-XGB feature_importances_ PCA mapping (e175765)** — Added `"pca" not in best_pipe.named_steps` check for feature importance labeling, consistent with the pattern used in linear workflows.

## Review & Testing Checklist for Human

- [ ] **Verify PCA-reduced coefficients are labeled correctly** — When PCA is active, coefficient artifacts should use `PC0, PC1, …` labels, not original feature names. This is critical for WF-LIN's core purpose (feature sign verification). Check a few runs in the Results tab artifacts for correctness.
- [ ] **Test dim_reduction toggle OFF** — Run experiment with dim_reduction unchecked. Verify coefficient artifacts use original feature names, not PC labels. This path was not tested in the Devin session.
- [ ] **Test with real user CSV data on pandas 3.0** — Devin testing used auto-generated sample data (200 samples). SIGSEGV risks may differ with real user data on pandas 3.0.
- [ ] **Check magic number in WF-ENS** — `workflows.py:647` hardcodes `_make_pca_step(132, ...)` for ensemble members. This "132" is an estimate of typical feature count. PCA will internally cap to `min(n_samples, n_features)` so it's safe, but inelegant.

### Test Plan


1. Start GUI: `python -m hea_extrapolation_platform gui --port 7860`
2. Use default settings (200 samples, all 5 workflows ON, dim_reduction ON, Quick Mode ON)
3. Click "▶ Run Analysis" and wait for completion (~2 min)
4. Verify Dashboard, Results, OOD Map, Report tabs all render correctly
5. Check that WF-LASSO and WF-ARD appear in Results table with plausible metrics (R² > 0, RMSE reasonable)
6. Re-run with dim_reduction OFF and verify no PCA step appears in logs; check that coefficient artifacts use original feature names

### Notes

- Link to Devin Session: https://app.devin.ai/sessions/bca8c5188d2c4cd58e2182d85a0e19ad
- Requested by: @minimumtone
- Minor lint issue: `Lasso` is imported in `workflows.py` but never used (only `LassoCV` is used). Consider removing if this triggers linter warnings.
- Devin testing verified: 1170 runs completed in ~105 sec, no SIGSEGV, all 5 workflows showing metrics in Results tab. Testing done with dim_reduction=ON only.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
