### PR TITLE
fix: SIGSEGV root cause — global pandas C-contiguous monkey-patch

### DIFF
--- a/hea_extrapolation_platform/__init__.py
+++ b/hea_extrapolation_platform/__init__.py
@@ -27,4 +27,11 @@ literature_graph   Literature metadata graph (JSONL + FAISS embedding search)
 integrations       External tool adapters (MLflow, Feast, MInt)
 """
 
+# Install pandas C-contiguous compatibility patches BEFORE any other
+# imports that might use pandas.  This is the global SIGSEGV fix for
+# pandas 3.0's F-contiguous array layout.
+from hea_extrapolation_platform._compat import install as _install_compat
+_install_compat()
+del _install_compat
+
 __version__ = "0.1.0"

--- a/hea_extrapolation_platform/__main__.py
+++ b/hea_extrapolation_platform/__main__.py
@@ -33,13 +33,18 @@ import time
 from pathlib import Path
 from typing import List, Optional
 
-import numpy as np
-import pandas as pd
-
 # Enable faulthandler so that SIGSEGV prints a Python traceback
 # instead of silently crashing.  This is invaluable for diagnosing
 # BLAS/LAPACK crashes caused by F-contiguous array layouts.
 faulthandler.enable()
+
+# Install pandas C-contiguous patches BEFORE importing numpy/pandas.
+# This is the global SIGSEGV fix for pandas 3.0's F-contiguous layout.
+from hea_extrapolation_platform._compat import install as _install_compat
+_install_compat()
+
+import numpy as np
+import pandas as pd
 
 
 def _setup_logging(verbose: bool = False) -> None:

--- a/hea_extrapolation_platform/_compat.py
+++ b/hea_extrapolation_platform/_compat.py
@@ -88,12 +88,6 @@ def install() -> None:
     # --- Patch DataFrame.to_numpy ---
     _orig_df_to_numpy = pd.DataFrame.to_numpy
 
-    def _safe_df_to_numpy(self, dtype=None, copy=False, na_value=pd.api.types.pandas_dtype("O") if False else object(), **kwargs):
-        # Call original with all arguments
-        arr = _orig_df_to_numpy(self, dtype=dtype, copy=copy, na_value=na_value, **kwargs)
-        return _ensure_c_contiguous(arr)
-
-    # Fix the signature to match the original more closely
     def _patched_df_to_numpy(self, *args, **kwargs):
         arr = _orig_df_to_numpy(self, *args, **kwargs)
         return _ensure_c_contiguous(arr)

--- a/hea_extrapolation_platform/_compat.py
+++ b/hea_extrapolation_platform/_compat.py
@@ -1,0 +1,138 @@
+"""
+pandas 3.0 / numpy C-contiguous compatibility layer
+pandas 3.0 互換レイヤー
+
+Problem
+-------
+pandas 3.0's BlockManager produces **F-contiguous** (column-major) numpy
+arrays from ``.values``, ``.to_numpy()``, and internal operations.  Many C
+extensions in numpy, scipy, scikit-learn, and plotly assume C-contiguous
+(row-major) layout.  When an F-contiguous array reaches these extensions
+the result is a **SIGSEGV** (segmentation fault).
+
+Previous fixes patched individual call sites (``safe_array``,
+``np.ascontiguousarray``, ``_to_list``).  This was insufficient because
+pandas-derived data can reach C extensions through **any** code path —
+including trivial ones like ``np.mean(list_of_floats)`` when the floats
+originate from pandas objects.
+
+Solution
+--------
+This module **monkey-patches pandas at the source** so that every array
+produced by pandas is guaranteed C-contiguous.  It patches:
+
+1. ``DataFrame.to_numpy()``  — the primary extraction method
+2. ``Series.to_numpy()``     — used by sklearn, evaluation, etc.
+3. ``DataFrame.values``      — legacy property (calls to_numpy internally)
+4. ``Series.values``         — legacy property
+
+The patches are applied **once** at import time via ``install()``.
+All downstream code — sklearn, scipy, plotly, evaluation, etc. — receives
+C-contiguous arrays without any per-call-site changes.
+
+Usage
+-----
+Import this module as early as possible (in ``__init__.py``)::
+
+    from hea_extrapolation_platform._compat import install as _install_compat
+    _install_compat()
+
+The install function is idempotent; calling it multiple times is safe.
+
+Additionally, this module provides ``safe_float()`` which converts
+any numpy scalar to a plain Python float, severing the reference to
+the original numpy memory block.
+"""
+
+from __future__ import annotations
+
+import logging
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+_INSTALLED = False
+
+
+def safe_float(x: object) -> float:
+    """Convert *x* to a plain Python ``float``.
+
+    numpy scalars (``np.float64``, etc.) retain a reference to their
+    parent array's memory block.  Converting to ``float()`` severs that
+    link, preventing C-extension crashes when the parent block is
+    F-contiguous.
+    """
+    return float(x)
+
+
+def _ensure_c_contiguous(arr: np.ndarray) -> np.ndarray:
+    """Return *arr* as C-contiguous if it isn't already."""
+    if arr.ndim == 0:
+        return arr
+    if not arr.flags["C_CONTIGUOUS"]:
+        return np.ascontiguousarray(arr)
+    return arr
+
+
+def install() -> None:
+    """Monkey-patch pandas to always return C-contiguous numpy arrays.
+
+    This is the **single global fix** for all SIGSEGV issues caused by
+    pandas 3.0's F-contiguous array layout.  Call once at startup.
+    """
+    global _INSTALLED
+    if _INSTALLED:
+        return
+
+    # --- Patch DataFrame.to_numpy ---
+    _orig_df_to_numpy = pd.DataFrame.to_numpy
+
+    def _safe_df_to_numpy(self, dtype=None, copy=False, na_value=pd.api.types.pandas_dtype("O") if False else object(), **kwargs):
+        # Call original with all arguments
+        arr = _orig_df_to_numpy(self, dtype=dtype, copy=copy, na_value=na_value, **kwargs)
+        return _ensure_c_contiguous(arr)
+
+    # Fix the signature to match the original more closely
+    def _patched_df_to_numpy(self, *args, **kwargs):
+        arr = _orig_df_to_numpy(self, *args, **kwargs)
+        return _ensure_c_contiguous(arr)
+
+    pd.DataFrame.to_numpy = _patched_df_to_numpy
+
+    # --- Patch Series.to_numpy ---
+    _orig_series_to_numpy = pd.Series.to_numpy
+
+    def _patched_series_to_numpy(self, *args, **kwargs):
+        arr = _orig_series_to_numpy(self, *args, **kwargs)
+        return _ensure_c_contiguous(arr)
+
+    pd.Series.to_numpy = _patched_series_to_numpy
+
+    # --- Patch DataFrame.values property ---
+    _orig_df_values = pd.DataFrame.values.fget  # type: ignore[attr-defined]
+
+    @property  # type: ignore[misc]
+    def _safe_df_values(self):
+        arr = _orig_df_values(self)
+        return _ensure_c_contiguous(arr)
+
+    pd.DataFrame.values = _safe_df_values  # type: ignore[assignment]
+
+    # --- Patch Series.values property ---
+    _orig_series_values = pd.Series.values.fget  # type: ignore[attr-defined]
+
+    @property  # type: ignore[misc]
+    def _safe_series_values(self):
+        arr = _orig_series_values(self)
+        if isinstance(arr, np.ndarray):
+            return _ensure_c_contiguous(arr)
+        return arr
+
+    pd.Series.values = _safe_series_values  # type: ignore[assignment]
+
+    _INSTALLED = True
+    logger.info(
+        "pandas C-contiguous compatibility patches installed "
+        "(DataFrame.to_numpy, Series.to_numpy, .values)"
+    )

