### PR TITLE
feat: 5 pipeline improvements (#3 early stop, #5 JSON serialize, #7 leak detect, #9 bootstrap CI, #11 n_jobs)

### DIFF
--- a/hea_extrapolation_platform/_compat.py
+++ b/hea_extrapolation_platform/_compat.py
@@ -120,6 +120,8 @@ def as_serializable(obj: object) -> object:
         converted = [as_serializable(item) for item in obj]
         return type(obj)(converted) if isinstance(obj, tuple) else converted
     if isinstance(obj, np.ndarray):
+        if obj.ndim == 0:
+            return as_serializable(obj.item())
         return [as_serializable(item) for item in obj.tolist()]
     if isinstance(obj, (np.integer,)):
         return int(obj)

--- a/hea_extrapolation_platform/_compat.py
+++ b/hea_extrapolation_platform/_compat.py
@@ -90,6 +90,60 @@ def safe_float(x: object) -> float:
     return float(x)
 
 
+def as_serializable(obj: object) -> object:
+    """Recursively convert numpy / pandas types to JSON-safe Python builtins.
+
+    Problem (#5): ``json.dump`` raises ``TypeError`` on ``numpy.float32``,
+    ``numpy.int64``, ``numpy.ndarray``, ``numpy.bool_``, etc.
+
+    This function walks a nested dict / list structure and converts:
+      - numpy integer types  → ``int``
+      - numpy float types    → ``float``
+      - numpy bool\_         → ``bool``
+      - numpy ndarray        → ``list`` (recursive)
+      - numpy generic        → appropriate Python scalar
+      - pandas Series        → ``list``
+      - pandas DataFrame     → ``list`` of dicts (``records`` orient)
+      - ``NaN`` / ``Inf``    → ``None`` (JSON has no NaN literal)
+
+    Usage::
+
+        import json
+        report = {"rmse": np.float64(0.42), "fi": np.array([1, 2, 3])}
+        json.dump(as_serializable(report), f)
+    """
+    import math
+
+    if isinstance(obj, dict):
+        return {as_serializable(k): as_serializable(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        converted = [as_serializable(item) for item in obj]
+        return type(obj)(converted) if isinstance(obj, tuple) else converted
+    if isinstance(obj, np.ndarray):
+        return [as_serializable(item) for item in obj.tolist()]
+    if isinstance(obj, (np.integer,)):
+        return int(obj)
+    if isinstance(obj, (np.floating,)):
+        val = float(obj)
+        if math.isnan(val) or math.isinf(val):
+            return None
+        return val
+    if isinstance(obj, np.bool_):
+        return bool(obj)
+    if isinstance(obj, np.generic):
+        return obj.item()
+    if isinstance(obj, float):
+        if math.isnan(obj) or math.isinf(obj):
+            return None
+        return obj
+    # pandas types
+    if isinstance(obj, pd.Series):
+        return [as_serializable(item) for item in obj.tolist()]
+    if isinstance(obj, pd.DataFrame):
+        return [as_serializable(row) for row in obj.to_dict(orient="records")]
+    return obj
+
+
 def _ensure_c_contiguous(arr: np.ndarray) -> np.ndarray:
     """Return *arr* as C-contiguous if it isn't already."""
     if arr.ndim == 0:

--- a/hea_extrapolation_platform/evaluation.py
+++ b/hea_extrapolation_platform/evaluation.py
@@ -22,6 +22,7 @@ import pandas as pd
 
 from hea_extrapolation_platform.features import FeatureSetName
 from hea_extrapolation_platform.workflows import RunResult
+from hea_extrapolation_platform._compat import as_serializable
 
 if TYPE_CHECKING:
     from hea_extrapolation_platform.multicollinearity import MulticollinearityReport
@@ -40,6 +41,14 @@ class ValidityScore:
     leak_penalty: float = 0.0
     extrapolation_safety: float = 0.0
     multicollinearity_penalty: float = 0.0
+
+    # Bootstrap 95% CI for RMSE_test (#9)
+    rmse_ci_lower: float = 0.0
+    rmse_ci_upper: float = 0.0
+    rmse_mean: float = 0.0
+
+    # Leak suspects from Phase 0 (#7)
+    leak_suspects: Dict[str, float] = field(default_factory=dict)
 
     @property
     def total(self) -> float:
@@ -63,7 +72,7 @@ class ValidityScore:
         )
 
     def to_dict(self) -> Dict[str, float]:
-        return {
+        d: Dict[str, Any] = {
             "feature_set": self.feature_set,
             "effect_size": round(self.effect_size, 4),
             "stability": round(self.stability, 4),
@@ -72,7 +81,13 @@ class ValidityScore:
             "extrapolation_safety": round(self.extrapolation_safety, 4),
             "multicollinearity_penalty": round(self.multicollinearity_penalty, 4),
             "total": round(self.total, 4),
+            "rmse_mean": round(self.rmse_mean, 4),
+            "rmse_ci_lower": round(self.rmse_ci_lower, 4),
+            "rmse_ci_upper": round(self.rmse_ci_upper, 4),
         }
+        if self.leak_suspects:
+            d["leak_suspects"] = self.leak_suspects
+        return d
 
 
 class FeatureValidityEvaluator:
@@ -156,8 +171,16 @@ class FeatureValidityEvaluator:
             block_runs = [r for r in fs_run_list if r.split_policy == "CompositionBlock"]
             vs.generalisation = self._generalisation_score(random_runs, block_runs, base_rmse)
 
-            # 4. Leak suspicion
-            vs.leak_penalty = self._leak_penalty(random_runs, block_runs, base_rmse)
+            # 4. Leak suspicion (combine behavioural + correlation-based)
+            behavioural_penalty = self._leak_penalty(random_runs, block_runs, base_rmse)
+            corr_penalty = 0.0
+            if mc_reports and fs_name in mc_reports and mc_reports[fs_name].leak_suspects:
+                # Scale: 1 suspect at 0.85 → 0.3, 3+ suspects → capped at 1.0
+                n_suspects = len(mc_reports[fs_name].leak_suspects)
+                max_corr = max(mc_reports[fs_name].leak_suspects.values())
+                corr_penalty = min(1.0, n_suspects * 0.3 * max_corr)
+                vs.leak_suspects = mc_reports[fs_name].leak_suspects
+            vs.leak_penalty = min(1.0, max(behavioural_penalty, corr_penalty))
 
             # 5. Extrapolation safety
             if ood_errors and fs_name in ood_errors:
@@ -174,6 +197,11 @@ class FeatureValidityEvaluator:
             else:
                 vs.multicollinearity_penalty = 0.0  # no info = neutral
 
+            # 7. Bootstrap 95% CI for RMSE_test (#9)
+            vs.rmse_mean, vs.rmse_ci_lower, vs.rmse_ci_upper = (
+                self._bootstrap_ci(rmses)
+            )
+
             scores.append(vs)
 
         scores.sort(key=lambda s: s.total, reverse=True)
@@ -187,6 +215,47 @@ class FeatureValidityEvaluator:
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _bootstrap_ci(
+        values: List[float],
+        n_bootstrap: int = 1000,
+        confidence: float = 0.95,
+        seed: int = 42,
+    ) -> Tuple[float, float, float]:
+        """Compute Bootstrap confidence interval for the mean (#9).
+
+        Parameters
+        ----------
+        values : list of float
+            Sample values (e.g. RMSE_test across CV folds/seeds).
+        n_bootstrap : int
+            Number of bootstrap resamples.
+        confidence : float
+            Confidence level (default 0.95 → 95% CI).
+        seed : int
+            Random seed for reproducibility.
+
+        Returns
+        -------
+        (mean, ci_lower, ci_upper)
+        """
+        if len(values) < 2:
+            m = values[0] if values else 0.0
+            return m, m, m
+
+        arr = np.array(values, dtype=float)
+        rng = np.random.RandomState(seed)
+        boot_means = np.empty(n_bootstrap, dtype=float)
+        n = len(arr)
+        for i in range(n_bootstrap):
+            sample = arr[rng.randint(0, n, size=n)]
+            boot_means[i] = sample.mean()
+
+        alpha = 1.0 - confidence
+        ci_lower = float(np.percentile(boot_means, 100 * alpha / 2))
+        ci_upper = float(np.percentile(boot_means, 100 * (1 - alpha / 2)))
+        return float(arr.mean()), ci_lower, ci_upper
 
     @staticmethod
     def _mean_test_rmse(runs: List[RunResult]) -> float:

--- a/hea_extrapolation_platform/gui/app.py
+++ b/hea_extrapolation_platform/gui/app.py
@@ -271,10 +271,10 @@ def _build_physical_interpretation_md(
     best_fs = scores[0].feature_set if scores else ""
 
     lines.append(
-        "| FS | 特徴量数 | RMSE(Test) Mean | R$^2$(Test) Mean "
-        "| Validity Total | 推奨 |"
+        "| FS | 特徴量数 | RMSE (95% CI) | R$^2$(Test) Mean "
+        "| Validity Total | Leak | 推奨 |"
     )
-    lines.append("|---|---|---|---|---|---|")
+    lines.append("|---|---|---|---|---|---|---|")
 
     _fs_sizes = {
         "FS_BASE": 8, "FS_THERMO": 11, "FS_SIZE": 12,
@@ -286,14 +286,28 @@ def _build_physical_interpretation_md(
         rmses = [r.rmse_test for r in fs_runs if r.rmse_test > 0]
         r2s = [r.r2_test for r in fs_runs]
         n_feat = _fs_sizes.get(fs_name, "?")
-        rmse_mean = f"{sum(rmses)/len(rmses):.2f}" if rmses else "N/A"
         r2_mean = f"{sum(r2s)/len(r2s):.4f}" if r2s else "N/A"
         vs = score_map.get(fs_name)
         total = f"{vs.total:.4f}" if vs else "N/A"
         recommend = "**Best**" if fs_name == best_fs else ""
+        # Bootstrap CI (#9)
+        if vs and getattr(vs, "rmse_mean", 0) > 0:
+            ci_lo = getattr(vs, "rmse_ci_lower", 0)
+            ci_hi = getattr(vs, "rmse_ci_upper", 0)
+            if ci_lo != ci_hi:
+                rmse_str = f"{vs.rmse_mean:.2f} [{ci_lo:.2f}, {ci_hi:.2f}]"
+            else:
+                rmse_str = f"{vs.rmse_mean:.2f}"
+        elif rmses:
+            rmse_str = f"{sum(rmses)/len(rmses):.2f}"
+        else:
+            rmse_str = "N/A"
+        # Leak suspects (#7)
+        n_leaks = len(getattr(vs, "leak_suspects", {})) if vs else 0
+        leak_str = f"⚠{n_leaks}" if n_leaks > 0 else "-"
         lines.append(
-            f"| {fs_name} | {n_feat} | {rmse_mean} "
-            f"| {r2_mean} | {total} | {recommend} |"
+            f"| {fs_name} | {n_feat} | {rmse_str} "
+            f"| {r2_mean} | {total} | {leak_str} | {recommend} |"
         )
 
     lines.append("")

--- a/hea_extrapolation_platform/gui/plotly_charts.py
+++ b/hea_extrapolation_platform/gui/plotly_charts.py
@@ -689,10 +689,13 @@ def runs_to_dataframe(runs: List[Any]) -> pd.DataFrame:
 
 
 def validity_scores_to_dataframe(scores: List[Any]) -> pd.DataFrame:
-    """Convert list of ValidityScore to a summary DataFrame."""
+    """Convert list of ValidityScore to a summary DataFrame.
+
+    Includes Bootstrap 95% CI for RMSE (#9) and leak suspect count (#7).
+    """
     records = []
     for i, s in enumerate(scores):
-        records.append({
+        rec: Dict[str, Any] = {
             "Rank": i + 1,
             "Feature Set": s.feature_set,
             "Effect Size": round(s.effect_size, 4),
@@ -701,7 +704,21 @@ def validity_scores_to_dataframe(scores: List[Any]) -> pd.DataFrame:
             "Leak Penalty": round(s.leak_penalty, 4),
             "Extrap. Safety": round(s.extrapolation_safety, 4),
             "Total": round(s.total, 4),
-        })
+        }
+        # Bootstrap CI (#9)
+        rmse_mean = getattr(s, "rmse_mean", 0.0)
+        ci_lo = getattr(s, "rmse_ci_lower", 0.0)
+        ci_hi = getattr(s, "rmse_ci_upper", 0.0)
+        if rmse_mean > 0 and ci_lo != ci_hi:
+            rec["RMSE 95%CI"] = f"{rmse_mean:.3f} [{ci_lo:.3f}, {ci_hi:.3f}]"
+        elif rmse_mean > 0:
+            rec["RMSE 95%CI"] = f"{rmse_mean:.3f}"
+        else:
+            rec["RMSE 95%CI"] = "N/A"
+        # Leak suspects (#7)
+        suspects = getattr(s, "leak_suspects", {})
+        rec["Leak Suspects"] = len(suspects) if suspects else 0
+        records.append(rec)
     return _records_to_df(records)
 
 

--- a/hea_extrapolation_platform/multicollinearity.py
+++ b/hea_extrapolation_platform/multicollinearity.py
@@ -34,6 +34,7 @@ VIF_HIGH_THRESHOLD = 10.0       # VIF > this → 'high multicollinearity'
 VIF_MODERATE_THRESHOLD = 5.0    # VIF > this → 'moderate'
 HIGH_VIF_RATIO_CUTOFF = 0.30    # high VIF feature ratio above this → block linear models
 MAGPIE_DIM_THRESHOLD = 100      # n_features >= this → 'high-dimensional'
+LEAK_CORR_THRESHOLD = 0.85      # |corr(feature, target)| > this → suspected leak (#7)
 
 # Priority columns to KEEP when breaking collinear ties
 # (physically interpretable HEA descriptors preferred over derived statistics)
@@ -165,6 +166,56 @@ def remove_constant_columns(
 # 3.1.4  MulticollinearityReport — diagnostic report dataclass
 # ---------------------------------------------------------------------------
 
+def detect_target_leakage(
+    X: pd.DataFrame,
+    y: pd.Series,
+    threshold: float = LEAK_CORR_THRESHOLD,
+) -> Dict[str, float]:
+    """Detect features with suspiciously high correlation to the target (#7).
+
+    Returns a dict of ``{feature_name: abs_correlation}`` for features
+    where ``|corr(feature, target)| > threshold``.
+
+    These features are likely leaky — they encode the target directly
+    (e.g. GSvolume_pa ≈ lattice parameter ≈ proxy for energy).
+
+    Parameters
+    ----------
+    X : DataFrame
+        Feature matrix (already cleaned of constant / collinear columns).
+    y : Series
+        Target vector.
+    threshold : float
+        Absolute Pearson correlation cutoff (default 0.85).
+
+    Returns
+    -------
+    dict of {feature_name: abs_correlation}, sorted descending.
+    """
+    suspects: Dict[str, float] = {}
+    y_arr = np.ascontiguousarray(np.asarray(y, dtype='float64'))
+    y_std = float(np.std(y_arr))
+    if y_std < 1e-10:
+        return suspects  # constant target — no leakage possible
+
+    for col in X.columns:
+        x_arr = np.ascontiguousarray(X[col].to_numpy(dtype='float64'))
+        if np.std(x_arr) < 1e-10:
+            continue
+        # Pearson correlation via numpy (avoids pandas overhead)
+        corr = float(np.corrcoef(x_arr, y_arr)[0, 1])
+        abs_corr = abs(corr)
+        if abs_corr > threshold:
+            suspects[col] = round(abs_corr, 4)
+            logger.warning(
+                'Leak suspect: %s has |corr(feature, target)| = %.4f (> %.2f)',
+                col, abs_corr, threshold,
+            )
+
+    # Sort descending by correlation
+    return dict(sorted(suspects.items(), key=lambda kv: -kv[1]))
+
+
 @dataclass
 class MulticollinearityReport:
     """Diagnostic result for one feature set."""
@@ -180,6 +231,11 @@ class MulticollinearityReport:
     multicollinearity_level: str   # 'low' | 'moderate' | 'high'
     recommended_workflows: List[str]
     blocked_workflows: List[str]
+    leak_suspects: Dict[str, float] = None  # type: ignore[assignment]  # {feat: |corr|}
+
+    def __post_init__(self) -> None:
+        if self.leak_suspects is None:
+            self.leak_suspects = {}
 
     @property
     def high_vif_ratio(self) -> float:
@@ -199,6 +255,7 @@ class MulticollinearityReport:
             'high_vif_ratio': round(self.high_vif_ratio, 4),
             'recommended_workflows': self.recommended_workflows,
             'blocked_workflows': self.blocked_workflows,
+            'leak_suspects': self.leak_suspects,
         }
 
 
@@ -269,10 +326,17 @@ def run_phase0_multicollinearity(
     feature_sets: List[FeatureSetName],
     all_workflows: List[str],
     n_samples: int,
+    target: Optional[pd.Series] = None,
 ) -> Dict[str, MulticollinearityReport]:
     """Run full multicollinearity pipeline for every feature set.
 
     Called by runner.py before Phase 1. Returns {fs_name: MulticollinearityReport}.
+
+    Parameters
+    ----------
+    target : Series, optional
+        When provided, runs leak detection (#7) — flags features with
+        ``|corr(feature, target)| > 0.85``.
     """
     reports: Dict[str, MulticollinearityReport] = {}
 
@@ -318,6 +382,17 @@ def run_phase0_multicollinearity(
         else:
             level = 'low'
 
+        # Step C2: Leak detection (#7) — flag features highly correlated with target
+        leak_suspects: Dict[str, float] = {}
+        if target is not None and X_fs.shape[1] > 0:
+            leak_suspects = detect_target_leakage(X_fs, target)
+            if leak_suspects:
+                logger.warning(
+                    'Phase 0 [%s]: %d leak suspect(s): %s',
+                    fs_key, len(leak_suspects),
+                    ', '.join(f'{k}={v:.4f}' for k, v in leak_suspects.items()),
+                )
+
         # Step D: Model selection
         report = MulticollinearityReport(
             feature_set=fs_key,
@@ -331,6 +406,7 @@ def run_phase0_multicollinearity(
             multicollinearity_level=level,
             recommended_workflows=[],
             blocked_workflows=[],
+            leak_suspects=leak_suspects,
         )
         allowed, blocked, reason = select_workflows_for_feature_set(
             report, all_workflows, n_samples
@@ -341,10 +417,10 @@ def run_phase0_multicollinearity(
 
         logger.info(
             'Phase 0 [%s]: %dD→%dD (dropped const=%d perfect=%d) '
-            'VIF_high=%d VIF_mod=%d level=%s | %s',
+            'VIF_high=%d VIF_mod=%d level=%s leak=%d | %s',
             fs_key, n_before, len(vif),
             len(dropped_const), len(dropped_perfect),
-            high_count, mod_count, level, reason,
+            high_count, mod_count, level, len(leak_suspects), reason,
         )
 
     return reports

--- a/hea_extrapolation_platform/report.py
+++ b/hea_extrapolation_platform/report.py
@@ -119,16 +119,40 @@ class ReportGenerator:
         # ---- 2. Feature Validity Ranking ----
         lines.append("## 2. Feature Set Validity Ranking")
         lines.append("")
-        lines.append("| Rank | Feature Set | Effect Size | Stability | Generalisation | Leak Penalty | Extrap. Safety | **Total** |")
-        lines.append("|------|-------------|-------------|-----------|----------------|--------------|----------------|-----------|")
+        lines.append("| Rank | Feature Set | Effect Size | Stability | Generalisation | Leak Penalty | Extrap. Safety | RMSE (95% CI) | **Total** |")
+        lines.append("|------|-------------|-------------|-----------|----------------|--------------|----------------|---------------|-----------|")
         for i, s in enumerate(validity_scores):
+            # Format Bootstrap CI if available (#9)
+            if s.rmse_mean > 0 and s.rmse_ci_lower != s.rmse_ci_upper:
+                ci_str = f"{s.rmse_mean:.3f} [{s.rmse_ci_lower:.3f}, {s.rmse_ci_upper:.3f}]"
+            elif s.rmse_mean > 0:
+                ci_str = f"{s.rmse_mean:.3f}"
+            else:
+                ci_str = "N/A"
             lines.append(
                 f"| {i+1} | {s.feature_set} | {s.effect_size:.4f} | "
                 f"{s.stability:.4f} | {s.generalisation:.4f} | "
                 f"{s.leak_penalty:.4f} | {s.extrapolation_safety:.4f} | "
+                f"{ci_str} | "
                 f"**{s.total:.4f}** |"
             )
         lines.append("")
+
+        # ---- 2b. Leak Suspect Features (#7) ----
+        any_leaks = any(s.leak_suspects for s in validity_scores)
+        if any_leaks:
+            lines.append("### Leak Suspect Features")
+            lines.append("")
+            lines.append(
+                "Features with |corr(feature, target)| > 0.85 detected in Phase 0:"
+            )
+            lines.append("")
+            lines.append("| Feature Set | Feature | |Correlation| |")
+            lines.append("|-------------|---------|---------------|")
+            for s in validity_scores:
+                for feat, corr_val in s.leak_suspects.items():
+                    lines.append(f"| {s.feature_set} | {feat} | {corr_val:.4f} |")
+            lines.append("")
 
         # ---- 3. Performance Comparison ----
         lines.append("## 3. Split-wise Performance Comparison")

--- a/hea_extrapolation_platform/runner.py
+++ b/hea_extrapolation_platform/runner.py
@@ -90,6 +90,7 @@ from hea_extrapolation_platform.multicollinearity import (
     MulticollinearityReport,
     run_phase0_multicollinearity,
 )
+from hea_extrapolation_platform._compat import as_serializable
 
 logger = logging.getLogger(__name__)
 
@@ -170,9 +171,17 @@ class RunRegistry:
         return pd.DataFrame(columns)
 
     def export_json(self, path: Path) -> None:
+        """Export runs to JSON with numpy-safe serialization.
+
+        Uses ``as_serializable`` to convert numpy types (float32, int64,
+        ndarray, bool\_) to JSON-safe Python builtins before writing.
+        This prevents ``TypeError`` on ``json.dump`` (#5).
+        """
         df = self.to_dataframe()
         path.parent.mkdir(parents=True, exist_ok=True)
-        df.to_json(path, orient="records", indent=2, force_ascii=False)
+        records = as_serializable(df.to_dict(orient="records"))
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(records, f, indent=2, ensure_ascii=False)
         logger.info("Exported %d runs to %s", len(self._runs), path)
 
 
@@ -428,9 +437,10 @@ class ExperimentRunner:
         )
 
         try:
-            # ── Phase 0: Multicollinearity diagnostics & model selection ──
+            # ── Phase 0: Multicollinearity diagnostics & leak detection ──
             mc_reports = run_phase0_multicollinearity(
                 features_all, feature_sets, wf_names, len(features_all),
+                target=target,
             )
             self._mc_reports = mc_reports
             if progress_callback is not None:

--- a/hea_extrapolation_platform/workflows.py
+++ b/hea_extrapolation_platform/workflows.py
@@ -29,6 +29,23 @@ from sklearn.preprocessing import StandardScaler
 logger = logging.getLogger(__name__)
 
 
+def _get_inner_n_jobs() -> int:
+    """Return the n_jobs for inner estimators (GridSearchCV, RandomForest, etc.).
+
+    Problem (#11): When ``RandomizedSearchCV(n_jobs=-1)`` runs inside a
+    ``ProcessPoolExecutor`` worker, both compete for CPU cores.  The inner
+    parallelism should be limited to 1 per worker to avoid resource contention.
+
+    Respects ``HEA_INNER_N_JOBS`` environment variable.  Defaults to 1.
+    """
+    import os
+    raw = os.environ.get("HEA_INNER_N_JOBS", "1")
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return 1
+
+
 def _safe_np(source: Any) -> np.ndarray:
     """Return a C-contiguous float64 array from DataFrame / Series / ndarray.
 
@@ -521,7 +538,7 @@ class WorkflowXGB(BaseWorkflow):
             return XGBRegressor(
                 objective="reg:squarederror",
                 random_state=seed,
-                n_jobs=1,
+                n_jobs=_get_inner_n_jobs(),
                 verbosity=0,
             )
         else:
@@ -562,18 +579,64 @@ class WorkflowXGB(BaseWorkflow):
         ]
         pipe = Pipeline(steps)
 
+        _inner_jobs = _get_inner_n_jobs()
         grid = GridSearchCV(
             pipe,
             self._param_grid(),
             cv=max(2, min(self._n_cv, len(X_train))),
             scoring="neg_root_mean_squared_error",
             refit=True,
-            n_jobs=1,
+            n_jobs=_inner_jobs,
             error_score=np.nan,  # skip failing folds instead of raising
         )
         grid.fit(_safe_np(X_train), _safe_np(y_train))
 
+        # ── Early stopping refinement (#3) ──
+        # After GridSearchCV finds the best hyperparameters, retrain the
+        # best model with early_stopping to find the optimal n_estimators.
+        # This reduces overfitting and training cost.
         best_pipe = grid.best_estimator_
+        best_model = best_pipe.named_steps["model"]
+        used_early_stop = False
+
+        if (
+            _XGB_AVAILABLE
+            and isinstance(best_model, XGBRegressor)
+            and not self._quick
+            and len(X_train) >= 20
+        ):
+            try:
+                # Apply the scaler (and optionally PCA) from the best pipeline
+                # to transform train and test data for early stopping
+                preprocessor = Pipeline(
+                    [(name, step) for name, step in best_pipe.steps if name != "model"]
+                )
+                X_tr_transformed = preprocessor.transform(_safe_np(X_train))
+                X_te_transformed = preprocessor.transform(_safe_np(X_test))
+
+                # Clone the best model's params but allow more estimators
+                es_params = best_model.get_params()
+                es_params["n_estimators"] = max(es_params.get("n_estimators", 200), 500)
+                es_model = XGBRegressor(**es_params)
+                es_model.fit(
+                    np.ascontiguousarray(X_tr_transformed),
+                    _safe_np(y_train),
+                    eval_set=[(np.ascontiguousarray(X_te_transformed), _safe_np(y_test))],
+                    verbose=False,
+                )
+                # Check if early stopping actually triggered (best_iteration set)
+                if hasattr(es_model, "best_iteration") and es_model.best_iteration > 0:
+                    # Replace the model step in the pipeline
+                    best_pipe.steps[-1] = ("model", es_model)
+                    used_early_stop = True
+                    logger.debug(
+                        "WF-XGB early stop: best_iteration=%d (was n_estimators=%d)",
+                        es_model.best_iteration,
+                        es_params.get("n_estimators", 200),
+                    )
+            except Exception:
+                logger.debug("WF-XGB early stopping failed, using GridSearchCV result")
+
         y_train_pred = best_pipe.predict(_safe_np(X_train))
         y_test_pred = best_pipe.predict(_safe_np(X_test))
 
@@ -610,6 +673,7 @@ class WorkflowXGB(BaseWorkflow):
             artifacts={
                 "feature_importance": fi,
                 "cv_results_best_score": float(grid.best_score_),
+                "early_stopping_used": used_early_stop,
             },
             elapsed_sec=time.time() - t0,
         )
@@ -653,7 +717,7 @@ class WorkflowENS(BaseWorkflow):
                 max_depth=4,
                 learning_rate=0.1,
                 random_state=seed,
-                n_jobs=1,
+                n_jobs=_get_inner_n_jobs(),
                 verbosity=0,
             )
         elif self._base_workflow == "xgb":
@@ -785,11 +849,12 @@ class WorkflowRF(BaseWorkflow):
         logger.debug("WF-RF: train=%d, test=%d, features=%d",
                       len(X_train), len(X_test), X_train.shape[1])
 
+        _inner_jobs = _get_inner_n_jobs()
         steps: List[Tuple[str, Any]] = [
             ("scaler", StandardScaler()),
             *_make_pca_step(X_train.shape[1], self._dim_reduction),
             ("model", RandomForestRegressor(
-                random_state=seed, n_jobs=1,
+                random_state=seed, n_jobs=_inner_jobs,
             )),
         ]
         pipe = Pipeline(steps)
@@ -800,7 +865,7 @@ class WorkflowRF(BaseWorkflow):
             cv=max(2, min(self._n_cv, len(X_train))),
             scoring="neg_root_mean_squared_error",
             refit=True,
-            n_jobs=1,
+            n_jobs=_inner_jobs,
             error_score=np.nan,
         )
         grid.fit(_safe_np(X_train), _safe_np(y_train))

--- a/hea_extrapolation_platform/workflows.py
+++ b/hea_extrapolation_platform/workflows.py
@@ -606,28 +606,44 @@ class WorkflowXGB(BaseWorkflow):
             and len(X_train) >= 20
         ):
             try:
+                from sklearn.model_selection import train_test_split as _tts
+
                 # Apply the scaler (and optionally PCA) from the best pipeline
-                # to transform train and test data for early stopping
                 preprocessor = Pipeline(
                     [(name, step) for name, step in best_pipe.steps if name != "model"]
                 )
                 X_tr_transformed = preprocessor.transform(_safe_np(X_train))
-                X_te_transformed = preprocessor.transform(_safe_np(X_test))
+
+                # Split *training* data into train/validation for early stopping
+                # to avoid leaking the held-out test set into model selection.
+                X_tr_es, X_val_es, y_tr_es, y_val_es = _tts(
+                    X_tr_transformed, _safe_np(y_train),
+                    test_size=0.2, random_state=seed,
+                )
 
                 # Clone the best model's params but allow more estimators
                 es_params = best_model.get_params()
                 es_params["n_estimators"] = max(es_params.get("n_estimators", 200), 500)
+                es_params["early_stopping_rounds"] = 20
                 es_model = XGBRegressor(**es_params)
                 es_model.fit(
-                    np.ascontiguousarray(X_tr_transformed),
-                    _safe_np(y_train),
-                    eval_set=[(np.ascontiguousarray(X_te_transformed), _safe_np(y_test))],
+                    np.ascontiguousarray(X_tr_es),
+                    y_tr_es,
+                    eval_set=[(np.ascontiguousarray(X_val_es), y_val_es)],
                     verbose=False,
                 )
-                # Check if early stopping actually triggered (best_iteration set)
+                # Check if early stopping actually triggered
                 if hasattr(es_model, "best_iteration") and es_model.best_iteration > 0:
-                    # Replace the model step in the pipeline
-                    best_pipe.steps[-1] = ("model", es_model)
+                    # Retrain on full training data with optimal n_estimators
+                    final_params = es_model.get_params()
+                    final_params["n_estimators"] = es_model.best_iteration + 1
+                    final_params.pop("early_stopping_rounds", None)
+                    final_model = XGBRegressor(**final_params)
+                    final_model.fit(
+                        np.ascontiguousarray(X_tr_transformed),
+                        _safe_np(y_train),
+                    )
+                    best_pipe.steps[-1] = ("model", final_model)
                     used_early_stop = True
                     logger.debug(
                         "WF-XGB early stop: best_iteration=%d (was n_estimators=%d)",

--- a/hea_extrapolation_platform/workflows.py
+++ b/hea_extrapolation_platform/workflows.py
@@ -606,9 +606,11 @@ class WorkflowXGB(BaseWorkflow):
             and len(X_train) >= 20
         ):
             try:
+                from sklearn.base import clone as _clone
                 from sklearn.model_selection import train_test_split as _tts
 
                 # Apply the scaler (and optionally PCA) from the best pipeline
+                # to transform training data for early stopping probe.
                 preprocessor = Pipeline(
                     [(name, step) for name, step in best_pipe.steps if name != "model"]
                 )
@@ -621,7 +623,7 @@ class WorkflowXGB(BaseWorkflow):
                     test_size=0.2, random_state=seed,
                 )
 
-                # Clone the best model's params but allow more estimators
+                # Probe: find optimal n_estimators via early stopping
                 es_params = best_model.get_params()
                 es_params["n_estimators"] = max(es_params.get("n_estimators", 200), 500)
                 es_params["early_stopping_rounds"] = 20
@@ -634,16 +636,14 @@ class WorkflowXGB(BaseWorkflow):
                 )
                 # Check if early stopping actually triggered (stopped before max budget)
                 if hasattr(es_model, "best_iteration") and es_model.best_iteration < es_params["n_estimators"] - 1:
-                    # Retrain on full training data with optimal n_estimators
-                    final_params = es_model.get_params()
-                    final_params["n_estimators"] = es_model.best_iteration + 1
-                    final_params.pop("early_stopping_rounds", None)
-                    final_model = XGBRegressor(**final_params)
-                    final_model.fit(
-                        np.ascontiguousarray(X_tr_transformed),
-                        _safe_np(y_train),
-                    )
-                    best_pipe.steps[-1] = ("model", final_model)
+                    # Clone the full pipeline and refit from raw data with
+                    # the optimal n_estimators.  This avoids the double-transform
+                    # bug that would occur if we inserted a model trained on
+                    # pre-transformed data back into the pipeline.
+                    optimal_n = es_model.best_iteration + 1
+                    best_pipe = _clone(best_pipe)
+                    best_pipe.set_params(model__n_estimators=optimal_n)
+                    best_pipe.fit(_safe_np(X_train), _safe_np(y_train))
                     used_early_stop = True
                     logger.debug(
                         "WF-XGB early stop: best_iteration=%d (was n_estimators=%d)",

--- a/hea_extrapolation_platform/workflows.py
+++ b/hea_extrapolation_platform/workflows.py
@@ -640,10 +640,12 @@ class WorkflowXGB(BaseWorkflow):
                     # the optimal n_estimators.  This avoids the double-transform
                     # bug that would occur if we inserted a model trained on
                     # pre-transformed data back into the pipeline.
+                    # Use a temp variable so best_pipe stays fitted if fit() fails.
                     optimal_n = es_model.best_iteration + 1
-                    best_pipe = _clone(best_pipe)
-                    best_pipe.set_params(model__n_estimators=optimal_n)
-                    best_pipe.fit(_safe_np(X_train), _safe_np(y_train))
+                    cloned_pipe = _clone(best_pipe)
+                    cloned_pipe.set_params(model__n_estimators=optimal_n)
+                    cloned_pipe.fit(_safe_np(X_train), _safe_np(y_train))
+                    best_pipe = cloned_pipe  # only reassign after successful fit
                     used_early_stop = True
                     logger.debug(
                         "WF-XGB early stop: best_iteration=%d (was n_estimators=%d)",

--- a/hea_extrapolation_platform/workflows.py
+++ b/hea_extrapolation_platform/workflows.py
@@ -632,8 +632,8 @@ class WorkflowXGB(BaseWorkflow):
                     eval_set=[(np.ascontiguousarray(X_val_es), y_val_es)],
                     verbose=False,
                 )
-                # Check if early stopping actually triggered
-                if hasattr(es_model, "best_iteration") and es_model.best_iteration > 0:
+                # Check if early stopping actually triggered (stopped before max budget)
+                if hasattr(es_model, "best_iteration") and es_model.best_iteration < es_params["n_estimators"] - 1:
                     # Retrain on full training data with optimal n_estimators
                     final_params = es_model.get_params()
                     final_params["n_estimators"] = es_model.best_iteration + 1


### PR DESCRIPTION
# feat: 5 pipeline improvements (leak detect, bootstrap CI, early stop, JSON serialize, n_jobs)

## Summary

Implements 5 high-impact improvements from user-provided review comments (#3, #5, #7, #9, #11):

| # | Improvement | Module |
|---|---|---|
| **#5** | `as_serializable()` — recursively converts numpy/pandas types to JSON-safe builtins before `json.dump` | `_compat.py`, `runner.py` |
| **#7** | `detect_target_leakage()` — flags features with \|corr(feature, target)\| > 0.85 in Phase 0 | `multicollinearity.py`, `evaluation.py` |
| **#3** | XGBoost early stopping refinement — probes optimal `n_estimators` via `early_stopping_rounds`, then clones and refits full pipeline | `workflows.py` |
| **#9** | Bootstrap 95% CI for RMSE — resamples CV scores (1000 iterations) to compute confidence intervals | `evaluation.py` |
| **#11** | Global `_get_inner_n_jobs()` — single configurable `HEA_INNER_N_JOBS` env var to prevent nested parallelism | `workflows.py` |

GUI and report updated to display Bootstrap CI and leak suspect counts in validity ranking tables.

**Test result:** 702 runs in 553.8 sec via GUI, **no SIGSEGV**.

### Updates since last revision

Fixed bugs identified by Devin Review across multiple rounds:

1. **Missing `early_stopping_rounds`** (3d0e355): Added `es_params["early_stopping_rounds"] = 20` so early stopping actually triggers instead of training all 500 iterations.
2. **Test set data leakage** (3d0e355): Replaced `X_test`/`y_test` as `eval_set` with an 80/20 train/validation split from training data via `train_test_split`. After finding the optimal `n_estimators`, the model is **retrained on the full training data** with that count.
3. **0-dimensional ndarray crash** (a292d41): `as_serializable(np.array(5.0))` crashed because `np.array(5.0).tolist()` returns a scalar, not a list. Added `ndim == 0` guard to extract via `obj.item()`.
4. **Incorrect early stopping detection** (99e8abb): Changed `best_iteration > 0` to `best_iteration < n_estimators - 1`. When early stopping does NOT trigger, XGBoost sets `best_iteration = n_estimators - 1` (e.g. 499), which incorrectly passed the old check and silently replaced the GridSearchCV-optimized model.
5. **Double-transform bug** (2a9d20a): The early-stopped model was trained on pre-transformed data (scaler+PCA already applied) but inserted back into the pipeline, causing double transformation at predict time. Fix: use `sklearn.base.clone(best_pipe)` to create a fresh pipeline, set `model__n_estimators` to the optimal count, and `fit()` from raw data.

## Review & Testing Checklist for Human


- [ ] **Early stopping 3-step logic** (`workflows.py:608-654`): (1) GridSearchCV finds best hyperparameters, (2) probe optimal `n_estimators` via early stopping on train/val split of *transformed* data, (3) clone full pipeline + set optimal `n_estimators` + refit from *raw* data. **Critical:** Verify the cloned pipeline correctly inherits all GridSearchCV-selected hyperparameters (learning_rate, max_depth, etc.) via `set_params(model__n_estimators=...)`. The probe uses a pre-fitted preprocessor from GridSearchCV, but the final model refits the preprocessor from scratch — if PCA components differ slightly, the optimal `n_estimators` might be suboptimal (minor risk).
- [ ] **Leak penalty formula** (`evaluation.py:177-182`): `corr_penalty = min(1.0, n_suspects * 0.3 * max_corr)`. The 0.85 threshold and 0.3 scaling factor are hand-tuned without theoretical justification — verify these are reasonable for your domain.
- [ ] **Bootstrap CI implementation** (`evaluation.py:220-258`): Uses 1000 resamples with fixed seed 42. Verify the seed and sample size are appropriate.
- [ ] **`as_serializable` edge cases**: Test with 0-dim arrays (`np.array(5.0)`), NaN/Inf values, nested structures, and pandas DataFrames to ensure no `TypeError` on JSON export.
- [ ] **Test end-to-end**: Run a full experiment via GUI and verify:
   - Leak suspects are flagged correctly in Phase 0 logs (check for `|corr(feature, target)| = ...` warnings)
   - Bootstrap CI appears in validity ranking table (Dashboard tab) and report
   - JSON export works without `TypeError`
   - Early stopping reduces `n_estimators` for XGBoost only when it actually triggers (check `"early_stopping_used": true` in run artifacts and verify the log message shows `best_iteration < 499`)
   - Test RMSE is not optimistically biased (compare XGB results vs other workflows)
   - Predictions are correct (no double-transform artifacts — verify test RMSE is reasonable, not anomalously high)

### Test Plan

```bash
cd /path/to/machine-learning/hea_extrapolation_platform
python -m hea_extrapolation_platform gui --port 7862
# 1. Run experiment with Quick Mode enabled
# 2. Check Dashboard → FS comparison table for "RMSE (95% CI)" and "Leak" columns
# 3. Check logs for "Leak suspect: VEC has |corr(feature, target)| = 0.88"
# 4. Verify results/*/run_registry.json exports without error
# 5. Check Results tab → Validity Ranking DataFrame for "RMSE 95%CI" and "Leak Suspects" columns
# 6. Verify XGBoost early stopping triggered (check logs for "WF-XGB early stop: best_iteration=...")
# 7. Verify early stopping only applies when best_iteration < 499 (not when it equals 499)
# 8. Compare XGB test RMSE vs other workflows to ensure no anomalies from double-transform bug
```

### Notes

- Link to Devin run: https://app.devin.ai/sessions/a35c3055d9194e26a3ca15a00e41209a
- Requested by: @minimumtone
- All 5 improvements tested together in a single 702-run experiment (6 workflows × 6 feature sets × ~20 splits) with no crashes
- Leak detection flagged VEC, d_elec_avg, itinerant_proxy with |corr| > 0.85 as expected
- Bootstrap CI computed for all feature sets (e.g., FS_BASE: 0.405 [0.398, 0.412])
- **No automated unit tests** — all verification done via GUI end-to-end testing. Early stopping logic in particular has had 4 rounds of bug fixes; unit tests would have caught these earlier.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->