### PR TITLE
fix: use os.path.basename() for CONTCAR source detection

### DIFF
--- a/vasp_inputs/extract_vasp_results.py
+++ b/vasp_inputs/extract_vasp_results.py
@@ -100,7 +100,7 @@ def read_lattice_constant(calc_dir):
         except Exception:
             pass
 
-    src_name = 'CONTCAR' if 'CONTCAR' in source else 'POSCAR'
+    src_name = 'CONTCAR' if os.path.basename(source) == 'CONTCAR' else 'POSCAR'
     return lattice_const, converged, src_name
 
 


### PR DESCRIPTION
## Summary

`extract_vasp_results.py` の `read_lattice_constant()` で、`'CONTCAR' in source` の部分文字列チェックを `os.path.basename(source) == 'CONTCAR'` に修正。

親ディレクトリ名に "CONTCAR" が含まれる場合（例: `/data/CONTCAR_backup/BCC_B2/Ag1Al1/POSCAR`）に、POSCARを誤ってCONTCARと判定するバグを防止。

## Review & Testing Checklist for Human
- [ ] 1行の修正のみ — `os.path.basename()` で正しくファイル名のみをチェックしていることを確認

### Notes
- Devin Reviewの指摘 (PR #165 comment 3166102647) への対応

Link to Devin session: https://app.devin.ai/sessions/aa336d0f2b374126a139328ec9469942
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
