### PR TITLE
fix: plotly Template.__deepcopy__ monkey-patch — prevent SIGSEGV in update_layout

### DIFF
--- a/hea_extrapolation_platform/_compat.py
+++ b/hea_extrapolation_platform/_compat.py
@@ -125,8 +125,36 @@ def install() -> None:
 
     pd.Series.values = _safe_series_values  # type: ignore[assignment]
 
+    # --- Patch plotly Template.__deepcopy__ ---
+    # plotly's update_layout() internally deepcopies the global Template
+    # object.  During deepcopy, Parcoords.__init__ and other validators
+    # reconstruct numpy arrays via C extensions.  If any F-contiguous
+    # arrays are reachable from the template graph, the C extension
+    # crashes with SIGSEGV.
+    #
+    # Fix: replace Template.__deepcopy__ with a no-op that returns self.
+    # Templates are effectively immutable singletons so sharing is safe.
+    try:
+        import plotly.graph_objs.layout as _plotly_layout
+        import plotly.io as pio
+
+        _Template = _plotly_layout.Template
+
+        def _template_deepcopy_noop(self, memo=None):  # type: ignore[override]
+            """Return *self* instead of deepcopying — avoids SIGSEGV."""
+            return self
+
+        _Template.__deepcopy__ = _template_deepcopy_noop
+
+        # Set global default so individual calls don't need template=
+        pio.templates.default = "plotly_white"
+
+        logger.info("plotly Template.__deepcopy__ safety patch installed")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("plotly Template patch skipped: %s", exc)
+
     _INSTALLED = True
     logger.info(
         "pandas C-contiguous compatibility patches installed "
-        "(DataFrame.to_numpy, Series.to_numpy, .values)"
+        "(DataFrame.to_numpy, Series.to_numpy, .values, plotly Template)"
     )

--- a/hea_extrapolation_platform/gui/plotly_charts.py
+++ b/hea_extrapolation_platform/gui/plotly_charts.py
@@ -180,7 +180,6 @@ def plotly_ood_map(
         title=title,
         xaxis_title=f"PC1 — 第1主成分 ({var_ratio[0]*100:.1f}% 分散説明)",
         yaxis_title=f"PC2 — 第2主成分 ({var_ratio[1]*100:.1f}% 分散説明)",
-        template="plotly_white",
         dragmode="lasso",
         height=600,
     )
@@ -253,7 +252,6 @@ def plotly_validity_ranking(
         title="Feature Set Validity Ranking — 特徴量セット妥当性ランキング",
         xaxis_title="妥当性スコア (Score) — 高いほど良い",
         yaxis_title="特徴量セット (Feature Set)",
-        template="plotly_white",
         height=max(400, len(fs_names) * 80),
         legend=dict(orientation="h", yanchor="bottom", y=-0.3),
     )
@@ -322,7 +320,6 @@ def plotly_heatmap(
         title=f"パフォーマンスヒートマップ: {metric_display}",
         xaxis_title="分割方法 (Split Policy)",
         yaxis_title="特徴量セット (Feature Set)",
-        template="plotly_white",
         height=max(400, len(pivot) * 60 + 200),
     )
     return fig
@@ -407,7 +404,6 @@ def plotly_parity(
         title=title,
         xaxis_title="実測値 (True Value)",
         yaxis_title="予測値 (Predicted Value)",
-        template="plotly_white",
         height=600,
         width=600,
     )
@@ -457,7 +453,6 @@ def plotly_uncertainty_ood(
         title="予測不確実性 vs OODスコア",
         xaxis_title="OODスコア — 高いほど分布外",
         yaxis_title="予測不確実性 (std) — 高いほどばらつきが大きい",
-        template="plotly_white",
         height=500,
     )
     return fig
@@ -506,7 +501,6 @@ def plotly_feature_frequency(
         xaxis_title="出現論文数 (Count) — 多いほど有効性が高い",
         yaxis_title="記述子 (Feature)",
         yaxis=dict(autorange="reversed"),
-        template="plotly_white",
         height=max(300, len(names) * 30 + 100),
     )
     return fig
@@ -584,7 +578,6 @@ def plotly_target_histogram(
         title=title,
         xaxis_title=target.name or "Value",
         yaxis_title="Count",
-        template="plotly_white",
         height=350,
     )
     return fig
@@ -638,7 +631,6 @@ def plotly_composition_heatmap(
         title=title,
         xaxis_title="Element",
         yaxis_title="Mean Atomic Fraction",
-        template="plotly_white",
         height=350,
     )
     return fig
@@ -854,7 +846,6 @@ def plotly_feature_correlation(
                 "</span>"
             ),
         ),