--- a/hea_extrapolation_platform/evaluation.py
+++ b/hea_extrapolation_platform/evaluation.py
@@ -13,8 +13,6 @@ Scores each feature set along five axes:
 from __future__ import annotations
 
 import logging
-import math
-import statistics
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 

--- a/hea_extrapolation_platform/evaluation.py
+++ b/hea_extrapolation_platform/evaluation.py
@@ -13,6 +13,8 @@ Scores each feature set along five axes:
 from __future__ import annotations
 
 import logging
+import math
+import statistics
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -129,7 +131,10 @@ class FeatureValidityEvaluator:
                 if r.rmse_test > 0 and np.isfinite(r.rmse_test)
             ]
             if len(rmses) > 1:
-                cv = float(np.std(rmses) / np.mean(rmses)) if np.mean(rmses) > 0 else 1.0
+                _mean = sum(rmses) / len(rmses)
+                _var = sum((x - _mean) ** 2 for x in rmses) / len(rmses)
+                _std = _var ** 0.5
+                cv = _std / _mean if _mean > 0 else 1.0
                 vs.stability = max(0.0, 1.0 - cv)
             else:
                 vs.stability = 0.5  # neutral
@@ -170,7 +175,10 @@ class FeatureValidityEvaluator:
     def _mean_test_rmse(runs: List[RunResult]) -> float:
         if not runs:
             return 0.0
