### PR TITLE
feat: add WF-RF, 10-fold CV defaults, per-algorithm parity plots with generalization performance

### DIFF
--- a/hea_extrapolation_platform/gui/app.py
+++ b/hea_extrapolation_platform/gui/app.py
@@ -64,6 +64,7 @@ from hea_extrapolation_platform.gui.plotly_charts import (
     plotly_heatmap,
     plotly_ood_map,
     plotly_parity,
+    plotly_parity_per_algorithm,
     plotly_target_histogram,
     plotly_uncertainty_ood,
     plotly_validity_ranking,
@@ -449,7 +450,7 @@ def _refresh_results_data(
         filtered = [r for r in filtered if r.split_policy == sp_filter]
 
     r_df = runs_to_dataframe(filtered) if filtered else pd.DataFrame()
-    parity_fig = plotly_parity(filtered) if filtered else None
+    parity_fig = plotly_parity_per_algorithm(filtered) if filtered else None
 
     # Physical interpretation + FS comparison
     interp_md = _build_physical_interpretation_md(runs, scores, ood_results)
@@ -1537,6 +1538,7 @@ def create_app() -> gr.Blocks:
                         "- **WF-LIN** (Ridge回帰): 特徴量の符号検証・リーク検出に有効\n"
                         "- **WF-LASSO** (Lasso回帰): L1正則化によるスパース特徴量選択\n"
                         "- **WF-ARD** (ARD回帰): ベイズ的自動関連度決定\n"
+                        "- **WF-RF** (Random Forest + GridSearchCV): アンサンブル決定木による非線形回帰\n"
                         "- **WF-XGB** (XGBoost + GridSearchCV): 非線形交互作用を捕捉\n"
                         "- **WF-ENS** (Seed-varied Ensemble): 予測不確実性の定量化"
                     )
@@ -1551,6 +1553,10 @@ def create_app() -> gr.Blocks:
                         )
                         wf_ard_check = gr.Checkbox(
                             label="WF-ARD (Bayesian ARD)",
+                            value=True,
+                        )
+                        wf_rf_check = gr.Checkbox(
+                            label="WF-RF (Random Forest + HPO)",
                             value=True,
                         )
                         wf_xgb_check = gr.Checkbox(
@@ -2038,6 +2044,7 @@ def create_app() -> gr.Blocks:
             use_wf_lin: bool,
             use_wf_lasso: bool,
             use_wf_ard: bool,
+            use_wf_rf: bool,
             use_wf_xgb: bool,
             use_wf_ens: bool,
             use_dim_reduction: bool,
@@ -2231,12 +2238,14 @@ def create_app() -> gr.Blocks:
                     selected_wfs.append("WF-LASSO")
                 if use_wf_ard:
                     selected_wfs.append("WF-ARD")
+                if use_wf_rf:
+                    selected_wfs.append("WF-RF")
                 if use_wf_xgb:
                     selected_wfs.append("WF-XGB")
                 if use_wf_ens:
                     selected_wfs.append("WF-ENS")
                 if not selected_wfs:
-                    selected_wfs = ["WF-LIN", "WF-LASSO", "WF-ARD", "WF-XGB", "WF-ENS"]
+                    selected_wfs = ["WF-LIN", "WF-LASSO", "WF-ARD", "WF-RF", "WF-XGB", "WF-ENS"]
                     log("No workflows selected; using all.")
 
                 log(
@@ -2576,7 +2585,7 @@ def create_app() -> gr.Blocks:
                 seeds_input, n_samples, quick_mode,
                 exclude_elements, skip_literature, skip_plots,
                 wf_lin_check, wf_lasso_check, wf_ard_check,
-                wf_xgb_check, wf_ens_check,
+                wf_rf_check, wf_xgb_check, wf_ens_check,
                 dim_reduction_check,
                 run_csv_upload, run_csv_target,
                 state,

--- a/hea_extrapolation_platform/gui/plotly_charts.py
+++ b/hea_extrapolation_platform/gui/plotly_charts.py
@@ -411,6 +411,162 @@ def plotly_parity(
 
 
 # ---------------------------------------------------------------------------
+# 4b. Per-Algorithm Parity Plots with Generalization Performance
+# ---------------------------------------------------------------------------
+
+# Colour palette for workflows (colour-blind safe)
+_WF_COLORS: Dict[str, str] = {
+    "WF-LIN": "#4C72B0",
+    "WF-LASSO": "#55A868",
+    "WF-ARD": "#C44E52",
+    "WF-RF": "#8172B2",
+    "WF-XGB": "#CCB974",
+    "WF-ENS": "#64B5CD",
+}
+
+
+def plotly_parity_per_algorithm(
+    runs: List[Any],
+    title: str = "Per-Algorithm Parity Plot (Test Set) — アルゴリズム別パリティプロット",
+) -> go.Figure:
+    """Interactive parity plot with one trace per ML algorithm.
+
+    Each workflow is shown in a different colour.  An annotation box
+    displays generalization performance (RMSE_test, R²_test) for each
+    algorithm, averaged across all feature sets and seeds.
+
+    Parameters
+    ----------
+    runs : list of RunResult
+    title : str
+
+    Returns
+    -------
+    go.Figure
+    """
+    # Group data by workflow
+    wf_data: Dict[str, Dict[str, List[float]]] = {}
+    seen_keys: set = set()
+
+    for r in runs:
+        if r.y_test_true is None or r.y_test_pred is None:
+            continue
+        test_indices = getattr(r, "test_indices", None)
+        wf = r.workflow
+        if wf not in wf_data:
+            wf_data[wf] = {"true": [], "pred": [], "rmse": [], "r2": []}
+        for i in range(len(r.y_test_true)):
+            if test_indices is not None:
+                key = (r.workflow, r.feature_set, int(test_indices[i]))
+            else:
+                key = (r.workflow, r.feature_set, float(r.y_test_true[i]))
+            if key in seen_keys:
+                continue
+            seen_keys.add(key)
+            wf_data[wf]["true"].append(float(r.y_test_true[i]))
+            wf_data[wf]["pred"].append(float(r.y_test_pred[i]))
+
+    # Compute per-workflow average metrics from RunResult objects
+    wf_metrics: Dict[str, Dict[str, float]] = {}
+    wf_runs_grouped: Dict[str, List[Any]] = {}
+    for r in runs:
+        wf_runs_grouped.setdefault(r.workflow, []).append(r)
+    for wf, wf_run_list in wf_runs_grouped.items():
+        rmses = [float(r.rmse_test) for r in wf_run_list if r.rmse_test > 0]
+        r2s = [float(r.r2_test) for r in wf_run_list]
+        wf_metrics[wf] = {
+            "rmse_test": sum(rmses) / len(rmses) if rmses else 0.0,
+            "r2_test": sum(r2s) / len(r2s) if r2s else 0.0,
+        }
+
+    fig = go.Figure()
+
+    # Global min/max for y=x line
+    all_vals: List[float] = []
+
+    for wf in sorted(wf_data.keys()):
+        d = wf_data[wf]
+        if not d["true"]:
+            continue
+        color = _WF_COLORS.get(wf, "#999999")
+        m = wf_metrics.get(wf, {})
+        rmse_str = f"{m.get('rmse_test', 0):.2f}"
+        r2_str = f"{m.get('r2_test', 0):.4f}"
+        legend_label = f"{wf} (RMSE={rmse_str}, R²={r2_str})"
+
+        fig.add_trace(go.Scatter(
+            x=d["true"],
+            y=d["pred"],
+            mode="markers",
+            marker=dict(color=color, opacity=0.5, size=6,
+                        line=dict(width=0.3, color="black")),
+            name=legend_label,
+            hovertemplate=(
+                f"<b>{wf}</b><br>"
+                "True: %{x:.1f}<br>Pred: %{y:.1f}"
+                "<extra></extra>"
+            ),
+        ))
+        all_vals.extend(d["true"])
+        all_vals.extend(d["pred"])
+
+    # y = x reference line
+    if all_vals:
+        lo = min(all_vals)
+        hi = max(all_vals)
+        margin = (hi - lo) * 0.05
+        fig.add_trace(go.Scatter(
+            x=[lo - margin, hi + margin],
+            y=[lo - margin, hi + margin],
+            mode="lines",
+            line=dict(color="black", dash="dash", width=1),
+            name="y = x",
+            showlegend=True,
+        ))
+
+    # Build performance summary annotation
+    perf_lines: List[str] = []
+    for wf in sorted(wf_metrics.keys()):
+        m = wf_metrics[wf]
+        perf_lines.append(
+            f"{wf}: RMSE={m['rmse_test']:.2f}, R²={m['r2_test']:.4f}"
+        )
+    perf_text = "<br>".join(perf_lines) if perf_lines else "No data"
+
+    fig.update_layout(
+        title=title,
+        xaxis_title="実測値 (True Value)",
+        yaxis_title="予測値 (Predicted Value)",
+        height=700,
+        width=800,
+        legend=dict(
+            orientation="v",
+            yanchor="top",
+            y=0.99,
+            xanchor="left",
+            x=0.01,
+            bgcolor="rgba(255,255,255,0.8)",
+            font=dict(size=11),
+        ),
+        annotations=[
+            dict(
+                text=f"<b>汎化性能 (Generalization)</b><br>{perf_text}",
+                xref="paper", yref="paper",
+                x=0.98, y=0.02,
+                xanchor="right", yanchor="bottom",
+                showarrow=False,
+                font=dict(size=10),
+                bgcolor="rgba(255,255,255,0.85)",
+                bordercolor="#ccc",
+                borderwidth=1,
+                borderpad=6,
+            ),
+        ],
+    )
+    return fig
+
+
+# ---------------------------------------------------------------------------
 # 5. Uncertainty vs OOD Score
 # ---------------------------------------------------------------------------
 

--- a/hea_extrapolation_platform/gui/plotly_charts.py
+++ b/hea_extrapolation_platform/gui/plotly_charts.py
@@ -473,7 +473,8 @@ def plotly_parity_per_algorithm(
         wf_runs_grouped.setdefault(r.workflow, []).append(r)
     for wf, wf_run_list in wf_runs_grouped.items():
         rmses = [float(r.rmse_test) for r in wf_run_list if r.rmse_test > 0]
-        r2s = [float(r.r2_test) for r in wf_run_list]
+        r2s = [float(r.r2_test) for r in wf_run_list
+               if not (r.r2_test != r.r2_test)]  # exclude NaN
         wf_metrics[wf] = {
             "rmse_test": sum(rmses) / len(rmses) if rmses else 0.0,
             "r2_test": sum(r2s) / len(r2s) if r2s else 0.0,

--- a/hea_extrapolation_platform/runner.py
+++ b/hea_extrapolation_platform/runner.py
@@ -68,6 +68,7 @@ from hea_extrapolation_platform.workflows import (
     WorkflowENS,
     WorkflowLASSO,
     WorkflowLIN,
+    WorkflowRF,
     WorkflowXGB,
 )
 from hea_extrapolation_platform.ood import OODDetector, OODResult
@@ -225,13 +226,15 @@ def _run_job(
     y_test  = _pd.Series(y[job.test_idx])
 
     from hea_extrapolation_platform.workflows import (
-        WorkflowARD, WorkflowENS, WorkflowLASSO, WorkflowLIN, WorkflowXGB,
+        WorkflowARD, WorkflowENS, WorkflowLASSO, WorkflowLIN, WorkflowRF,
+        WorkflowXGB,
     )
     _dr = job.dim_reduction
     wf_map: Dict[str, Any] = {
         "WF-LIN": WorkflowLIN(dim_reduction=_dr),
         "WF-LASSO": WorkflowLASSO(dim_reduction=_dr),
         "WF-ARD": WorkflowARD(dim_reduction=_dr),
+        "WF-RF": WorkflowRF(quick=job.quick, dim_reduction=_dr),
         "WF-XGB": WorkflowXGB(quick=job.quick, dim_reduction=_dr),
         "WF-ENS": WorkflowENS(
             n_members=3 if job.quick else 5, quick=job.quick,
@@ -381,7 +384,7 @@ class ExperimentRunner:
 
         self._feature_store.store_features(features_all)
 
-        all_wf_names = ["WF-LIN", "WF-LASSO", "WF-ARD", "WF-XGB", "WF-ENS"]
+        all_wf_names = ["WF-LIN", "WF-LASSO", "WF-ARD", "WF-RF", "WF-XGB", "WF-ENS"]
         mint_configs: Dict[str, MIntWorkflowConfig] = {}
         if self._mint_registry is not None:
             for wf_info in self._mint_registry.list_workflows():

--- a/hea_extrapolation_platform/workflows.py
+++ b/hea_extrapolation_platform/workflows.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 import pandas as pd
 from sklearn.decomposition import PCA
+from sklearn.ensemble import RandomForestRegressor
 from sklearn.linear_model import ARDRegression, Lasso, LassoCV, Ridge
 from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
 from sklearn.model_selection import GridSearchCV
@@ -329,7 +330,7 @@ class WorkflowLASSO(BaseWorkflow):
         steps: List[Tuple[str, Any]] = [
             ("scaler", StandardScaler()),
             *_make_pca_step(X_train.shape[1], self._dim_reduction),
-            ("model", LassoCV(cv=max(2, min(5, len(X_train))), random_state=seed, max_iter=10000)),
+            ("model", LassoCV(cv=max(2, min(10, len(X_train))), random_state=seed, max_iter=10000)),
         ]
         pipe = Pipeline(steps)
         pipe.fit(_safe_np(X_train), _safe_np(y_train))
@@ -510,7 +511,7 @@ class WorkflowXGB(BaseWorkflow):
 
     name = "WF-XGB"
 
-    def __init__(self, n_cv: int = 3, quick: bool = False, dim_reduction: bool = True) -> None:
+    def __init__(self, n_cv: int = 10, quick: bool = False, dim_reduction: bool = True) -> None:
         self._n_cv = n_cv
         self._quick = quick
         self._dim_reduction = dim_reduction
@@ -735,6 +736,119 @@ class WorkflowENS(BaseWorkflow):
 
 
 # ---------------------------------------------------------------------------
+# WF-RF: Random Forest
+# ---------------------------------------------------------------------------
+
+
+class WorkflowRF(BaseWorkflow):
+    """Random Forest workflow with grid-search hyperparameter optimisation.
+
+    Purpose:
+    - Non-linear regression with ensemble of decision trees
+    - Feature importance via impurity-based measures
+    - Robust to overfitting with proper tuning
+    - Captures non-linear interactions without gradient boosting bias
+
+    Uses 10-fold CV by default for hyperparameter tuning.
+    """
+
+    name = "WF-RF"
+
+    def __init__(self, n_cv: int = 10, quick: bool = False, dim_reduction: bool = True) -> None:
+        self._n_cv = n_cv
+        self._quick = quick
+        self._dim_reduction = dim_reduction
+
+    def _param_grid(self) -> Dict[str, List[Any]]:
+        if self._quick:
+            return {
+                "model__n_estimators": [100],
+                "model__max_depth": [None],
+                "model__min_samples_split": [2],
+            }
+        return {
+            "model__n_estimators": [100, 200, 500],
+            "model__max_depth": [None, 10, 20],
+            "model__min_samples_split": [2, 5],
+        }
+
+    def run(
+        self,
+        X_train: pd.DataFrame,
+        y_train: pd.Series,
+        X_test: pd.DataFrame,
+        y_test: pd.Series,
+        seed: int = 42,
+        **kwargs: Any,
+    ) -> RunResult:
+        t0 = time.time()
+        logger.debug("WF-RF: train=%d, test=%d, features=%d",
+                      len(X_train), len(X_test), X_train.shape[1])
+
+        steps: List[Tuple[str, Any]] = [
+            ("scaler", StandardScaler()),
+            *_make_pca_step(X_train.shape[1], self._dim_reduction),
+            ("model", RandomForestRegressor(
+                random_state=seed, n_jobs=1,
+            )),
+        ]
+        pipe = Pipeline(steps)
+
+        grid = GridSearchCV(
+            pipe,
+            self._param_grid(),
+            cv=max(2, min(self._n_cv, len(X_train))),
+            scoring="neg_root_mean_squared_error",
+            refit=True,
+            n_jobs=1,
+            error_score=np.nan,
+        )
+        grid.fit(_safe_np(X_train), _safe_np(y_train))
+
+        best_pipe = grid.best_estimator_
+        y_train_pred = best_pipe.predict(_safe_np(X_train))
+        y_test_pred = best_pipe.predict(_safe_np(X_test))
+
+        train_s = _score(_safe_np(y_train), y_train_pred)
+        test_s = _score(_safe_np(y_test), y_test_pred)
+
+        # Feature importance from tree model
+        model_step = best_pipe.named_steps["model"]
+        if hasattr(model_step, "feature_importances_"):
+            fi_raw = model_step.feature_importances_.tolist()
+            if "pca" not in best_pipe.named_steps:
+                fi = dict(zip(X_train.columns, fi_raw))
+            else:
+                fi = {f"PC{i}": float(v) for i, v in enumerate(fi_raw)}
+        else:
+            fi = {}
+
+        result = RunResult(
+            workflow=self.name,
+            feature_set=kwargs.get("feature_set", ""),
+            split_policy=kwargs.get("split_policy", ""),
+            seed=seed,
+            fold=kwargs.get("fold", 0),
+            rmse_train=train_s["rmse"],
+            rmse_test=test_s["rmse"],
+            mae_train=train_s["mae"],
+            mae_test=test_s["mae"],
+            r2_train=train_s["r2"],
+            r2_test=test_s["r2"],
+            y_test_true=_safe_np(y_test).copy(),
+            y_test_pred=y_test_pred.copy(),
+            test_indices=kwargs.get("test_indices"),
+            params=grid.best_params_,
+            artifacts={
+                "feature_importance": fi,
+                "cv_results_best_score": float(grid.best_score_),
+            },
+            elapsed_sec=time.time() - t0,
+        )
+        return result
+
+
+# ---------------------------------------------------------------------------
 # Workflow registry
 # ---------------------------------------------------------------------------
 
@@ -743,6 +857,7 @@ WORKFLOW_REGISTRY: Dict[str, type] = {
     "WF-LASSO": WorkflowLASSO,
     "WF-ARD": WorkflowARD,
     "WF-XGB": WorkflowXGB,
+    "WF-RF": WorkflowRF,
     "WF-ENS": WorkflowENS,
 }
 


### PR DESCRIPTION
# feat: add WF-RF, 10-fold CV defaults, per-algorithm parity plots

## Summary

Adds a Random Forest regression workflow (WF-RF), makes 10-fold cross-validation the default for all hyperparameter tuning, and replaces the single-colour parity plot with a per-algorithm colour-coded version that displays generalization performance metrics.

**workflows.py:**
- New `WorkflowRF` class: `StandardScaler → optional PCA → RandomForestRegressor` with `GridSearchCV` (18 combos in full mode, 1 in quick mode), 10-fold CV default, feature importance extraction
- `WorkflowXGB`: default `n_cv` changed from **3 → 10**
- `WorkflowLASSO`: `LassoCV` cv cap changed from **5 → 10**

**plotly_charts.py:**
- New `plotly_parity_per_algorithm()` function: one colour-coded scatter trace per workflow, with an annotation box showing averaged RMSE and R² per algorithm (generalization performance)
- All data converted to Python `float` lists before reaching plotly (SIGSEGV safe — no numpy arrays)

**runner.py:**
- `WorkflowRF` imported, instantiated in `_run_job()`, added to `all_wf_names`

**app.py:**
- WF-RF checkbox added to ML Algorithm Selection (default: ON)
- `run_experiment` wired with new `use_wf_rf` parameter
- Results tab now calls `plotly_parity_per_algorithm` instead of `plotly_parity`

## Updates since last revision

- **NaN R² fix** (b3ead91): The R² average in `plotly_parity_per_algorithm` now excludes NaN values (from single-sample test folds where `r2_score` returns NaN). Previously, a single degenerate fold would poison the entire workflow's displayed R² via `sum()`. The RMSE filter already implicitly excluded NaN; R² now has an explicit `not (x != x)` guard matching that behavior.

## Review & Testing Checklist for Human

- [ ] **Positional argument ordering**: Verify `run_experiment` function signature parameter order matches `run_btn.click(inputs=[...])` list exactly — Gradio maps positionally, a mismatch silently swaps boolean flags. Specifically confirm `use_wf_rf` is in the same position as `wf_rf_check` (both should be between ARD and XGB).
- [ ] **End-to-end test with real CSV (287×150)**: This has **NOT been tested yet**. Run all 6 workflows (WF-LIN, WF-LASSO, WF-ARD, WF-RF, WF-XGB, WF-ENS) and confirm WF-RF completes without errors, parity plot renders with 6 colour-coded traces + annotation box showing per-algorithm RMSE and R².
- [ ] **Performance/timeout check**: 10-fold CV is now default for all workflows. RF full mode = 18 combos × 10 folds = 180 fits per job. Confirm total experiment time is acceptable (expect ~2× increase from previous 3-fold/5-fold defaults).
- [ ] **Feature importance shape when PCA is ON**: `WorkflowRF` extracts `feature_importances_` from the RF estimator; when PCA is active, importance maps to PCs not original features. Verify the `"pca" not in best_pipe.named_steps` branch works correctly.
- [ ] **SIGSEGV**: Confirm no segfault on your environment (pandas 3.0 + plotly). The new `plotly_parity_per_algorithm` uses only Python lists, but verify `update_layout` with `annotations` doesn't trigger deepcopy issues.

### Notes
- **Model selection is already automatic by default** (all checkboxes default to `value=True`), so no additional changes needed for that requirement
- Minor code smell: `wf_data[wf]` dict initializes unused `"rmse"` and `"r2"` keys (line 459) that are never populated — harmless but could be cleaned up
- Devin Review bot identified the NaN R² bug (fixed in b3ead91)
- Session: https://app.devin.ai/sessions/bca8c5188d2c4cd58e2182d85a0e19ad
- Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