-        template="plotly_white",
         height=max(700, total),
         width=max(700, total),
         showlegend=False,
@@ -1003,7 +994,6 @@ def plotly_pairwise_scatter(
                                  title_font_size=9, tickfont_size=7)
 
     fig.update_layout(
-        template="plotly_white",
         title=title,
         height=max(500, n_dim * 110 + 80),
         width=max(600, n_dim * 120 + 80),
@@ -1161,7 +1151,6 @@ def plotly_fs_radar(
             radialaxis=dict(visible=True, range=[0, 1]),
         ),
         title="特徴量セット比較レーダーチャート — FS Comparison Radar",
-        template="plotly_white",
         height=550,
         legend=dict(orientation="h", yanchor="bottom", y=-0.25),
     )
@@ -1246,7 +1235,6 @@ def plotly_fs_boxplot(
         title=f"特徴量セット別メトリクス分布 — {metric_display}",
         yaxis_title=metric_display,
         xaxis_title="特徴量セット (Feature Set)",
-        template="plotly_white",
         height=500,
         showlegend=False,
     )
@@ -1319,7 +1307,6 @@ def plotly_fs_grouped_bar(
         title=f"特徴量セット × 分割方法 — {metric_display}",
         xaxis_title="特徴量セット (Feature Set)",
         yaxis_title=metric_display,
-        template="plotly_white",
         height=500,
         legend=dict(orientation="h", yanchor="bottom", y=-0.2),
     )
@@ -1552,7 +1539,6 @@ def plotly_fs_train_vs_test(
         title=f"Train vs Test {label} — 対角線から離れるほど過学習の兆候",
         xaxis_title=f"{label} (Train)",
         yaxis_title=f"{label} (Test)",
-        template="plotly_white",
         height=500,
         legend=dict(orientation="h", yanchor="bottom", y=-0.25),
     )
@@ -1717,7 +1703,6 @@ def plotly_knowledge_graph(
 
     fig.update_layout(
         title="知識グラフ — Knowledge Graph",
-        template="plotly_white",
         showlegend=True,
         legend=dict(orientation="h", yanchor="bottom", y=-0.15),
         height=650,


### PR DESCRIPTION
# fix: patch plotly Template.__deepcopy__ to prevent SIGSEGV in update_layout

## Summary

Addresses the remaining SIGSEGV crash in `plotly_target_histogram` → `update_layout()` → `deepcopy(Template)` → `Parcoords.__init__` path, where pandas 3.0's F-contiguous arrays trigger C-extension crashes during plotly's internal template deepcopy.

**Two changes:**

1. **`_compat.py`** — Adds a plotly `Template.__deepcopy__` monkey-patch (inside the existing `install()` function) that returns `self` instead of performing a real deepcopy. Also sets `pio.templates.default = "plotly_white"` globally so individual chart functions don't need to pass the template parameter.

2. **`plotly_charts.py`** — Removes all 15 `template="plotly_white"` arguments from `update_layout()` calls (now redundant due to the global default).

## Review & Testing Checklist for Human

- [ ] **Verify `Template.__deepcopy__` returning `self` is safe**: The patch makes all figures share the same Template instance. If any plotly code path mutates a template after deepcopy (rather than treating it as read-only), this could cause cross-figure state corruption. Check whether plotly ever writes to the deepcopied template object.
- [ ] **Test with real 287×150 CSV (`HEA_ml_numeric_highconf.csv`)**: Previous fixes passed in Devin's environment but crashed on user's machine. Run full 1170-run experiment (5 workflows × 3 seeds, Quick Mode ON, Dim Reduction ON) and verify all 5 phases complete — especially Phase 5 (Evaluation) which previously crashed.
- [ ] **Verify chart styling**: Confirm all 15 chart types still render with `plotly_white` theme via the global default (not just unstyled).
- [ ] **Check the `except Exception` fallback**: If plotly's internal module path changes in a future version, the patch silently skips. Verify the warning log appears correctly when plotly is unavailable or the import path changes.

### Notes

- This complements PR #131's pandas C-contiguous monkey-patches. PR #131 fixed the pandas source; this PR fixes the plotly deepcopy consumer path that was missed.
- The `try/except` around the plotly patch is intentional — the platform should still function (without the safety patch) if plotly's internal API changes.
- No automated tests added; the fix is a runtime monkey-patch that's difficult to unit test without reproducing the exact F-contiguous memory layout that triggers SIGSEGV.

Link to Devin Session: https://app.devin.ai/sessions/bca8c5188d2c4cd58e2182d85a0e19ad
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