-        return float(np.mean([r.rmse_test for r in runs]))
+        # Use pure Python to avoid numpy C-extension SIGSEGV on
+        # pandas 3.0 F-contiguous memory (even for list-of-floats).
+        vals = [float(r.rmse_test) for r in runs]
+        return sum(vals) / len(vals)
 
     @staticmethod
     def _generalisation_score(
@@ -181,8 +189,10 @@ class FeatureValidityEvaluator:
         """Score [0, 1]: both splits improve -> 1, divergent -> 0."""
         if not random_runs or not block_runs or base_rmse <= 0:
             return 0.5
-        rand_rmse = float(np.mean([r.rmse_test for r in random_runs]))
-        block_rmse = float(np.mean([r.rmse_test for r in block_runs]))
+        _rand_vals = [float(r.rmse_test) for r in random_runs]
+        _block_vals = [float(r.rmse_test) for r in block_runs]
+        rand_rmse = sum(_rand_vals) / len(_rand_vals)
+        block_rmse = sum(_block_vals) / len(_block_vals)
         rand_improve = (base_rmse - rand_rmse) / base_rmse
         block_improve = (base_rmse - block_rmse) / base_rmse
         # Both improve -> high score; divergent -> low.
@@ -209,8 +219,10 @@ class FeatureValidityEvaluator:
         """Detect leak: Random improves a lot but Block degrades."""
         if not random_runs or not block_runs or base_rmse <= 0:
             return 0.0
-        rand_rmse = float(np.mean([r.rmse_test for r in random_runs]))
-        block_rmse = float(np.mean([r.rmse_test for r in block_runs]))
+        _rand_vals = [float(r.rmse_test) for r in random_runs]
+        _block_vals = [float(r.rmse_test) for r in block_runs]
+        rand_rmse = sum(_rand_vals) / len(_rand_vals)
+        block_rmse = sum(_block_vals) / len(_block_vals)
         rand_improve = (base_rmse - rand_rmse) / base_rmse
         block_change = (base_rmse - block_rmse) / base_rmse
         if rand_improve > 0.05 and block_change < -0.02:
@@ -223,9 +235,9 @@ class FeatureValidityEvaluator:
 
         Desired: uncertainty increases for OOD, errors do not explode.
         """
-        errors = np.asarray(ood_data.get("errors", []))
-        uncertainties = np.asarray(ood_data.get("uncertainties", []))
-        is_ood = np.asarray(ood_data.get("is_ood", []), dtype=bool)
+        errors = np.ascontiguousarray(np.asarray(ood_data.get("errors", [])))
+        uncertainties = np.ascontiguousarray(np.asarray(ood_data.get("uncertainties", [])))
+        is_ood = np.ascontiguousarray(np.asarray(ood_data.get("is_ood", []), dtype=bool))
 
         if len(errors) == 0 or is_ood.sum() == 0 or (~is_ood).sum() == 0:
             return 0.5

--- a/hea_extrapolation_platform/gui/app.py
+++ b/hea_extrapolation_platform/gui/app.py
@@ -284,8 +284,8 @@ def _build_physical_interpretation_md(
         rmses = [r.rmse_test for r in fs_runs if r.rmse_test > 0]
         r2s = [r.r2_test for r in fs_runs]
         n_feat = _fs_sizes.get(fs_name, "?")
-        rmse_mean = f"{np.mean(rmses):.2f}" if rmses else "N/A"
-        r2_mean = f"{np.mean(r2s):.4f}" if r2s else "N/A"
+        rmse_mean = f"{sum(rmses)/len(rmses):.2f}" if rmses else "N/A"
+        r2_mean = f"{sum(r2s)/len(r2s):.4f}" if r2s else "N/A"
         vs = score_map.get(fs_name)
         total = f"{vs.total:.4f}" if vs else "N/A"
         recommend = "**Best**" if fs_name == best_fs else ""
@@ -390,9 +390,8 @@ def _build_physical_interpretation_md(
             )
         lines.append("")
         # Interpretation
-        avg_ratio = np.mean(
-            [r.ood_ratio for r in ood_results.values()]
-        )
+        _ratios = [float(r.ood_ratio) for r in ood_results.values()]
+        avg_ratio = sum(_ratios) / len(_ratios) if _ratios else 0.0
         if avg_ratio > 0.2:
             lines.append(
                 "**注意**: OOD比率が20%超です。データの分布がトレーニング領域から"

--- a/hea_extrapolation_platform/gui/plotly_charts.py
+++ b/hea_extrapolation_platform/gui/plotly_charts.py
@@ -1381,9 +1381,13 @@ def build_fs_comparison_summary_md(
         rmses = [r.rmse_test for r in fs_runs if r.rmse_test > 0]
         r2s = [r.r2_test for r in fs_runs]
         n_feat = _fs_sizes.get(fs_name, "?")
-        rmse_mean = f"{np.mean(rmses):.2f}" if rmses else "N/A"
-        rmse_std = f"{np.std(rmses):.2f}" if len(rmses) > 1 else "N/A"
-        r2_mean = f"{np.mean(r2s):.4f}" if r2s else "N/A"
+        rmse_mean = f"{sum(rmses)/len(rmses):.2f}" if rmses else "N/A"
+        if len(rmses) > 1:
+            _rm = sum(rmses) / len(rmses)
+            rmse_std = f"{(sum((x - _rm)**2 for x in rmses) / len(rmses))**0.5:.2f}"
+        else:
+            rmse_std = "N/A"
+        r2_mean = f"{sum(r2s)/len(r2s):.4f}" if r2s else "N/A"
         vs = score_map.get(fs_name)
         total = f"{vs.total:.4f}" if vs else "N/A"
         recommend = "**Best**" if fs_name == best_fs else ""

--- a/hea_extrapolation_platform/runner.py
+++ b/hea_extrapolation_platform/runner.py
@@ -700,8 +700,8 @@ class ExperimentRunner:
                 ood_res = detector.score(X_test_ood)
                 ood_results[fs_key] = ood_res
                 self._ood_split_indices[fs_key] = (
-                    np.asarray(ood_train_idx),
-                    np.asarray(ood_test_idx),
+                    np.ascontiguousarray(np.asarray(ood_train_idx)),
+                    np.ascontiguousarray(np.asarray(ood_test_idx)),
                 )
 
                 try:
@@ -752,7 +752,7 @@ class ExperimentRunner:
         ood_test_idx: np.ndarray,
         out: Dict[str, Dict[str, np.ndarray]],
     ) -> None:
-        ood_test_indices = np.asarray(ood_test_idx)
+        ood_test_indices = np.ascontiguousarray(np.asarray(ood_test_idx))
         ens_runs = [
             r for r in self._registry.runs
             if r.feature_set == fs_key
@@ -761,22 +761,31 @@ class ExperimentRunner:
         ]
         matched = None
         for er in reversed(ens_runs):
-            if np.array_equal(np.asarray(er.test_indices), ood_test_indices):
+            if np.array_equal(
+                np.ascontiguousarray(np.asarray(er.test_indices)),
+                ood_test_indices,
+            ):
                 matched = er
                 break
         if matched is None:
             logger.info("No matching ENS run for OOD eval on %s", fs_key)
             return
-        pred_std = np.array(matched.artifacts.get("pred_std_test", []))
+        pred_std = np.ascontiguousarray(
+            np.array(matched.artifacts.get("pred_std_test", []))
+        )
         if (
             matched.y_test_true is not None
             and matched.y_test_pred is not None
             and len(pred_std) > 0
         ):
+            _errors = np.ascontiguousarray(
+                matched.y_test_true - matched.y_test_pred
+            )
+            _is_ood = np.ascontiguousarray(np.asarray(ood_res.is_ood))
             out[fs_key] = {
-                "errors":        matched.y_test_true - matched.y_test_pred,
+                "errors":        _errors,
                 "uncertainties": pred_std,
-                "is_ood":        ood_res.is_ood,
+                "is_ood":        _is_ood,
             }
 
     def export(self, out_dir: Path) -> None:

--- a/hea_extrapolation_platform/workflows.py
+++ b/hea_extrapolation_platform/workflows.py
@@ -89,6 +89,30 @@ class RunResult:
     artifacts: Dict[str, Any] = field(default_factory=dict)
     elapsed_sec: float = 0.0
 
+    def __post_init__(self) -> None:
+        """Enforce plain Python floats and C-contiguous numpy arrays.
+
+        pandas 3.0 produces numpy scalars that retain references to
+        F-contiguous memory blocks.  Converting metrics to ``float()``
+        severs these references.  numpy arrays stored in the result are
+        forced C-contiguous to prevent downstream SIGSEGV.
+        """
+        # Sever numpy scalar references to F-contiguous memory
+        self.rmse_train = float(self.rmse_train)
+        self.rmse_test = float(self.rmse_test)
+        self.mae_train = float(self.mae_train)
+        self.mae_test = float(self.mae_test)
+        self.r2_train = float(self.r2_train)
+        self.r2_test = float(self.r2_test)
+        self.elapsed_sec = float(self.elapsed_sec)
+        # Ensure all stored numpy arrays are C-contiguous
+        if self.y_test_true is not None:
+            self.y_test_true = np.ascontiguousarray(self.y_test_true)
+        if self.y_test_pred is not None:
+            self.y_test_pred = np.ascontiguousarray(self.y_test_pred)
+        if self.test_indices is not None:
+            self.test_indices = np.ascontiguousarray(self.test_indices)
+
     def metrics_dict(self) -> Dict[str, float]:
         return {
             "rmse_train": self.rmse_train,


### PR DESCRIPTION
# fix: global pandas C-contiguous monkey-patch to prevent SIGSEGV

## Summary

Addresses recurring SIGSEGV crashes (20+ occurrences across PRs #123–#130) caused by pandas 3.0's BlockManager producing F-contiguous (column-major) numpy arrays. Previous PRs patched individual call sites, but crashes kept appearing at new locations because pandas-derived data reaches C extensions through countless code paths.

**Root cause fix:** Instead of per-call-site patches, this PR monkey-patches pandas at the source — `DataFrame.to_numpy()`, `Series.to_numpy()`, and `.values` — to guarantee C-contiguous output globally. A new `_compat.py` module is installed at startup before any numpy/pandas usage.

**Additional hardening (defense-in-depth):**
- `evaluation.py`: Replaced `np.mean`/`np.std` on lists-of-floats with pure Python `sum()/len()` arithmetic
- `workflows.py`: Added `RunResult.__post_init__` to force `float()` on all metrics and `np.ascontiguousarray` on stored arrays
- `app.py` / `plotly_charts.py`: Replaced `np.mean`/`np.std` in display-formatting code with pure Python
- `runner.py`: Wrapped `np.asarray`/`np.array` calls in `_collect_ood_errors` with `np.ascontiguousarray`

## Review & Testing Checklist for Human

- [ ] **Verify monkey-patch doesn't break pandas behavior**: Run the full 1170-run experiment with real data (287 samples, 150 features) and confirm Phase 5 (Evaluation) completes without SIGSEGV. Previous Devin testing used only auto-generated 200-sample data which did not trigger the F-contiguous layout.
- [ ] **Check `_compat.py` dead code**: Lines 95–98 define `_safe_df_to_numpy` with a bizarre default argument (`pd.api.types.pandas_dtype("O") if False else object()`) — this function is **never used**; only `_patched_df_to_numpy` (lines 101–103) is actually assigned. Confirm this dead code doesn't cause import-time errors.
- [ ] **Unused imports in `evaluation.py`**: `import math` and `import statistics` were added but neither is used — the code uses manual `sum()/len()` instead. These should be removed or used.
- [ ] **Std deviation formula consistency**: `evaluation.py` and `plotly_charts.py` replace `np.std()` (population std, ddof=0) with manual `sqrt(sum((x-mean)^2)/n)` — verify this matches the original behavior (it should, since `np.std` defaults to ddof=0).
- [ ] **End-to-end GUI test plan**: Upload real CSV → Run 1170-run experiment (all 5 workflows: WF-LIN, WF-LASSO, WF-ARD, WF-XGB, WF-ENS) → Verify Phase 5 completes → Check Results/Dashboard/Report tabs render without crash. If SIGSEGV still occurs, check which numpy operation is involved (the monkey-patch should have caught pandas-sourced arrays, so a remaining crash would indicate a different root cause).

### Notes
- **Why monkey-patching?** Per-call-site fixes (PR #123–#129) were insufficient because pandas data flows to C extensions through unpredictable paths (e.g., `np.mean([float(x) for x in pandas_series])` still triggered SIGSEGV). The global fix ensures **every** pandas-derived array is C-contiguous before leaving pandas.
- **Performance impact:** `np.ascontiguousarray` is nearly free for already-C-contiguous arrays (memoryview, no copy). For F-contiguous arrays, it forces a copy, but this is necessary to prevent crashes.
- **Unused imports cleanup needed**: `math`, `statistics` in `evaluation.py` should be removed if not used elsewhere.

Link to Devin Session: https://app.devin.ai/sessions/bca8c5188d2c4cd58e2182d85a0e19ad  
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
