### PR TITLE
fix: AttributeError on MulticollinearityReport.leaked_features → leak_suspects

### DIFF
--- a/extrapolation_discovery_platform/runner.py
+++ b/extrapolation_discovery_platform/runner.py
@@ -513,8 +513,8 @@ class ExperimentRunner:
                     _dropped = set(_rpt.dropped_constant + _rpt.dropped_perfect)
                     _orig = [c for c in _orig if c not in _dropped]
                     # Auto-exclude leaked features (high |r| with target)
-                    if self._leak_auto_exclude and _rpt.leaked_features:
-                        _leak_set = set(_rpt.leaked_features)
+                    if self._leak_auto_exclude and _rpt.leak_suspects:
+                        _leak_set = set(_rpt.leak_suspects.keys())
                         _before = len(_orig)
                         _orig = [c for c in _orig if c not in _leak_set]
                         if _before != len(_orig):


### PR DESCRIPTION
## Summary

Fixes a runtime `AttributeError` crash when running experiments with leak auto-exclude enabled:

```
AttributeError: 'MulticollinearityReport' object has no attribute 'leaked_features'
```

The `MulticollinearityReport` dataclass (in `multicollinearity.py`) stores leak detection results in `leak_suspects: Dict[str, float]` (mapping feature name → absolute correlation), but `runner.py` was referencing the nonexistent attribute `leaked_features`. This was introduced in PR #144.

**Fix:** `_rpt.leaked_features` → `_rpt.leak_suspects`, and `set(...)` → `set(...keys())` since `leak_suspects` is a dict (we need the feature names, not the correlation values).

## Review & Testing Checklist for Human

- [ ] **End-to-end test**: Upload `mp_b2_data.csv`, run with leak auto-exclude enabled (default), verify no `AttributeError` and that leaked features are correctly excluded from training
- [ ] Verify that excluded features match what Phase 0 logs as leak suspects

### Notes
- Requested by: @minimumtone
- [Link to Devin Session](https://app.devin.ai/sessions/3d0db910ced242efbdeb4736c680da01)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
