### PR TITLE
feat: 不等式制約付きSLSQP最適化 + Bootstrap不確定性評価（ベクトル化・並列化）

### DIFF
--- a/four_case_comparison_study.py
+++ b/four_case_comparison_study.py
@@ -7,6 +7,7 @@ classifies them as B2 or L1_2, calculates effective atomic radii via TRF
 optimisation, and generates a comprehensive comparison report with figures.
 """
 
+import multiprocessing
 import os
 import re
 import sys
@@ -21,6 +22,7 @@ import numpy as np
 import pandas as pd
 import requests
 from scipy.optimize import least_squares, minimize
+from threadpoolctl import threadpool_limits
 
 warnings.filterwarnings("ignore")
 
@@ -271,32 +273,35 @@ def extract_oqmd_compounds(structure_type: str) -> pd.DataFrame:
 # Radius calculation (same TRF approach as existing code)
 # ---------------------------------------------------------------------------
 
-def _determine_active_contacts_df(df: pd.DataFrame,
-                                   radii_arr: np.ndarray,
-                                   el2idx: Dict[str, int],
-                                   stype: str) -> List[str]:
-    """Determine the active (dominant) contact condition for each compound."""
-    contacts = []
-    for _, row in df.iterrows():
-        iA, iB = el2idx[row["element_A"]], el2idx[row["element_B"]]
-        rA, rB = radii_arr[iA], radii_arr[iB]
-        if stype == "B2":
-            a_AA = 2 * rA
-            a_BB = 2 * rB
-            a_AB = (2 / np.sqrt(3)) * (rA + rB)
-            vals = {"AA": a_AA, "BB": a_BB, "AB": a_AB}
-            contacts.append(max(vals, key=vals.get))
-        else:  # L1_2
-            if row["count_A"] > row["count_B"]:
-                r_major, r_minor = rA, rB
-            else:
-                r_major, r_minor = rB, rA
-            a_AA = 2 * np.sqrt(2) * r_major
-            a_AB = np.sqrt(2) * (r_major + r_minor)
-            a_BB = 2 * r_minor
-            vals = {"AA": a_AA, "AB": a_AB, "BB": a_BB}
-            contacts.append(max(vals, key=vals.get))
-    return contacts
+def _determine_active_contacts_vec(radii_arr: np.ndarray,
+                                    iA_arr: np.ndarray, iB_arr: np.ndarray,
+                                    im_arr: np.ndarray, in_arr: np.ndarray,
+                                    stype: str) -> np.ndarray:
+    """Vectorised active-contact determination.  Returns array of 0/1/2
+    encoding AA/BB/AB respectively."""
+    _sqrt2 = np.sqrt(2)
+    _2s3 = 2.0 / np.sqrt(3)
+    if stype == "B2":
+        a_AA = 2.0 * radii_arr[iA_arr]
+        a_BB = 2.0 * radii_arr[iB_arr]
+        a_AB = _2s3 * (radii_arr[iA_arr] + radii_arr[iB_arr])
+        stacked = np.column_stack([a_AA, a_BB, a_AB])
+    else:  # L1_2
+        rm = radii_arr[im_arr]
+        rn = radii_arr[in_arr]
+        a_AA = 2.0 * _sqrt2 * rm
+        a_AB = _sqrt2 * (rm + rn)
+        a_BB = 2.0 * rn
+        stacked = np.column_stack([a_AA, a_AB, a_BB])
+    return stacked.argmax(axis=1)
+
+
+# contact-type integer codes used throughout the vectorised path
+_CT_AA, _CT_BB, _CT_AB = 0, 1, 2
+# For L1_2 the column order is AA, AB, BB → codes 0, 1, 2 but
+# _CT_AB=2 would collide with BB.  Keep separate mappings:
+_B2_CODES  = np.array([0, 1, 2])   # AA, BB, AB columns
+_L12_CODES = np.array([0, 1, 2])   # AA, AB, BB columns
 
 
 def calculate_radii_trf(df: pd.DataFrame,
@@ -304,7 +309,7 @@ def calculate_radii_trf(df: pd.DataFrame,
                         initial_guess: Optional[Dict[str, float]] = None,
                         ) -> Tuple[Dict[str, float], Dict]:
     """Calculate effective atomic radii using iterative constrained
-    optimisation (SLSQP).
+    optimisation (SLSQP) with fully vectorised inner functions.
 
     At each iteration the dominant contact condition (max) is determined
     for every compound from the current radii.  A constrained optimisation
