### PR TITLE
fix: disable cyclic GC globally to prevent SIGSEGV during plotly/GC interaction

### DIFF
--- a/hea_extrapolation_platform/_compat.py
+++ b/hea_extrapolation_platform/_compat.py
@@ -46,13 +46,37 @@ the original numpy memory block.
 
 from __future__ import annotations
 
+import contextlib
+import gc
 import logging
+from typing import Iterator
+
 import numpy as np
 import pandas as pd
 
 logger = logging.getLogger(__name__)
 
 _INSTALLED = False
+
+
+@contextlib.contextmanager
+def gc_disabled() -> Iterator[None]:
+    """Context manager that disables the cyclic garbage collector.
+
+    During plotly chart creation and other critical operations, GC can
+    trigger C-extension finalizers on F-contiguous numpy arrays left
+    over from pandas 3.0 operations.  These finalizers crash with
+    SIGSEGV.  Disabling GC during these operations prevents the crash.
+
+    Reference counting still frees non-cyclic objects normally.
+    """
+    was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        yield
+    finally:
+        if was_enabled:
+            gc.enable()
 
 
 def safe_float(x: object) -> float:
@@ -153,8 +177,20 @@ def install() -> None:
     except Exception as exc:  # noqa: BLE001
         logger.warning("plotly Template patch skipped: %s", exc)
 
+    # --- Disable cyclic GC globally ---
+    # GC triggers C-extension finalizers on F-contiguous numpy arrays
+    # left over from pandas 3.0 operations. These finalizers crash with
+    # SIGSEGV during plotly chart creation, literature search, and other
+    # operations.  Disabling GC is safe because:
+    # 1. Reference counting still frees non-cyclic objects immediately
+    # 2. GUI sessions are short-lived (~100s)
+    # 3. Memory usage is bounded (~310 MB peak)
+    # 4. Process exit reclaims all memory
+    gc.disable()
+    logger.info("Cyclic garbage collector disabled to prevent SIGSEGV")
+
     _INSTALLED = True
     logger.info(
         "pandas C-contiguous compatibility patches installed "
-        "(DataFrame.to_numpy, Series.to_numpy, .values, plotly Template)"
+        "(DataFrame.to_numpy, Series.to_numpy, .values, plotly Template, GC disabled)"
     )


### PR DESCRIPTION
## Summary

Disables Python's cyclic garbage collector globally at startup (inside `_compat.install()`) to prevent SIGSEGV crashes caused by GC triggering C-extension finalizers on F-contiguous numpy arrays during plotly operations.

The crash occurs when GC runs *during* plotly chart creation (e.g. `plotly_feature_frequency` → `update_layout()` → `chomp_empty_strings`). The GC cycle invokes finalizers on F-contiguous arrays left over from pandas 3.0's BlockManager, which crash C extensions expecting C-contiguous layout.

Also adds a `gc_disabled()` context manager for potential fine-grained use, though the current approach is to disable GC globally.

## Review & Testing Checklist for Human

- [ ] **Memory leak risk in long-running sessions**: `gc.disable()` is called inside `install()` which runs at import time. This disables GC for the *entire process lifetime* — not just during chart creation. If the Gradio server stays running across multiple experiment runs, cyclic reference memory will never be reclaimed. Verify this is acceptable for your usage pattern, or consider re-enabling GC at safe points between experiments.
- [ ] **Applies to ALL entry points, not just GUI**: The docstring says "GUI sessions are short-lived" to justify disabling GC, but `install()` is called from `__init__.py` at import time, affecting CLI mode, tests, and any other entry point. Confirm this is intentional.
- [ ] **`gc_disabled()` context manager is unused**: The diff defines a `gc_disabled()` context manager but it is never actually used — the global `gc.disable()` makes it redundant. Consider whether a targeted approach (wrapping only plotly/critical sections with `gc_disabled()`) would be safer than blanket disabling.
- [ ] **Test on your actual machine with your 287×150 CSV**: Previous fixes (PRs #123–#132) all passed in Devin's environment but crashed on your machine. Run the full 1170-run experiment *and* trigger the Literature Search flow (which is where this specific crash occurred) to confirm the fix works end-to-end.

### Notes
- Requested by: @minimumtone
- [Link to Devin Session](https://app.devin.ai/sessions/bca8c5188d2c4cd58e2182d85a0e19ad)
- This is the 10th SIGSEGV-related PR in this series (#123–#132). The root cause remains pandas 3.0's F-contiguous array layout interacting with C extensions. This fix addresses a new crash path: GC-triggered finalizers during plotly operations.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