@@ -331,149 +336,167 @@ def calculate_radii_trf(df: pd.DataFrame,
     _sqrt2 = np.sqrt(2)
     _2s3 = 2.0 / np.sqrt(3)
 
-    # Pre-extract row data for speed
-    row_data = []
-    for _, row in df.iterrows():
-        row_data.append((
-            row["lattice_constant"],
-            el2idx[row["element_A"]], el2idx[row["element_B"]],
-            row["count_A"], row["count_B"],
-        ))
+    # Pre-extract numpy arrays (done once)
+    n_comp = len(df)
+    a_vals = df["lattice_constant"].values.astype(np.float64)
+    iA_arr = np.array([el2idx[e] for e in df["element_A"]], dtype=np.intp)
+    iB_arr = np.array([el2idx[e] for e in df["element_B"]], dtype=np.intp)
+    cA_arr = df["count_A"].values
+    cB_arr = df["count_B"].values
+
+    # For L1_2: pre-compute major / minor element indices
+    is_A_major = cA_arr > cB_arr
+    im_arr = np.where(is_A_major, iA_arr, iB_arr)  # major
+    in_arr = np.where(is_A_major, iB_arr, iA_arr)  # minor
 
     # --- iterative loop ---
     current_radii = x0.copy()
-    active_contacts: List[str] = []
+    prev_ct = np.full(n_comp, -1, dtype=np.intp)
     n_iterations = 0
     _bounds = [(0.5, 3.5)] * n_el
 
     for iteration in range(max_iter):
-        new_contacts = _determine_active_contacts_df(df, current_radii,
-                                                     el2idx, stype)
-        if new_contacts == active_contacts:
+        ct = _determine_active_contacts_vec(current_radii,
+                                            iA_arr, iB_arr,
+                                            im_arr, in_arr, stype)
+        if np.array_equal(ct, prev_ct):
             break
-        active_contacts = new_contacts
+        prev_ct = ct.copy()
         n_iterations = iteration + 1
 
-        frozen = list(active_contacts)
+        # --- build masks for current contact assignment ---
+        if stype == "B2":
+            mAA = ct == 0; mBB = ct == 1; mAB = ct == 2  # noqa: E702
+        else:
+            mAA = ct == 0; mAB = ct == 1; mBB = ct == 2  # noqa: E702
 
-        # Objective: 0.5 * sum of squared residuals (dominant contacts)
-        def _obj(radii, _ct=frozen):
-            ssr = 0.0
-            for i, (a, iA, iB, cA, cB) in enumerate(row_data):
-                rA, rB = radii[iA], radii[iB]
-                ct = _ct[i]
-                if stype == "B2":
-                    if ct == "AA":
-                        d = 2.0 * rA - a
-                    elif ct == "BB":
-                        d = 2.0 * rB - a
-                    else:
-                        d = _2s3 * (rA + rB) - a
-                else:
-                    rm = rA if cA > cB else rB
-                    rn = rB if cA > cB else rA
-                    if ct == "AA":
-                        d = 2.0 * _sqrt2 * rm - a
-                    elif ct == "AB":
-                        d = _sqrt2 * (rm + rn) - a
-                    else:
-                        d = 2.0 * rn - a
-                ssr += d * d
-            return 0.5 * ssr
+        # ---- vectorised objective (0.5 * SSR) ----
+        if stype == "B2":
+            def _obj(radii, _mAA=mAA, _mBB=mBB, _mAB=mAB):
+                rA = radii[iA_arr]; rB = radii[iB_arr]
+                d = np.empty(n_comp)
+                d[_mAA] = 2.0 * rA[_mAA] - a_vals[_mAA]
+                d[_mBB] = 2.0 * rB[_mBB] - a_vals[_mBB]
+                d[_mAB] = _2s3 * (rA[_mAB] + rB[_mAB]) - a_vals[_mAB]
+                return 0.5 * np.dot(d, d)
 
-        def _grad(radii, _ct=frozen):
-            g = np.zeros_like(radii)
-            for i, (a, iA, iB, cA, cB) in enumerate(row_data):
-                rA, rB = radii[iA], radii[iB]
-                ct = _ct[i]
-                if stype == "B2":
-                    if ct == "AA":
-                        d = 2.0 * rA - a
-                        g[iA] += 2.0 * d
-                    elif ct == "BB":
-                        d = 2.0 * rB - a
-                        g[iB] += 2.0 * d
-                    else:
-                        d = _2s3 * (rA + rB) - a
-                        g[iA] += _2s3 * d
-                        g[iB] += _2s3 * d
-                else:
-                    im = iA if cA > cB else iB
-                    imn = iB if cA > cB else iA
-                    rm, rn = radii[im], radii[imn]
-                    if ct == "AA":
-                        d = 2.0 * _sqrt2 * rm - a
-                        g[im] += 2.0 * _sqrt2 * d
-                    elif ct == "AB":
-                        d = _sqrt2 * (rm + rn) - a
-                        g[im] += _sqrt2 * d
-                        g[imn] += _sqrt2 * d
-                    else:
-                        d = 2.0 * rn - a
-                        g[imn] += 2.0 * d
-            return g
+            def _grad(radii, _mAA=mAA, _mBB=mBB, _mAB=mAB):
+                rA = radii[iA_arr]; rB = radii[iB_arr]
+                d = np.empty(n_comp)
+                d[_mAA] = 2.0 * rA[_mAA] - a_vals[_mAA]
+                d[_mBB] = 2.0 * rB[_mBB] - a_vals[_mBB]
+                d[_mAB] = _2s3 * (rA[_mAB] + rB[_mAB]) - a_vals[_mAB]
+                g = np.zeros(n_el)
+                np.add.at(g, iA_arr[_mAA], 2.0 * d[_mAA])
+                np.add.at(g, iB_arr[_mBB], 2.0 * d[_mBB])
+                np.add.at(g, iA_arr[_mAB], _2s3 * d[_mAB])
+                np.add.at(g, iB_arr[_mAB], _2s3 * d[_mAB])
+                return g
+        else:  # L1_2
+            def _obj(radii, _mAA=mAA, _mAB=mAB, _mBB=mBB):
+                rm = radii[im_arr]; rn = radii[in_arr]
+                d = np.empty(n_comp)
+                d[_mAA] = 2.0 * _sqrt2 * rm[_mAA] - a_vals[_mAA]
+                d[_mAB] = _sqrt2 * (rm[_mAB] + rn[_mAB]) - a_vals[_mAB]
+                d[_mBB] = 2.0 * rn[_mBB] - a_vals[_mBB]
+                return 0.5 * np.dot(d, d)
 
-        # Inequality constraints: a_DFT - a_non_dominant >= 0
-        def _ineq(radii, _ct=frozen):
-            vals = []
-            for i, (a, iA, iB, cA, cB) in enumerate(row_data):
-                rA, rB = radii[iA], radii[iB]
-                ct = _ct[i]
-                if stype == "B2":
-                    if ct != "AA":
-                        vals.append(a - 2.0 * rA)
-                    if ct != "BB":
-                        vals.append(a - 2.0 * rB)
-                    if ct != "AB":
-                        vals.append(a - _2s3 * (rA + rB))
-                else:
-                    rm = rA if cA > cB else rB
-                    rn = rB if cA > cB else rA
-                    if ct != "AA":
-                        vals.append(a - 2.0 * _sqrt2 * rm)
-                    if ct != "AB":
-                        vals.append(a - _sqrt2 * (rm + rn))
-                    if ct != "BB":
-                        vals.append(a - 2.0 * rn)
-            return np.array(vals)
+            def _grad(radii, _mAA=mAA, _mAB=mAB, _mBB=mBB):
+                rm = radii[im_arr]; rn = radii[in_arr]
+                d = np.empty(n_comp)
+                d[_mAA] = 2.0 * _sqrt2 * rm[_mAA] - a_vals[_mAA]
+                d[_mAB] = _sqrt2 * (rm[_mAB] + rn[_mAB]) - a_vals[_mAB]
+                d[_mBB] = 2.0 * rn[_mBB] - a_vals[_mBB]
+                g = np.zeros(n_el)
+                np.add.at(g, im_arr[_mAA], 2.0 * _sqrt2 * d[_mAA])
+                np.add.at(g, im_arr[_mAB], _sqrt2 * d[_mAB])
+                np.add.at(g, in_arr[_mAB], _sqrt2 * d[_mAB])
+                np.add.at(g, in_arr[_mBB], 2.0 * d[_mBB])
+                return g
 
-        def _ineq_jac(radii, _ct=frozen):
-            rows = []
-            for i, (a, iA, iB, cA, cB) in enumerate(row_data):
-                ct = _ct[i]
-                if stype == "B2":
-                    if ct != "AA":
-                        row = np.zeros(n_el)
-                        row[iA] = -2.0
-                        rows.append(row)
-                    if ct != "BB":
-                        row = np.zeros(n_el)
-                        row[iB] = -2.0
-                        rows.append(row)
-                    if ct != "AB":
-                        row = np.zeros(n_el)
-                        row[iA] = -_2s3
-                        row[iB] = -_2s3
-                        rows.append(row)
-                else:
-                    im = iA if cA > cB else iB
-                    imn = iB if cA > cB else iA
-                    if ct != "AA":
-                        row = np.zeros(n_el)
-                        row[im] = -2.0 * _sqrt2
-                        rows.append(row)
-                    if ct != "AB":
-                        row = np.zeros(n_el)
-                        row[im] = -_sqrt2
-                        row[imn] = -_sqrt2
-                        rows.append(row)
-                    if ct != "BB":
-                        row = np.zeros(n_el)
-                        row[imn] = -2.0
-                        rows.append(row)
-            if not rows:
+        # ---- vectorised inequality constraints ----
+        # Build constraint index arrays & pre-compute constant Jacobian
+        # (constraints are linear in radii → Jacobian is constant)
+        c_idx_list: List[int] = []      # compound index
+        c_type_list: List[int] = []     # 0=AA, 1=BB, 2=AB for B2 / 0=AA, 1=AB, 2=BB for L12
+        if stype == "B2":
+            for i in range(n_comp):
+                c = ct[i]
+                if c != 0:  # not AA
+                    c_idx_list.append(i); c_type_list.append(0)
+                if c != 1:  # not BB
+                    c_idx_list.append(i); c_type_list.append(1)
+                if c != 2:  # not AB
+                    c_idx_list.append(i); c_type_list.append(2)
+        else:
+            for i in range(n_comp):
+                c = ct[i]
+                if c != 0:  # not AA
+                    c_idx_list.append(i); c_type_list.append(0)
+                if c != 1:  # not AB
+                    c_idx_list.append(i); c_type_list.append(1)
+                if c != 2:  # not BB
+                    c_idx_list.append(i); c_type_list.append(2)
+
+        n_ineq = len(c_idx_list)
+        if n_ineq > 0:
+            ci = np.array(c_idx_list, dtype=np.intp)
+            ctp = np.array(c_type_list, dtype=np.intp)
+            c_a = a_vals[ci]
+            cmAA = ctp == 0; cmBB_or_AB1 = ctp == 1; cmAB_or_BB2 = ctp == 2
+
+            if stype == "B2":
+                c_iA = iA_arr[ci]; c_iB = iB_arr[ci]
+
+                def _ineq(radii, _cmAA=cmAA, _cmBB=cmBB_or_AB1,
+                          _cmAB=cmAB_or_BB2):
+                    rA = radii[c_iA]; rB = radii[c_iB]
+                    v = np.empty(n_ineq)
+                    v[_cmAA] = c_a[_cmAA] - 2.0 * rA[_cmAA]
+                    v[_cmBB] = c_a[_cmBB] - 2.0 * rB[_cmBB]
+                    v[_cmAB] = c_a[_cmAB] - _2s3 * (rA[_cmAB] + rB[_cmAB])
+                    return v
+
+                # constant Jacobian
+                jac = np.zeros((n_ineq, n_el))
+                aa_rows = np.where(cmAA)[0]
+                jac[aa_rows, c_iA[aa_rows]] += -2.0
+                bb_rows = np.where(cmBB_or_AB1)[0]
+                jac[bb_rows, c_iB[bb_rows]] += -2.0
+                ab_rows = np.where(cmAB_or_BB2)[0]
+                jac[ab_rows, c_iA[ab_rows]] += -_2s3
+                jac[ab_rows, c_iB[ab_rows]] += -_2s3
+            else:  # L1_2
+                c_im = im_arr[ci]; c_in = in_arr[ci]
+
+                def _ineq(radii, _cmAA=cmAA, _cmAB=cmBB_or_AB1,
+                          _cmBB=cmAB_or_BB2):
+                    rm = radii[c_im]; rn = radii[c_in]
+                    v = np.empty(n_ineq)
+                    v[_cmAA] = c_a[_cmAA] - 2.0 * _sqrt2 * rm[_cmAA]
+                    v[_cmAB] = c_a[_cmAB] - _sqrt2 * (rm[_cmAB] + rn[_cmAB])
+                    v[_cmBB] = c_a[_cmBB] - 2.0 * rn[_cmBB]
+                    return v
+
+                jac = np.zeros((n_ineq, n_el))
+                aa_rows = np.where(cmAA)[0]
+                jac[aa_rows, c_im[aa_rows]] += -2.0 * _sqrt2
+                ab_rows = np.where(cmBB_or_AB1)[0]
+                jac[ab_rows, c_im[ab_rows]] += -_sqrt2
+                jac[ab_rows, c_in[ab_rows]] += -_sqrt2
+                bb_rows = np.where(cmAB_or_BB2)[0]
+                jac[bb_rows, c_in[bb_rows]] += -2.0
+
+            _const_jac = jac
+
+            def _ineq_jac(radii):
+                return _const_jac
+        else:
+            def _ineq(radii):
+                return np.array([])
+
+            def _ineq_jac(radii):
                 return np.empty((0, n_el))
-            return np.array(rows)
 
         result = minimize(
             _obj, current_radii, jac=_grad,
@@ -485,62 +508,80 @@ def calculate_radii_trf(df: pd.DataFrame,
 
     radii = {el: current_radii[el2idx[el]] for el in elements}
 
-    # Final stats using max (the true model)
-    final_res = []
-    for _, row in df.iterrows():
-        eA, eB = row["element_A"], row["element_B"]
-        rA, rB = radii[eA], radii[eB]
-        if stype == "B2":
-            a_calc = max(2 * rA, 2 * rB, _2s3 * (rA + rB))
-        else:
-            if row["count_A"] > row["count_B"]:
-                r_major, r_minor = rA, rB
-            else:
-                r_major, r_minor = rB, rA
-            a_calc = max(2 * _sqrt2 * r_major,
-                         _sqrt2 * (r_major + r_minor),
-                         2 * r_minor)
-        final_res.append(a_calc - row["lattice_constant"])
-    final_res = np.array(final_res)
+    # Final stats using max (the true model) — vectorised
+    rA_f = np.array([radii[e] for e in df["element_A"]])
+    rB_f = np.array([radii[e] for e in df["element_B"]])
+    if stype == "B2":
+        a_calc = np.maximum(np.maximum(2 * rA_f, 2 * rB_f),
+                            _2s3 * (rA_f + rB_f))
+    else:
+        rm_f = np.where(is_A_major, rA_f, rB_f)
+        rn_f = np.where(is_A_major, rB_f, rA_f)
+        a_calc = np.maximum(np.maximum(2 * _sqrt2 * rm_f,
+                                       _sqrt2 * (rm_f + rn_f)),
+                            2 * rn_f)
+    final_res = a_calc - a_vals
 
-    # Count constraint violations
-    n_violated = 0
-    for _, row in df.iterrows():
-        eA, eB = row["element_A"], row["element_B"]
-        rA, rB = radii[eA], radii[eB]
-        a = row["lattice_constant"]
-        if stype == "B2":
-            for v in [2 * rA, 2 * rB, _2s3 * (rA + rB)]:
-                if v > a + 1e-6:
-                    n_violated += 1
-        else:
-            if row["count_A"] > row["count_B"]:
-                rm, rn = rA, rB
-            else:
-                rm, rn = rB, rA
-            for v in [2 * _sqrt2 * rm, _sqrt2 * (rm + rn), 2 * rn]:
-                if v > a + 1e-6:
-                    n_violated += 1
+    # Count constraint violations — vectorised
+    if stype == "B2":
+        all_contacts = np.column_stack([2 * rA_f, 2 * rB_f,
+                                        _2s3 * (rA_f + rB_f)])
+    else:
+        all_contacts = np.column_stack([2 * _sqrt2 * rm_f,
+                                        _sqrt2 * (rm_f + rn_f),
+                                        2 * rn_f])
+    n_violated = int(np.sum(all_contacts > a_vals[:, None] + 1e-6))
 
     return radii, {
         "n_compounds": len(df),
         "n_elements": len(elements),
-        "rmse": np.sqrt(np.mean(final_res ** 2)),
-        "mae": np.mean(np.abs(final_res)),
+        "rmse": float(np.sqrt(np.mean(final_res ** 2))),
+        "mae": float(np.mean(np.abs(final_res))),
         "contact_iterations": n_iterations,
         "n_constraint_violations": n_violated,
     }
+
+
+# ---------------------------------------------------------------------------
+# Module-level state for multiprocessing bootstrap workers
+# ---------------------------------------------------------------------------
+_BOOT_DF: Optional[pd.DataFrame] = None
+_BOOT_GUESS: Optional[Dict[str, float]] = None
+
+
+def _init_boot_pool(df: pd.DataFrame, guess: Dict[str, float]) -> None:
+    """Initialiser called once per worker process."""
+    global _BOOT_DF, _BOOT_GUESS
+    _BOOT_DF = df
+    _BOOT_GUESS = guess
+
+
+def _boot_worker(seed: int) -> Optional[Dict[str, float]]:
+    """Single bootstrap iteration (must be module-level for pickling)."""
+    with threadpool_limits(limits=1):
+        rng = np.random.RandomState(seed)
+        n = len(_BOOT_DF)
+        idx = rng.choice(n, size=n, replace=True)
+        sample = _BOOT_DF.iloc[idx].reset_index(drop=True)
+        try:
+            r, _ = calculate_radii_trf(sample, max_iter=10,
+                                       initial_guess=_BOOT_GUESS)
+            return r
+        except Exception:
+            return None
 
 
 def bootstrap_uncertainty(df: pd.DataFrame,
                           n_bootstrap: int = 1000,
                           random_state: int = 42,
                           initial_guess: Optional[Dict[str, float]] = None,
+                          n_jobs: Optional[int] = None,
                           ) -> Dict:
     """Estimate uncertainty in atomic radii via bootstrap resampling.
 
     Resamples compounds with replacement, re-optimises for each sample,
     and returns per-element mean, std, and 95 % confidence intervals.
+    Uses multiprocessing to parallelise across CPU cores.
     """
     if len(df) == 0:
         return {}
@@ -549,23 +590,28 @@ def bootstrap_uncertainty(df: pd.DataFrame,
         initial_guess, _ = calculate_radii_trf(df)
 
     elements = sorted(initial_guess.keys())
-    n = len(df)
+
+    if n_jobs is None:
+        n_jobs = min(os.cpu_count() or 1, 8)
+
     rng = np.random.RandomState(random_state)
+    seeds = rng.randint(0, 2**31, size=n_bootstrap).tolist()
 
     boot_radii: Dict[str, List[float]] = {el: [] for el in elements}
+    n_done = 0
 
-    for b in range(n_bootstrap):
-        if (b + 1) % 100 == 0:
-            print(f"  bootstrap {b + 1}/{n_bootstrap}")
-        idx = rng.choice(n, size=n, replace=True)
-        sample = df.iloc[idx].reset_index(drop=True)
-        try:
-            r, _ = calculate_radii_trf(sample, initial_guess=initial_guess)
-            for el in elements:
-                if el in r:
-                    boot_radii[el].append(r[el])
-        except Exception:
-            continue
+    with multiprocessing.Pool(
+        n_jobs, initializer=_init_boot_pool,
+        initargs=(df, initial_guess),
+    ) as pool:
+        for r in pool.imap_unordered(_boot_worker, seeds, chunksize=4):
+            n_done += 1
+            if n_done % 100 == 0:
+                print(f"  bootstrap {n_done}/{n_bootstrap}")
+            if r is not None:
+                for el in elements:
+                    if el in r:
+                        boot_radii[el].append(r[el])
 
     out: Dict = {"mean": {}, "std": {},
                  "ci_lower": {}, "ci_upper": {},

--- a/four_case_comparison_study.py
+++ b/four_case_comparison_study.py
@@ -20,7 +20,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import requests
-from scipy.optimize import least_squares
+from scipy.optimize import least_squares, minimize
 
 warnings.filterwarnings("ignore")
 
@@ -300,14 +300,18 @@ def _determine_active_contacts_df(df: pd.DataFrame,
 
 
 def calculate_radii_trf(df: pd.DataFrame,
-                        max_iter: int = 50) -> Tuple[Dict[str, float], Dict]:
-    """Calculate effective atomic radii using iterative TRF optimisation.
+                        max_iter: int = 50,
+                        initial_guess: Optional[Dict[str, float]] = None,
+                        ) -> Tuple[Dict[str, float], Dict]:
+    """Calculate effective atomic radii using iterative constrained
+    optimisation (SLSQP).
 
     At each iteration the dominant contact condition (max) is determined
-    for every compound from the current radii.  A smooth least-squares
-    sub-problem is then solved using only that fixed contact condition.
-    The loop repeats until no compound switches its active contact,
-    guaranteeing self-consistent radii.
+    for every compound from the current radii.  A constrained optimisation
+    sub-problem is then solved: the objective minimises residuals for the
+    active contacts while inequality constraints enforce that every
+    non-dominant contact satisfies a_contact <= a_DFT.  The loop repeats
+    until no compound switches its active contact (self-consistent radii).
     """
     if len(df) == 0:
         return {}, {"n_compounds": 0, "n_elements": 0,
@@ -315,9 +319,17 @@ def calculate_radii_trf(df: pd.DataFrame,
 
     elements = sorted(set(df["element_A"]) | set(df["element_B"]))
     el2idx = {el: i for i, el in enumerate(elements)}
-    x0 = np.array([PAULING_RADII.get(el, 1.4) for el in elements])
+    n_el = len(elements)
+
+    if initial_guess:
+        x0 = np.array([initial_guess.get(el, 1.4) for el in elements])
+    else:
+        x0 = np.array([PAULING_RADII.get(el, 1.4) for el in elements])
 
     stype = df["structure_type"].iloc[0]
+
+    _sqrt2 = np.sqrt(2)
+    _2s3 = 2.0 / np.sqrt(3)
 
     # Pre-extract row data for speed
     row_data = []
@@ -332,6 +344,7 @@ def calculate_radii_trf(df: pd.DataFrame,
     current_radii = x0.copy()
     active_contacts: List[str] = []
     n_iterations = 0
+    _bounds = [(0.5, 3.5)] * n_el
 
     for iteration in range(max_iter):
         new_contacts = _determine_active_contacts_df(df, current_radii,
@@ -341,36 +354,133 @@ def calculate_radii_trf(df: pd.DataFrame,
         active_contacts = new_contacts
         n_iterations = iteration + 1
 
-        frozen_contacts = list(active_contacts)
+        frozen = list(active_contacts)
 
-        def residuals(radii, _contacts=frozen_contacts):
-            res = []
+        # Objective: 0.5 * sum of squared residuals (dominant contacts)
+        def _obj(radii, _ct=frozen):
+            ssr = 0.0
             for i, (a, iA, iB, cA, cB) in enumerate(row_data):
                 rA, rB = radii[iA], radii[iB]
-                ct = _contacts[i]
+                ct = _ct[i]
                 if stype == "B2":
                     if ct == "AA":
-                        res.append(2 * rA - a)
+                        d = 2.0 * rA - a
                     elif ct == "BB":
-                        res.append(2 * rB - a)
-                    else:  # AB
-                        res.append((2 / np.sqrt(3)) * (rA + rB) - a)
-                else:  # L1_2
-                    if cA > cB:
-                        r_major, r_minor = rA, rB
+                        d = 2.0 * rB - a
                     else:
-                        r_major, r_minor = rB, rA
+                        d = _2s3 * (rA + rB) - a
+                else:
+                    rm = rA if cA > cB else rB
+                    rn = rB if cA > cB else rA
                     if ct == "AA":
-                        res.append(2 * np.sqrt(2) * r_major - a)
+                        d = 2.0 * _sqrt2 * rm - a
                     elif ct == "AB":
-                        res.append(np.sqrt(2) * (r_major + r_minor) - a)
+                        d = _sqrt2 * (rm + rn) - a
                     else:
-                        res.append(2 * r_minor - a)
-            return np.array(res)
+                        d = 2.0 * rn - a
+                ssr += d * d
+            return 0.5 * ssr
 
-        result = least_squares(residuals, current_radii,
-                               bounds=(0.5, 3.5), method="trf",
-                               ftol=1e-10, xtol=1e-10, gtol=1e-10)
+        def _grad(radii, _ct=frozen):
+            g = np.zeros_like(radii)
+            for i, (a, iA, iB, cA, cB) in enumerate(row_data):
+                rA, rB = radii[iA], radii[iB]
+                ct = _ct[i]
+                if stype == "B2":
+                    if ct == "AA":
+                        d = 2.0 * rA - a
+                        g[iA] += 2.0 * d
+                    elif ct == "BB":
+                        d = 2.0 * rB - a
+                        g[iB] += 2.0 * d
+                    else:
+                        d = _2s3 * (rA + rB) - a
+                        g[iA] += _2s3 * d
+                        g[iB] += _2s3 * d
+                else:
+                    im = iA if cA > cB else iB
+                    imn = iB if cA > cB else iA
+                    rm, rn = radii[im], radii[imn]
+                    if ct == "AA":
+                        d = 2.0 * _sqrt2 * rm - a
+                        g[im] += 2.0 * _sqrt2 * d
+                    elif ct == "AB":
+                        d = _sqrt2 * (rm + rn) - a
+                        g[im] += _sqrt2 * d
+                        g[imn] += _sqrt2 * d
+                    else:
+                        d = 2.0 * rn - a
+                        g[imn] += 2.0 * d
+            return g
+
+        # Inequality constraints: a_DFT - a_non_dominant >= 0
+        def _ineq(radii, _ct=frozen):
+            vals = []
+            for i, (a, iA, iB, cA, cB) in enumerate(row_data):
+                rA, rB = radii[iA], radii[iB]
+                ct = _ct[i]
+                if stype == "B2":
+                    if ct != "AA":
+                        vals.append(a - 2.0 * rA)
+                    if ct != "BB":
+                        vals.append(a - 2.0 * rB)
+                    if ct != "AB":
+                        vals.append(a - _2s3 * (rA + rB))
+                else:
+                    rm = rA if cA > cB else rB
+                    rn = rB if cA > cB else rA
+                    if ct != "AA":
+                        vals.append(a - 2.0 * _sqrt2 * rm)
+                    if ct != "AB":
+                        vals.append(a - _sqrt2 * (rm + rn))
+                    if ct != "BB":
+                        vals.append(a - 2.0 * rn)
+            return np.array(vals)
+
+        def _ineq_jac(radii, _ct=frozen):
+            rows = []
+            for i, (a, iA, iB, cA, cB) in enumerate(row_data):
+                ct = _ct[i]
+                if stype == "B2":
+                    if ct != "AA":
+                        row = np.zeros(n_el)
+                        row[iA] = -2.0
+                        rows.append(row)
+                    if ct != "BB":
+                        row = np.zeros(n_el)
+                        row[iB] = -2.0
+                        rows.append(row)
+                    if ct != "AB":
+                        row = np.zeros(n_el)
+                        row[iA] = -_2s3
+                        row[iB] = -_2s3
+                        rows.append(row)
+                else:
+                    im = iA if cA > cB else iB
+                    imn = iB if cA > cB else iA
+                    if ct != "AA":
+                        row = np.zeros(n_el)
+                        row[im] = -2.0 * _sqrt2
+                        rows.append(row)
+                    if ct != "AB":
+                        row = np.zeros(n_el)
+                        row[im] = -_sqrt2
+                        row[imn] = -_sqrt2
+                        rows.append(row)
+                    if ct != "BB":
+                        row = np.zeros(n_el)
+                        row[imn] = -2.0
+                        rows.append(row)
+            if not rows:
+                return np.empty((0, n_el))
+            return np.array(rows)
+
+        result = minimize(
+            _obj, current_radii, jac=_grad,
+            method="SLSQP", bounds=_bounds,
+            constraints={"type": "ineq", "fun": _ineq, "jac": _ineq_jac},
+            options={"maxiter": 1000, "ftol": 1e-12},
+        )
         current_radii = result.x
 
     radii = {el: current_radii[el2idx[el]] for el in elements}
@@ -381,17 +491,36 @@ def calculate_radii_trf(df: pd.DataFrame,
         eA, eB = row["element_A"], row["element_B"]
         rA, rB = radii[eA], radii[eB]
         if stype == "B2":
-            a_calc = max(2 * rA, 2 * rB, (2 / np.sqrt(3)) * (rA + rB))
+            a_calc = max(2 * rA, 2 * rB, _2s3 * (rA + rB))
         else:
             if row["count_A"] > row["count_B"]:
                 r_major, r_minor = rA, rB
             else:
                 r_major, r_minor = rB, rA
-            a_calc = max(2 * np.sqrt(2) * r_major,
-                         np.sqrt(2) * (r_major + r_minor),
+            a_calc = max(2 * _sqrt2 * r_major,
+                         _sqrt2 * (r_major + r_minor),
                          2 * r_minor)
         final_res.append(a_calc - row["lattice_constant"])
     final_res = np.array(final_res)
+
+    # Count constraint violations
+    n_violated = 0
+    for _, row in df.iterrows():
+        eA, eB = row["element_A"], row["element_B"]
+        rA, rB = radii[eA], radii[eB]
+        a = row["lattice_constant"]
+        if stype == "B2":
+            for v in [2 * rA, 2 * rB, _2s3 * (rA + rB)]:
+                if v > a + 1e-6:
+                    n_violated += 1
+        else:
+            if row["count_A"] > row["count_B"]:
+                rm, rn = rA, rB
+            else:
+                rm, rn = rB, rA
+            for v in [2 * _sqrt2 * rm, _sqrt2 * (rm + rn), 2 * rn]:
+                if v > a + 1e-6:
+                    n_violated += 1
 
     return radii, {
         "n_compounds": len(df),
@@ -399,7 +528,57 @@ def calculate_radii_trf(df: pd.DataFrame,
         "rmse": np.sqrt(np.mean(final_res ** 2)),
         "mae": np.mean(np.abs(final_res)),
         "contact_iterations": n_iterations,
+        "n_constraint_violations": n_violated,
     }
+
+
+def bootstrap_uncertainty(df: pd.DataFrame,
+                          n_bootstrap: int = 1000,
+                          random_state: int = 42,
+                          initial_guess: Optional[Dict[str, float]] = None,
+                          ) -> Dict:
+    """Estimate uncertainty in atomic radii via bootstrap resampling.
+
+    Resamples compounds with replacement, re-optimises for each sample,
+    and returns per-element mean, std, and 95 % confidence intervals.
+    """
+    if len(df) == 0:
+        return {}
+
+    if initial_guess is None:
+        initial_guess, _ = calculate_radii_trf(df)
+
+    elements = sorted(initial_guess.keys())
+    n = len(df)
+    rng = np.random.RandomState(random_state)
+
+    boot_radii: Dict[str, List[float]] = {el: [] for el in elements}
+
+    for b in range(n_bootstrap):
+        if (b + 1) % 100 == 0:
+            print(f"  bootstrap {b + 1}/{n_bootstrap}")
+        idx = rng.choice(n, size=n, replace=True)
+        sample = df.iloc[idx].reset_index(drop=True)
+        try:
+            r, _ = calculate_radii_trf(sample, initial_guess=initial_guess)
+            for el in elements:
+                if el in r:
+                    boot_radii[el].append(r[el])
+        except Exception:
+            continue
+
+    out: Dict = {"mean": {}, "std": {},
+                 "ci_lower": {}, "ci_upper": {},
+                 "n_success": 0}
+    for el in elements:
+        vals = np.array(boot_radii[el])
+        if len(vals) > 0:
+            out["mean"][el] = float(np.mean(vals))
+            out["std"][el] = float(np.std(vals))
+            out["ci_lower"][el] = float(np.percentile(vals, 2.5))
+            out["ci_upper"][el] = float(np.percentile(vals, 97.5))
+            out["n_success"] = max(out["n_success"], len(vals))
+    return out
 
 
 def _calc_lattice_constant(stype: str, rA: float, rB: float,
@@ -529,13 +708,44 @@ def run_analysis(api_key: str, fig_dir: str):
         }
         print(f"\n  [{CASE_LABELS[key]}]")
         print(f"    Compounds: {stats['n_compounds']}, Elements: {stats['n_elements']}")
+        n_viol = stats.get("n_constraint_violations", 0)
         print(f"    Radii  RMSE={stats['rmse']:.4f} A, MAE={stats['mae']:.4f} A")
         print(f"    Lattice RMSE={lat_rmse:.4f} A, MAE={lat_mae:.4f} A")
         print(f"    Rel Error: mean={mean_rel:.2f}%, median={med_rel:.2f}%, max={max_rel:.2f}%")
+        print(f"    Constraint violations: {n_viol}")
 
         # Save radii
         r_df = pd.DataFrame([{"element": el, "radius": r} for el, r in sorted(radii.items())])
         r_df.to_csv(os.path.join(fig_dir, f"radii_{key}.csv"), index=False)
+
+    # ==================================================================
+    # Step 2b: Bootstrap uncertainty estimation
+    # ==================================================================
+    print("\n" + "=" * 70)
+    print("Step 2b: Bootstrap uncertainty estimation (1000 resamples)")
+    print("=" * 70)
+
+    boot_results: Dict[str, Dict] = {}
+    for key, df in datasets.items():
+        print(f"\n  [{CASE_LABELS[key]}]")
+        radii = results[key]["radii"]
+        boot = bootstrap_uncertainty(df, n_bootstrap=1000,
+                                     initial_guess=radii)
+        boot_results[key] = boot
+
+        # Save radii with uncertainty
+        rows_out = []
+        for el in sorted(radii.keys()):
+            rows_out.append({
+                "element": el,
+                "radius": radii[el],
+                "std": boot["std"].get(el, float("nan")),
+                "ci_lower": boot["ci_lower"].get(el, float("nan")),
+                "ci_upper": boot["ci_upper"].get(el, float("nan")),
+            })
+        pd.DataFrame(rows_out).to_csv(
+            os.path.join(fig_dir, f"radii_{key}_bootstrap.csv"), index=False)
+        print(f"    bootstrap success: {boot.get('n_success', 0)}/1000")
 
     # Save CSVs (after radii calculation so lattice_constant_calc is included)
     for key, df in datasets.items():

--- a/hea_radius_estimation.py
+++ b/hea_radius_estimation.py
@@ -38,7 +38,7 @@ from typing import Dict, List, Optional, Tuple
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from scipy.optimize import least_squares
+from scipy.optimize import least_squares, minimize
 
 warnings.filterwarnings("ignore")
 
@@ -328,10 +328,26 @@ class HEARadiusCalculator:
         else:
             x0 = np.array([PAULING_RADII.get(el, 1.4) for el in elements])
 
+        # Pre-computed constants
+        _sqrt2 = np.sqrt(2)
+        _2_over_sqrt3 = 2.0 / np.sqrt(3)
+
+        # Pre-extract compound data for vectorised access
+        _cdata = []
+        for c in compounds:
+            _cdata.append((
+                c.lattice_constant,
+                element_to_idx[c.element_A],
+                element_to_idx[c.element_B],
+                c.count_A, c.count_B,
+                c.structure_type,
+            ))
+
         # --- iterative loop --------------------------------------------------
         current_radii = x0.copy()
         active_contacts: List[str] = []
         n_iterations = 0
+        _bounds = [(0.5, 3.0)] * n_elements
 
         for iteration in range(max_iter):
             # 1. Determine active contact for each compound
@@ -345,48 +361,136 @@ class HEARadiusCalculator:
             active_contacts = new_contacts
             n_iterations = iteration + 1
 
-            # 3. Build smooth residual using fixed active contacts
-            frozen_contacts = list(active_contacts)  # snapshot
+            # 3. Objective: sum of squared residuals for dominant contacts
+            frozen = list(active_contacts)
 
-            def residuals(radii, _contacts=frozen_contacts):
-                res = []
-                for i, c in enumerate(compounds):
-                    a = c.lattice_constant
-                    idx_A = element_to_idx[c.element_A]
-                    idx_B = element_to_idx[c.element_B]
-                    r_A = radii[idx_A]
-                    r_B = radii[idx_B]
-                    ct = _contacts[i]
-
-                    if c.structure_type == "B2":
+            def _objective(radii, _ct=frozen):
+                ssr = 0.0
+                for i, (a, iA, iB, cA, cB, st) in enumerate(_cdata):
+                    rA, rB = radii[iA], radii[iB]
+                    ct = _ct[i]
+                    if st == "B2":
                         if ct == "AA":
-                            res.append(2 * r_A - a)
+                            d = 2.0 * rA - a
                         elif ct == "BB":
-                            res.append(2 * r_B - a)
-                        else:  # AB
-                            res.append((2 / np.sqrt(3)) * (r_A + r_B) - a)
-                    elif c.structure_type == "L12":
-                        if c.count_A > c.count_B:
-                            r_major, r_minor = r_A, r_B
+                            d = 2.0 * rB - a
                         else:
-                            r_major, r_minor = r_B, r_A
+                            d = _2_over_sqrt3 * (rA + rB) - a
+                    else:  # L12
+                        rm = rA if cA > cB else rB
+                        rn = rB if cA > cB else rA
                         if ct == "AA":
-                            res.append(2 * np.sqrt(2) * r_major - a)
+                            d = 2.0 * _sqrt2 * rm - a
                         elif ct == "AB":
-                            res.append(np.sqrt(2) * (r_major + r_minor) - a)
-                        else:  # BB
-                            res.append(2 * r_minor - a)
-                return np.array(res)
+                            d = _sqrt2 * (rm + rn) - a
+                        else:
+                            d = 2.0 * rn - a
+                    ssr += d * d
+                return 0.5 * ssr
 
-            # 4. Optimise with TRF
-            result = least_squares(
-                residuals,
-                current_radii,
-                bounds=(0.5, 3.0),
-                method="trf",
-                ftol=1e-10,
-                xtol=1e-10,
-                gtol=1e-10
+            def _gradient(radii, _ct=frozen):
+                g = np.zeros_like(radii)
+                for i, (a, iA, iB, cA, cB, st) in enumerate(_cdata):
+                    rA, rB = radii[iA], radii[iB]
+                    ct = _ct[i]
+                    if st == "B2":
+                        if ct == "AA":
+                            d = 2.0 * rA - a
+                            g[iA] += 2.0 * d
+                        elif ct == "BB":
+                            d = 2.0 * rB - a
+                            g[iB] += 2.0 * d
+                        else:
+                            d = _2_over_sqrt3 * (rA + rB) - a
+                            g[iA] += _2_over_sqrt3 * d
+                            g[iB] += _2_over_sqrt3 * d
+                    else:  # L12
+                        im = iA if cA > cB else iB
+                        imn = iB if cA > cB else iA
+                        rm, rn = radii[im], radii[imn]
+                        if ct == "AA":
+                            d = 2.0 * _sqrt2 * rm - a
+                            g[im] += 2.0 * _sqrt2 * d
+                        elif ct == "AB":
+                            d = _sqrt2 * (rm + rn) - a
+                            g[im] += _sqrt2 * d
+                            g[imn] += _sqrt2 * d
+                        else:
+                            d = 2.0 * rn - a
+                            g[imn] += 2.0 * d
+                return g
+
+            # 4. Inequality constraints: a_DFT - a_non_dominant >= 0
+            def _ineq_fun(radii, _ct=frozen):
+                vals = []
+                for i, (a, iA, iB, cA, cB, st) in enumerate(_cdata):
+                    rA, rB = radii[iA], radii[iB]
+                    ct = _ct[i]
+                    if st == "B2":
+                        if ct != "AA":
+                            vals.append(a - 2.0 * rA)
+                        if ct != "BB":
+                            vals.append(a - 2.0 * rB)
+                        if ct != "AB":
+                            vals.append(a - _2_over_sqrt3 * (rA + rB))
+                    else:  # L12
+                        rm = rA if cA > cB else rB
+                        rn = rB if cA > cB else rA
+                        if ct != "AA":
+                            vals.append(a - 2.0 * _sqrt2 * rm)
+                        if ct != "AB":
+                            vals.append(a - _sqrt2 * (rm + rn))
+                        if ct != "BB":
+                            vals.append(a - 2.0 * rn)
+                return np.array(vals)
+
+            def _ineq_jac(radii, _ct=frozen):
+                rows = []
+                for i, (a, iA, iB, cA, cB, st) in enumerate(_cdata):
+                    ct = _ct[i]
+                    if st == "B2":
+                        if ct != "AA":
+                            row = np.zeros(n_elements)
+                            row[iA] = -2.0
+                            rows.append(row)
+                        if ct != "BB":
+                            row = np.zeros(n_elements)
+                            row[iB] = -2.0
+                            rows.append(row)
+                        if ct != "AB":
+                            row = np.zeros(n_elements)
+                            row[iA] = -_2_over_sqrt3
+                            row[iB] = -_2_over_sqrt3
+                            rows.append(row)
+                    else:  # L12
+                        im = iA if cA > cB else iB
+                        imn = iB if cA > cB else iA
+                        if ct != "AA":
+                            row = np.zeros(n_elements)
+                            row[im] = -2.0 * _sqrt2
+                            rows.append(row)
+                        if ct != "AB":
+                            row = np.zeros(n_elements)
+                            row[im] = -_sqrt2
+                            row[imn] = -_sqrt2
+                            rows.append(row)
+                        if ct != "BB":
+                            row = np.zeros(n_elements)
+                            row[imn] = -2.0
+                            rows.append(row)
+                if not rows:
+                    return np.empty((0, n_elements))
+                return np.array(rows)
+
+            # 5. Optimise with SLSQP (supports inequality constraints)
+            result = minimize(
+                _objective, current_radii,
+                jac=_gradient,
+                method="SLSQP",
+                bounds=_bounds,
+                constraints={"type": "ineq",
+                             "fun": _ineq_fun, "jac": _ineq_jac},
+                options={"maxiter": 1000, "ftol": 1e-12},
             )
             current_radii = result.x
 
@@ -416,18 +520,98 @@ class HEARadiusCalculator:
         rmse = np.sqrt(np.mean(final_res ** 2))
         mae = np.mean(np.abs(final_res))
 
+        # Count constraint violations (any contact > a_DFT)
+        n_violated = 0
+        for c in compounds:
+            r_A = radii[c.element_A]
+            r_B = radii[c.element_B]
+            a = c.lattice_constant
+            if c.structure_type == "B2":
+                for v in [2 * r_A, 2 * r_B,
+                          _2_over_sqrt3 * (r_A + r_B)]:
+                    if v > a + 1e-6:
+                        n_violated += 1
+            else:
+                if c.count_A > c.count_B:
+                    r_maj, r_min = r_A, r_B
+                else:
+                    r_maj, r_min = r_B, r_A
+                for v in [2 * _sqrt2 * r_maj,
+                          _sqrt2 * (r_maj + r_min),
+                          2 * r_min]:
+                    if v > a + 1e-6:
+                        n_violated += 1
+
         stats = {
             "n_compounds": len(compounds),
             "n_elements": n_elements,
             "rmse": rmse,
             "mae": mae,
             "success": result.success,
-            "cost": result.cost,
-            "optimality": result.optimality,
+            "cost": float(result.fun),
+            "optimality": float(np.max(np.abs(result.jac)))
+                if hasattr(result, "jac") and result.jac is not None
+                else float("nan"),
             "contact_iterations": n_iterations,
+            "n_constraint_violations": n_violated,
         }
 
         return radii, stats
+
+    def bootstrap_uncertainty(
+        self,
+        compounds: List[CompoundData],
+        structure_type: Optional[str] = None,
+        n_bootstrap: int = 1000,
+        random_state: int = 42,
+        initial_guess: Optional[Dict[str, float]] = None,
+    ) -> Dict:
+        """Estimate uncertainty in atomic radii via bootstrap resampling.
+
+        Resamples compounds with replacement, re-optimises for each sample,
+        and returns per-element mean, std, and 95 % confidence intervals.
+        """
+        if structure_type:
+            compounds = [c for c in compounds
+                         if c.structure_type == structure_type]
+        if len(compounds) == 0:
+            return {}
+
+        if initial_guess is None:
+            initial_guess, _ = self.calculate_radii_trf(compounds)
+
+        elements = sorted(initial_guess.keys())
+        n = len(compounds)
+        rng = np.random.RandomState(random_state)
+
+        boot_radii: Dict[str, List[float]] = {el: [] for el in elements}
+
+        for b in range(n_bootstrap):
+            if (b + 1) % 100 == 0:
+                print(f"  bootstrap {b + 1}/{n_bootstrap}")
+            idx = rng.choice(n, size=n, replace=True)
+            sample = [compounds[i] for i in idx]
+            try:
+                r, _ = self.calculate_radii_trf(
+                    sample, initial_guess=initial_guess)
+                for el in elements:
+                    if el in r:
+                        boot_radii[el].append(r[el])
+            except Exception:
+                continue
+
+        out: Dict = {"mean": {}, "std": {},
+                     "ci_lower": {}, "ci_upper": {},
+                     "n_success": 0}
+        for el in elements:
+            vals = np.array(boot_radii[el])
+            if len(vals) > 0:
+                out["mean"][el] = float(np.mean(vals))
+                out["std"][el] = float(np.std(vals))
+                out["ci_lower"][el] = float(np.percentile(vals, 2.5))
+                out["ci_upper"][el] = float(np.percentile(vals, 97.5))
+                out["n_success"] = max(out["n_success"], len(vals))
+        return out
 
     def calculate_all_radii(self) -> None:
         """Calculate radii for B2, L12, and combined datasets."""

--- a/hea_radius_estimation.py
+++ b/hea_radius_estimation.py
@@ -245,41 +245,42 @@ class HEARadiusCalculator:
         return filtered
 
     @staticmethod
-    def _determine_active_contacts(
-        compounds: List[CompoundData],
+    def _determine_active_contacts_vec(
         radii_arr: np.ndarray,
-        element_to_idx: Dict[str, int]
-    ) -> List[str]:
-        """Determine the active (dominant) contact condition for each compound.
+        iA_arr: np.ndarray, iB_arr: np.ndarray,
+        im_arr: np.ndarray, in_arr: np.ndarray,
+        is_b2: np.ndarray,
+    ) -> np.ndarray:
+        """Vectorised active-contact determination for mixed B2/L12.
 
-        Returns a list of contact labels, one per compound:
-          B2:  'AA', 'BB', or 'AB'
-          L12: 'AA', 'AB', or 'BB'
+        Returns integer codes per compound:
+          B2:  0=AA, 1=BB, 2=AB
+          L12: 0=AA, 1=AB, 2=BB
         """
-        contacts = []
-        for c in compounds:
-            idx_A = element_to_idx[c.element_A]
-            idx_B = element_to_idx[c.element_B]
-            r_A = radii_arr[idx_A]
-            r_B = radii_arr[idx_B]
+        _sqrt2 = np.sqrt(2)
+        _2s3 = 2.0 / np.sqrt(3)
+        n = len(iA_arr)
+        ct = np.zeros(n, dtype=np.intp)
 
-            if c.structure_type == "B2":
-                a_AA = 2 * r_A
-                a_BB = 2 * r_B
-                a_AB = (2 / np.sqrt(3)) * (r_A + r_B)
-                vals = {"AA": a_AA, "BB": a_BB, "AB": a_AB}
-                contacts.append(max(vals, key=vals.get))
-            elif c.structure_type == "L12":
-                if c.count_A > c.count_B:
-                    r_major, r_minor = r_A, r_B
-                else:
-                    r_major, r_minor = r_B, r_A
-                a_AA = 2 * np.sqrt(2) * r_major
-                a_AB = np.sqrt(2) * (r_major + r_minor)
-                a_BB = 2 * r_minor
-                vals = {"AA": a_AA, "AB": a_AB, "BB": a_BB}
-                contacts.append(max(vals, key=vals.get))
-        return contacts
+        # B2 compounds
+        bm = is_b2
+        if bm.any():
+            rA = radii_arr[iA_arr[bm]]
+            rB = radii_arr[iB_arr[bm]]
+            stk = np.column_stack([2.0 * rA, 2.0 * rB,
+                                   _2s3 * (rA + rB)])
+            ct[bm] = stk.argmax(axis=1)
+
+        # L12 compounds
+        lm = ~is_b2
+        if lm.any():
+            rm = radii_arr[im_arr[lm]]
+            rn = radii_arr[in_arr[lm]]
+            stk = np.column_stack([2.0 * _sqrt2 * rm,
+                                   _sqrt2 * (rm + rn),
+                                   2.0 * rn])
+            ct[lm] = stk.argmax(axis=1)
+        return ct
 
     def calculate_radii_trf(
         self,
@@ -288,23 +289,15 @@ class HEARadiusCalculator:
         initial_guess: Optional[Dict[str, float]] = None,
         max_iter: int = 50
     ) -> Tuple[Dict[str, float], Dict]:
-        """
-        Calculate effective atomic radii using iterative TRF optimisation.
+        """Calculate effective atomic radii using iterative constrained
+        optimisation (SLSQP) with fully vectorised inner functions.
 
         At each iteration the dominant contact condition (max) is determined
-        for every compound from the current radii.  A smooth least-squares
-        sub-problem is then solved using only that fixed contact condition.
-        The loop repeats until no compound switches its active contact,
-        guaranteeing self-consistent radii.
-
-        Args:
-            compounds: List of compound data
-            structure_type: "B2", "L12", or None for combined
-            initial_guess: Initial radius values for optimization
-            max_iter: Maximum number of contact-reassignment iterations
-
-        Returns:
-            Tuple of (radii dict, statistics dict)
+        for every compound from the current radii.  A constrained optimisation
+        sub-problem is then solved: the objective minimises residuals for the
+        active contacts while inequality constraints enforce that every
+        non-dominant contact satisfies a_contact <= a_DFT.  The loop repeats
+        until no compound switches its active contact (self-consistent radii).
         """
         if structure_type:
             compounds = [c for c in compounds if c.structure_type == structure_type]
@@ -328,161 +321,172 @@ class HEARadiusCalculator:
         else:
             x0 = np.array([PAULING_RADII.get(el, 1.4) for el in elements])
 
-        # Pre-computed constants
         _sqrt2 = np.sqrt(2)
-        _2_over_sqrt3 = 2.0 / np.sqrt(3)
+        _2s3 = 2.0 / np.sqrt(3)
 
-        # Pre-extract compound data for vectorised access
-        _cdata = []
-        for c in compounds:
-            _cdata.append((
-                c.lattice_constant,
-                element_to_idx[c.element_A],
-                element_to_idx[c.element_B],
-                c.count_A, c.count_B,
-                c.structure_type,
-            ))
+        # Pre-extract numpy arrays (done once)
+        n_comp = len(compounds)
+        a_vals = np.array([c.lattice_constant for c in compounds])
+        iA_arr = np.array([element_to_idx[c.element_A] for c in compounds],
+                          dtype=np.intp)
+        iB_arr = np.array([element_to_idx[c.element_B] for c in compounds],
+                          dtype=np.intp)
+        cA_arr = np.array([c.count_A for c in compounds])
+        cB_arr = np.array([c.count_B for c in compounds])
+        is_b2 = np.array([c.structure_type == "B2" for c in compounds])
+        is_l12 = ~is_b2
 
-        # --- iterative loop --------------------------------------------------
+        # major/minor indices for L12
+        is_A_major = cA_arr > cB_arr
+        im_arr = np.where(is_A_major, iA_arr, iB_arr)
+        in_arr = np.where(is_A_major, iB_arr, iA_arr)
+
+        # --- iterative loop ---
         current_radii = x0.copy()
-        active_contacts: List[str] = []
+        prev_ct = np.full(n_comp, -1, dtype=np.intp)
         n_iterations = 0
         _bounds = [(0.5, 3.0)] * n_elements
 
         for iteration in range(max_iter):
-            # 1. Determine active contact for each compound
-            new_contacts = self._determine_active_contacts(
-                compounds, current_radii, element_to_idx
-            )
+            ct = self._determine_active_contacts_vec(
+                current_radii, iA_arr, iB_arr, im_arr, in_arr, is_b2)
 
-            # 2. Check convergence (no contact switches)
-            if new_contacts == active_contacts:
+            if np.array_equal(ct, prev_ct):
                 break
-            active_contacts = new_contacts
+            prev_ct = ct.copy()
             n_iterations = iteration + 1
 
-            # 3. Objective: sum of squared residuals for dominant contacts
-            frozen = list(active_contacts)
+            # --- masks for B2 contacts ---
+            b2_AA = is_b2 & (ct == 0)
+            b2_BB = is_b2 & (ct == 1)
+            b2_AB = is_b2 & (ct == 2)
+            # --- masks for L12 contacts ---
+            l12_AA = is_l12 & (ct == 0)
+            l12_AB = is_l12 & (ct == 1)
+            l12_BB = is_l12 & (ct == 2)
 
-            def _objective(radii, _ct=frozen):
-                ssr = 0.0
-                for i, (a, iA, iB, cA, cB, st) in enumerate(_cdata):
-                    rA, rB = radii[iA], radii[iB]
-                    ct = _ct[i]
-                    if st == "B2":
-                        if ct == "AA":
-                            d = 2.0 * rA - a
-                        elif ct == "BB":
-                            d = 2.0 * rB - a
-                        else:
-                            d = _2_over_sqrt3 * (rA + rB) - a
-                    else:  # L12
-                        rm = rA if cA > cB else rB
-                        rn = rB if cA > cB else rA
-                        if ct == "AA":
-                            d = 2.0 * _sqrt2 * rm - a
-                        elif ct == "AB":
-                            d = _sqrt2 * (rm + rn) - a
-                        else:
-                            d = 2.0 * rn - a
-                    ssr += d * d
-                return 0.5 * ssr
+            # ---- vectorised objective ----
+            def _objective(radii,
+                           _b2AA=b2_AA, _b2BB=b2_BB, _b2AB=b2_AB,
+                           _l12AA=l12_AA, _l12AB=l12_AB, _l12BB=l12_BB):
+                rA = radii[iA_arr]; rB = radii[iB_arr]
+                rm = radii[im_arr]; rn = radii[in_arr]
+                d = np.empty(n_comp)
+                d[_b2AA] = 2.0 * rA[_b2AA] - a_vals[_b2AA]
+                d[_b2BB] = 2.0 * rB[_b2BB] - a_vals[_b2BB]
+                d[_b2AB] = _2s3 * (rA[_b2AB] + rB[_b2AB]) - a_vals[_b2AB]
+                d[_l12AA] = 2.0 * _sqrt2 * rm[_l12AA] - a_vals[_l12AA]
+                d[_l12AB] = _sqrt2 * (rm[_l12AB] + rn[_l12AB]) - a_vals[_l12AB]
+                d[_l12BB] = 2.0 * rn[_l12BB] - a_vals[_l12BB]
+                return 0.5 * np.dot(d, d)
 
-            def _gradient(radii, _ct=frozen):
-                g = np.zeros_like(radii)
-                for i, (a, iA, iB, cA, cB, st) in enumerate(_cdata):
-                    rA, rB = radii[iA], radii[iB]
-                    ct = _ct[i]
-                    if st == "B2":
-                        if ct == "AA":
-                            d = 2.0 * rA - a
-                            g[iA] += 2.0 * d
-                        elif ct == "BB":
-                            d = 2.0 * rB - a
-                            g[iB] += 2.0 * d
-                        else:
-                            d = _2_over_sqrt3 * (rA + rB) - a
-                            g[iA] += _2_over_sqrt3 * d
-                            g[iB] += _2_over_sqrt3 * d
-                    else:  # L12
-                        im = iA if cA > cB else iB
-                        imn = iB if cA > cB else iA
-                        rm, rn = radii[im], radii[imn]
-                        if ct == "AA":
-                            d = 2.0 * _sqrt2 * rm - a
-                            g[im] += 2.0 * _sqrt2 * d
-                        elif ct == "AB":
-                            d = _sqrt2 * (rm + rn) - a
-                            g[im] += _sqrt2 * d
-                            g[imn] += _sqrt2 * d
-                        else:
-                            d = 2.0 * rn - a
-                            g[imn] += 2.0 * d
+            def _gradient(radii,
+                          _b2AA=b2_AA, _b2BB=b2_BB, _b2AB=b2_AB,
+                          _l12AA=l12_AA, _l12AB=l12_AB, _l12BB=l12_BB):
+                rA = radii[iA_arr]; rB = radii[iB_arr]
+                rm = radii[im_arr]; rn = radii[in_arr]
+                d = np.empty(n_comp)
+                d[_b2AA] = 2.0 * rA[_b2AA] - a_vals[_b2AA]
+                d[_b2BB] = 2.0 * rB[_b2BB] - a_vals[_b2BB]
+                d[_b2AB] = _2s3 * (rA[_b2AB] + rB[_b2AB]) - a_vals[_b2AB]
+                d[_l12AA] = 2.0 * _sqrt2 * rm[_l12AA] - a_vals[_l12AA]
+                d[_l12AB] = _sqrt2 * (rm[_l12AB] + rn[_l12AB]) - a_vals[_l12AB]
+                d[_l12BB] = 2.0 * rn[_l12BB] - a_vals[_l12BB]
+                g = np.zeros(n_elements)
+                # B2
+                np.add.at(g, iA_arr[_b2AA], 2.0 * d[_b2AA])
+                np.add.at(g, iB_arr[_b2BB], 2.0 * d[_b2BB])
+                np.add.at(g, iA_arr[_b2AB], _2s3 * d[_b2AB])
+                np.add.at(g, iB_arr[_b2AB], _2s3 * d[_b2AB])
+                # L12
+                np.add.at(g, im_arr[_l12AA], 2.0 * _sqrt2 * d[_l12AA])
+                np.add.at(g, im_arr[_l12AB], _sqrt2 * d[_l12AB])
+                np.add.at(g, in_arr[_l12AB], _sqrt2 * d[_l12AB])
+                np.add.at(g, in_arr[_l12BB], 2.0 * d[_l12BB])
                 return g
 
-            # 4. Inequality constraints: a_DFT - a_non_dominant >= 0
-            def _ineq_fun(radii, _ct=frozen):
-                vals = []
-                for i, (a, iA, iB, cA, cB, st) in enumerate(_cdata):
-                    rA, rB = radii[iA], radii[iB]
-                    ct = _ct[i]
-                    if st == "B2":
-                        if ct != "AA":
-                            vals.append(a - 2.0 * rA)
-                        if ct != "BB":
-                            vals.append(a - 2.0 * rB)
-                        if ct != "AB":
-                            vals.append(a - _2_over_sqrt3 * (rA + rB))
-                    else:  # L12
-                        rm = rA if cA > cB else rB
-                        rn = rB if cA > cB else rA
-                        if ct != "AA":
-                            vals.append(a - 2.0 * _sqrt2 * rm)
-                        if ct != "AB":
-                            vals.append(a - _sqrt2 * (rm + rn))
-                        if ct != "BB":
-                            vals.append(a - 2.0 * rn)
-                return np.array(vals)
+            # ---- inequality constraints (constant Jacobian) ----
+            c_idx_list: List[int] = []
+            c_type_list: List[int] = []
+            c_is_b2_list: List[bool] = []
+            for i in range(n_comp):
+                c = ct[i]
+                if is_b2[i]:
+                    if c != 0: c_idx_list.append(i); c_type_list.append(0); c_is_b2_list.append(True)
+                    if c != 1: c_idx_list.append(i); c_type_list.append(1); c_is_b2_list.append(True)
+                    if c != 2: c_idx_list.append(i); c_type_list.append(2); c_is_b2_list.append(True)
+                else:
+                    if c != 0: c_idx_list.append(i); c_type_list.append(0); c_is_b2_list.append(False)
+                    if c != 1: c_idx_list.append(i); c_type_list.append(1); c_is_b2_list.append(False)
+                    if c != 2: c_idx_list.append(i); c_type_list.append(2); c_is_b2_list.append(False)
 
-            def _ineq_jac(radii, _ct=frozen):
-                rows = []
-                for i, (a, iA, iB, cA, cB, st) in enumerate(_cdata):
-                    ct = _ct[i]
-                    if st == "B2":
-                        if ct != "AA":
-                            row = np.zeros(n_elements)
-                            row[iA] = -2.0
-                            rows.append(row)
-                        if ct != "BB":
-                            row = np.zeros(n_elements)
-                            row[iB] = -2.0
-                            rows.append(row)
-                        if ct != "AB":
-                            row = np.zeros(n_elements)
-                            row[iA] = -_2_over_sqrt3
-                            row[iB] = -_2_over_sqrt3
-                            rows.append(row)
-                    else:  # L12
-                        im = iA if cA > cB else iB
-                        imn = iB if cA > cB else iA
-                        if ct != "AA":
-                            row = np.zeros(n_elements)
-                            row[im] = -2.0 * _sqrt2
-                            rows.append(row)
-                        if ct != "AB":
-                            row = np.zeros(n_elements)
-                            row[im] = -_sqrt2
-                            row[imn] = -_sqrt2
-                            rows.append(row)
-                        if ct != "BB":
-                            row = np.zeros(n_elements)
-                            row[imn] = -2.0
-                            rows.append(row)
-                if not rows:
+            n_ineq = len(c_idx_list)
+            if n_ineq > 0:
+                ci = np.array(c_idx_list, dtype=np.intp)
+                ctp = np.array(c_type_list, dtype=np.intp)
+                c_b2 = np.array(c_is_b2_list)
+                c_a = a_vals[ci]
+
+                # B2 constraint masks
+                cb2_AA = c_b2 & (ctp == 0)
+                cb2_BB = c_b2 & (ctp == 1)
+                cb2_AB = c_b2 & (ctp == 2)
+                # L12 constraint masks
+                cl_AA = (~c_b2) & (ctp == 0)
+                cl_AB = (~c_b2) & (ctp == 1)
+                cl_BB = (~c_b2) & (ctp == 2)
+
+                c_iA = iA_arr[ci]; c_iB = iB_arr[ci]
+                c_im = im_arr[ci]; c_in = in_arr[ci]
+
+                def _ineq_fun(radii,
+                              _cb2AA=cb2_AA, _cb2BB=cb2_BB, _cb2AB=cb2_AB,
+                              _clAA=cl_AA, _clAB=cl_AB, _clBB=cl_BB):
+                    rA = radii[c_iA]; rB = radii[c_iB]
+                    rm = radii[c_im]; rn = radii[c_in]
+                    v = np.empty(n_ineq)
+                    v[_cb2AA] = c_a[_cb2AA] - 2.0 * rA[_cb2AA]
+                    v[_cb2BB] = c_a[_cb2BB] - 2.0 * rB[_cb2BB]
+                    v[_cb2AB] = c_a[_cb2AB] - _2s3 * (rA[_cb2AB] + rB[_cb2AB])
+                    v[_clAA] = c_a[_clAA] - 2.0 * _sqrt2 * rm[_clAA]
+                    v[_clAB] = c_a[_clAB] - _sqrt2 * (rm[_clAB] + rn[_clAB])
+                    v[_clBB] = c_a[_clBB] - 2.0 * rn[_clBB]
+                    return v
+
+                # Pre-compute constant Jacobian
+                jac = np.zeros((n_ineq, n_elements))
+                for mask, col_arr, coeff in [
+                    (cb2_AA, c_iA, -2.0),
+                    (cb2_BB, c_iB, -2.0),
+                ]:
+                    rows_idx = np.where(mask)[0]
+                    if len(rows_idx): jac[rows_idx, col_arr[rows_idx]] += coeff
+                # B2 AB
+                ab_rows = np.where(cb2_AB)[0]
+                if len(ab_rows):
+                    jac[ab_rows, c_iA[ab_rows]] += -_2s3
+                    jac[ab_rows, c_iB[ab_rows]] += -_2s3
+                # L12 AA
+                aa_rows = np.where(cl_AA)[0]
+                if len(aa_rows): jac[aa_rows, c_im[aa_rows]] += -2.0 * _sqrt2
+                # L12 AB
+                ab_rows = np.where(cl_AB)[0]
+                if len(ab_rows):
+                    jac[ab_rows, c_im[ab_rows]] += -_sqrt2
+                    jac[ab_rows, c_in[ab_rows]] += -_sqrt2
+                # L12 BB
+                bb_rows = np.where(cl_BB)[0]
+                if len(bb_rows): jac[bb_rows, c_in[bb_rows]] += -2.0
+
+                _const_jac = jac
+                def _ineq_jac(radii):
+                    return _const_jac
+            else:
+                def _ineq_fun(radii):
+                    return np.array([])
+                def _ineq_jac(radii):
                     return np.empty((0, n_elements))
-                return np.array(rows)
 
-            # 5. Optimise with SLSQP (supports inequality constraints)
             result = minimize(
                 _objective, current_radii,
                 jac=_gradient,
@@ -494,59 +498,44 @@ class HEARadiusCalculator:
             )
             current_radii = result.x
 
-        # --- final statistics using the max-based lattice constant ------------
+        # --- final statistics (vectorised) ---
         radii = {el: current_radii[element_to_idx[el]] for el in elements}
 
-        # Compute residuals with max (the true model) for final stats
-        final_res = []
-        for c in compounds:
-            r_A = radii[c.element_A]
-            r_B = radii[c.element_B]
-            if c.structure_type == "B2":
-                a_calc = max(2 * r_A, 2 * r_B, (2 / np.sqrt(3)) * (r_A + r_B))
-            else:
-                if c.count_A > c.count_B:
-                    r_major, r_minor = r_A, r_B
-                else:
-                    r_major, r_minor = r_B, r_A
-                a_calc = max(
-                    2 * np.sqrt(2) * r_major,
-                    np.sqrt(2) * (r_major + r_minor),
-                    2 * r_minor
-                )
-            final_res.append(a_calc - c.lattice_constant)
-        final_res = np.array(final_res)
+        rA_f = np.array([radii[c.element_A] for c in compounds])
+        rB_f = np.array([radii[c.element_B] for c in compounds])
+        rm_f = np.where(is_A_major, rA_f, rB_f)
+        rn_f = np.where(is_A_major, rB_f, rA_f)
 
-        rmse = np.sqrt(np.mean(final_res ** 2))
-        mae = np.mean(np.abs(final_res))
+        a_calc = np.empty(n_comp)
+        if is_b2.any():
+            a_calc[is_b2] = np.maximum(
+                np.maximum(2 * rA_f[is_b2], 2 * rB_f[is_b2]),
+                _2s3 * (rA_f[is_b2] + rB_f[is_b2]))
+        if is_l12.any():
+            a_calc[is_l12] = np.maximum(
+                np.maximum(2 * _sqrt2 * rm_f[is_l12],
+                           _sqrt2 * (rm_f[is_l12] + rn_f[is_l12])),
+                2 * rn_f[is_l12])
+        final_res = a_calc - a_vals
 
-        # Count constraint violations (any contact > a_DFT)
+        # constraint violations (vectorised)
         n_violated = 0
-        for c in compounds:
-            r_A = radii[c.element_A]
-            r_B = radii[c.element_B]
-            a = c.lattice_constant
-            if c.structure_type == "B2":
-                for v in [2 * r_A, 2 * r_B,
-                          _2_over_sqrt3 * (r_A + r_B)]:
-                    if v > a + 1e-6:
-                        n_violated += 1
-            else:
-                if c.count_A > c.count_B:
-                    r_maj, r_min = r_A, r_B
-                else:
-                    r_maj, r_min = r_B, r_A
-                for v in [2 * _sqrt2 * r_maj,
-                          _sqrt2 * (r_maj + r_min),
-                          2 * r_min]:
-                    if v > a + 1e-6:
-                        n_violated += 1
+        if is_b2.any():
+            b2c = np.column_stack([2 * rA_f[is_b2], 2 * rB_f[is_b2],
+                                   _2s3 * (rA_f[is_b2] + rB_f[is_b2])])
+            n_violated += int(np.sum(b2c > a_vals[is_b2, None] + 1e-6))
+        if is_l12.any():
+            l12c = np.column_stack([
+                2 * _sqrt2 * rm_f[is_l12],
+                _sqrt2 * (rm_f[is_l12] + rn_f[is_l12]),
+                2 * rn_f[is_l12]])
+            n_violated += int(np.sum(l12c > a_vals[is_l12, None] + 1e-6))
 
         stats = {
             "n_compounds": len(compounds),
             "n_elements": n_elements,
-            "rmse": rmse,
-            "mae": mae,
+            "rmse": float(np.sqrt(np.mean(final_res ** 2))),
+            "mae": float(np.mean(np.abs(final_res))),
             "success": result.success,
             "cost": float(result.fun),
             "optimality": float(np.max(np.abs(result.jac)))
@@ -593,7 +582,7 @@ class HEARadiusCalculator:
             sample = [compounds[i] for i in idx]
             try:
                 r, _ = self.calculate_radii_trf(
-                    sample, initial_guess=initial_guess)
+                    sample, max_iter=10, initial_guess=initial_guess)
                 for el in elements:
                     if el in r:
                         boot_radii[el].append(r[el])


### PR DESCRIPTION
## Summary

Replaces the unconstrained TRF least-squares optimizer with **SLSQP constrained optimization** and adds **Bootstrap uncertainty estimation** for effective atomic radii, applied to both `four_case_comparison_study.py` and `hea_radius_estimation.py`.

### Core changes

1. **Inequality constraints (SLSQP)**: For each compound, the dominant contact condition (max) is used as the objective residual. All non-dominant contacts are enforced as inequality constraints (`a_contact ≤ a_DFT`), ensuring physically valid radii. The iterative contact-determination loop is preserved for self-consistency.

2. **Vectorized inner functions**: All objective, gradient, and constraint evaluations replaced with numpy vectorized operations (`np.add.at()` for gradient accumulation, boolean masks for contact-type dispatch). Constraint Jacobian is pre-computed once per iteration (linear in radii → constant).

3. **Parallel Bootstrap**: 1000 bootstrap resamples parallelized across 8 CPU cores via `multiprocessing.Pool` + `imap_unordered`. `threadpool_limits(limits=1)` prevents BLAS thread contention (~2.8× speedup over naive multiprocessing).

4. **`hea_radius_estimation.py`**: Same vectorized SLSQP + bootstrap applied to the class-based implementation (handles mixed B2/L1₂ datasets).

### Performance (benchmarked)

| Case | Bootstrap time (8 cores) |
|------|-------------------------|
| MP B2 (357 compounds) | ~3.3 min |
| MP L1₂ (848 compounds) | ~17 min |
| OQMD B2 (2539 compounds) | ~73 min |
| OQMD L1₂ (238 compounds) | ~2.4 min |

**Note**: Output files (CSVs, figures) will be added in a follow-up commit once the full 4-case analysis completes.

## Review & Testing Checklist for Human

- [ ] **Vectorized gradient correctness**: Verify `np.add.at()` accumulation in `_grad` functions matches the analytical partial derivatives for each contact type (B2: AA/BB/AB, L1₂: AA/AB/BB). A single sign or coefficient error would silently produce wrong radii. Cross-check against the loop-based version in git history.
- [ ] **Contact-type encoding consistency**: B2 uses column order `[AA, BB, AB]` → codes `0,1,2`; L1₂ uses `[AA, AB, BB]` → codes `0,1,2`. Confirm this mapping is consistent across `_determine_active_contacts_vec`, objective masks, and constraint construction in both files.
- [ ] **Constraint Jacobian construction**: The `jac[rows_idx, col_arr[rows_idx]] += coeff` pattern assumes no duplicate `(row, col)` entries. Verify this holds for all structure types (each constraint row should touch at most 2 element columns).
- [ ] **`threadpoolctl` dependency**: `from threadpoolctl import threadpool_limits` is a new import — confirm it's available in the target environment or add to requirements.
- [ ] **Run the 4-case analysis end-to-end** and verify: (a) RMSE/MAE values are physically reasonable, (b) constraint violation counts decrease vs. unconstrained, (c) bootstrap success rate > 90%, (d) CSV outputs include `std`, `ci_lower`, `ci_upper` columns.

### Notes
- Dead code: `_CT_AA`, `_CT_BB`, `_CT_AB`, `_B2_CODES`, `_L12_CODES` constants are defined but unused — can be removed.
- Module-level globals (`_BOOT_DF`, `_BOOT_GUESS`, `_BOOT_STYPE`) are used for multiprocessing data sharing — standard pattern but not thread-safe for concurrent calls.
- Bootstrap `max_iter=10` (vs. 50 for main optimization) is a deliberate trade-off for speed; may slightly undercount convergence failures in edge cases.

Link to Devin session: https://app.devin.ai/sessions/3f012e4c735d4430b933c09370eb2065
Requested by: @minimumtone