### PR TITLE
feat: extract_bib v2 — 1万件スケール対応 + Streamlit UI + 文献検索エンジン

### DIFF
--- a/extract_bib.py
+++ b/extract_bib.py
@@ -25,6 +25,7 @@ import logging
 import os
 import re
 import sys
+import threading
 import time
 import unicodedata
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -79,11 +80,12 @@ def file_sha256(path: str, chunk_size: int = 1 << 20) -> str:
 # ---------------------------------------------------------------------------
 
 class Checkpoint:
-    """SHA-256 → メタデータ のマッピングを JSON で永続化。"""
+    """SHA-256 → メタデータ のマッピングを JSON で永続化。スレッドセーフ。"""
 
     def __init__(self, path: str = ".extract_bib_checkpoint.json"):
         self.path = Path(path)
         self._data: Dict[str, Dict] = {}
+        self._lock = threading.Lock()
         self._load()
 
     def _load(self) -> None:
@@ -96,24 +98,31 @@ class Checkpoint:
                 self._data = {}
 
     def save(self) -> None:
+        with self._lock:
+            snapshot = dict(self._data)
         tmp = self.path.with_suffix(".tmp")
-        tmp.write_text(json.dumps(self._data, ensure_ascii=False, indent=1), encoding="utf-8")
+        tmp.write_text(json.dumps(snapshot, ensure_ascii=False, indent=1), encoding="utf-8")
         tmp.replace(self.path)
 
     def is_done(self, sha: str) -> bool:
-        return sha in self._data
+        with self._lock:
+            return sha in self._data
 
     def get(self, sha: str) -> Optional[Dict]:
-        return self._data.get(sha)
+        with self._lock:
+            return self._data.get(sha)
 
     def put(self, sha: str, meta: Dict) -> None:
-        self._data[sha] = meta
+        with self._lock:
+            self._data[sha] = meta
 
     def all_entries(self) -> List[Dict]:
-        return list(self._data.values())
+        with self._lock:
+            return list(self._data.values())
 
     def __len__(self) -> int:
-        return len(self._data)
+        with self._lock:
+            return len(self._data)
 
 
 # ---------------------------------------------------------------------------
@@ -359,17 +368,20 @@ def _process_one(
     base_url: Optional[str],
     api_key: Optional[str],
 ) -> Optional[Dict]:
-    """PDF 1 ファイルを処理。チェックポイント済みならスキップ。"""
+    """PDF 1 ファイルを処理。チェックポイント済みならスキップ。
+
+    Returns (meta, is_new): is_new=False ならキャッシュからの取得。
+    """
     sha = file_sha256(pdf_path)
 
     if checkpoint.is_done(sha):
         log.info("  [skip/hash] %s (処理済み)", Path(pdf_path).name)
-        return checkpoint.get(sha)
+        return checkpoint.get(sha), False
 
     text = extract_text_from_pdf(pdf_path)
     if len(text.strip()) < 100:
         log.warning("  [skip/short] %s テキスト不足", Path(pdf_path).name)
-        return None
+        return None, False
 
     meta = get_metadata_via_ai(
         text, provider=provider, model=model, base_url=base_url, api_key=api_key,
@@ -378,7 +390,7 @@ def _process_one(
     meta["_sha256"] = sha
 
     checkpoint.put(sha, meta)
-    return meta
+    return meta, True
 
 
 # ---------------------------------------------------------------------------
@@ -410,21 +422,25 @@ def run_batch(
 
     def _worker(pdf_path: str) -> tuple:
         try:
-            meta = _process_one(pdf_path, checkpoint, provider, model, base_url, api_key)
-            return pdf_path, meta, None
+            meta, is_new = _process_one(pdf_path, checkpoint, provider, model, base_url, api_key)
+            return pdf_path, meta, is_new, None
         except Exception as e:
-            return pdf_path, None, str(e)
+            return pdf_path, None, False, str(e)
+
+    new_entries: List[Dict] = []
 
     with ThreadPoolExecutor(max_workers=workers) as pool:
         futures = {pool.submit(_worker, p): p for p in pdfs}
         for future in as_completed(futures):
-            pdf_path, meta, error = future.result()
+            pdf_path, meta, is_new, error = future.result()
             done_count += 1
 
             if error:
                 log.error("  [error] %s: %s", Path(pdf_path).name, error)
             elif meta:
                 results.append(meta)
+                if is_new:
+                    new_entries.append(meta)
                 log.info(
                     "  [%d/%d] %s → %s",
                     done_count, total,
@@ -440,8 +456,9 @@ def run_batch(
 
     checkpoint.save()
 
-    write_bib(bib_path, results)
-    log.info("=== 完了: %d/%d 件を処理 ===", len(results), total)
+    if new_entries:
+        write_bib(bib_path, new_entries)
+    log.info("=== 完了: %d/%d 件を処理 (新規 %d 件) ===", len(results), total, len(new_entries))
     return results
 
 

--- a/extract_bib.py
+++ b/extract_bib.py
@@ -1,28 +1,42 @@
 #!/usr/bin/env python3
 """
-extract_bib.py — PDFから論文メタデータをAIで抽出しBibTeXに保存するツール
+extract_bib.py — PDFから論文メタデータをAIで抽出しBibTeXに保存するツール (v2)
 
 機能:
-  - PDF からテキストを抽出 (pymupdf4llm)
-  - OpenAI API でタイトル・著者・DOI に加え、
-    materials / theory / methods / summary_ja を抽出
-  - JabRef 互換の .bib ファイルへ出力
-    (カスタムフィールド materials, theory, methods + comment に日本語要約)
+  - PDF からテキストを抽出 (pymupdf4llm / PyMuPDF)
+  - OpenAI API または LM Studio (ローカルLLM) でメタデータ抽出
+    (title, authors, doi, materials, theory, methods, summary_ja)
+  - SHA-256 ハッシュによるチェックポイント管理
+    → PDF の置き場所が変わっても処理済みファイルを再処理しない
+  - DOI ベース重複検出
+  - 並行処理 (ThreadPoolExecutor) で 1万ファイル規模に対応
+  - JabRef 互換 .bib ファイルへ出力
 
 使い方:
-  python extract_bib.py paper1.pdf paper2.pdf ...
-  python extract_bib.py --input-dir ./papers/
-  python extract_bib.py paper.pdf --output my_library.bib
+  python extract_bib.py -d ./papers/
+  python extract_bib.py -d ./papers/ --workers 8 --provider lmstudio
+  python extract_bib.py paper1.pdf paper2.pdf -o my_library.bib
 """
 
 import argparse
+import hashlib
 import json
+import logging
 import os
 import re
 import sys
+import time
 import unicodedata
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # PDF → テキスト
@@ -45,7 +59,65 @@ def extract_text_from_pdf(pdf_path: str, max_chars: int = 80_000) -> str:
 
 
 # ---------------------------------------------------------------------------
-# OpenAI メタデータ抽出
+# SHA-256 ハッシュ (パス非依存の識別子)
+# ---------------------------------------------------------------------------
+
+def file_sha256(path: str, chunk_size: int = 1 << 20) -> str:
+    """ファイルの SHA-256 ハッシュを返す。"""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        while True:
+            chunk = f.read(chunk_size)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# チェックポイント管理
+# ---------------------------------------------------------------------------
+
+class Checkpoint:
+    """SHA-256 → メタデータ のマッピングを JSON で永続化。"""
+
+    def __init__(self, path: str = ".extract_bib_checkpoint.json"):
+        self.path = Path(path)
+        self._data: Dict[str, Dict] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if self.path.exists():
+            try:
+                self._data = json.loads(self.path.read_text(encoding="utf-8"))
+                log.info("チェックポイント読み込み: %d 件", len(self._data))
+            except (json.JSONDecodeError, OSError) as e:
+                log.warning("チェックポイント読み込み失敗 (%s), 新規作成", e)
+                self._data = {}
+
+    def save(self) -> None:
+        tmp = self.path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(self._data, ensure_ascii=False, indent=1), encoding="utf-8")
+        tmp.replace(self.path)
+
+    def is_done(self, sha: str) -> bool:
+        return sha in self._data
+
+    def get(self, sha: str) -> Optional[Dict]:
+        return self._data.get(sha)
+
+    def put(self, sha: str, meta: Dict) -> None:
+        self._data[sha] = meta
+
+    def all_entries(self) -> List[Dict]:
+        return list(self._data.values())
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+
+# ---------------------------------------------------------------------------
+# LLM クライアント (OpenAI / LM Studio 共通)
 # ---------------------------------------------------------------------------
 
 SYSTEM_MSG = (
@@ -64,30 +136,86 @@ SYSTEM_MSG = (
     "回答はJSONオブジェクトのみ（マークダウンのコードブロック不要）。"
 )
 
+DEFAULT_PROVIDERS: Dict[str, Dict[str, Any]] = {
+    "openai": {
+        "base_url": None,
+        "model": "gpt-4o",
+        "api_key_env": "OPENAI_API_KEY",
+        "api_key_required": True,
+    },
+    "lmstudio": {
+        "base_url": "http://localhost:1234/v1",
+        "model": "local-model",
+        "api_key_env": None,
+        "api_key_required": False,
+    },
+}
 
-def get_metadata_via_ai(text: str, model: str = "gpt-4o") -> Dict:
-    """OpenAI API を使って論文テキストからメタデータを抽出する。"""
+
+def _build_client(
+    provider: str = "openai",
+    base_url: Optional[str] = None,
+    model: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> tuple:
+    """OpenAI 互換クライアントと使用モデル名を返す。"""
     from openai import OpenAI
 
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
+    cfg = DEFAULT_PROVIDERS.get(provider, DEFAULT_PROVIDERS["openai"])
+
+    resolved_url = base_url or cfg["base_url"]
+    resolved_model = model or cfg["model"]
+
+    if api_key:
+        resolved_key = api_key
+    elif cfg["api_key_env"]:
+        resolved_key = os.getenv(cfg["api_key_env"], "")
+    else:
+        resolved_key = "lm-studio"
+
+    if cfg["api_key_required"] and not resolved_key:
         raise RuntimeError(
-            "環境変数 OPENAI_API_KEY が設定されていません。\n"
-            "  export OPENAI_API_KEY='sk-...'"
+            f"環境変数 {cfg['api_key_env']} が設定されていません。"
         )
 
-    client = OpenAI(api_key=api_key, timeout=120)
-    response = client.chat.completions.create(
-        model=model,
-        messages=[
-            {"role": "system", "content": SYSTEM_MSG},
-            {"role": "user", "content": f"以下の論文テキストを解析してください:\n\n{text}"},
-        ],
-        temperature=0.0,
-        max_tokens=2048,
-    )
-    raw = response.choices[0].message.content or ""
-    return _parse_json(raw)
+    kwargs: Dict[str, Any] = {"api_key": resolved_key, "timeout": 180}
+    if resolved_url:
+        kwargs["base_url"] = resolved_url
+
+    return OpenAI(**kwargs), resolved_model
+
+
+def get_metadata_via_ai(
+    text: str,
+    provider: str = "openai",
+    model: Optional[str] = None,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    max_retries: int = 3,
+) -> Dict:
+    """LLM API でメタデータを抽出する。リトライ付き。"""
+    client, resolved_model = _build_client(provider, base_url, model, api_key)
+
+    for attempt in range(1, max_retries + 1):
+        try:
+            response = client.chat.completions.create(
+                model=resolved_model,
+                messages=[
+                    {"role": "system", "content": SYSTEM_MSG},
+                    {"role": "user", "content": f"以下の論文テキストを解析してください:\n\n{text}"},
+                ],
+                temperature=0.0,
+                max_tokens=2048,
+            )
+            raw = response.choices[0].message.content or ""
+            return _parse_json(raw)
+        except Exception as e:
+            if attempt < max_retries:
+                wait = 2 ** attempt
+                log.warning("API エラー (attempt %d/%d): %s — %ds 後にリトライ", attempt, max_retries, e, wait)
+                time.sleep(wait)
+            else:
+                raise
 
 
 def _parse_json(text: str) -> Dict:
@@ -103,7 +231,7 @@ def _parse_json(text: str) -> Dict:
 
 
 # ---------------------------------------------------------------------------
-# BibTeX 生成キー
+# BibTeX 生成
 # ---------------------------------------------------------------------------
 
 def _make_cite_key(meta: Dict, pdf_path: str) -> str:
@@ -127,10 +255,6 @@ def _make_cite_key(meta: Dict, pdf_path: str) -> str:
     year_str = str(year) if year else "nd"
     return f"{first_author}{year_str}"
 
-
-# ---------------------------------------------------------------------------
-# BibTeX 書き出し
-# ---------------------------------------------------------------------------
 
 def _escape_bib(value: str) -> str:
     """BibTeX 値のエスケープ。"""
@@ -161,106 +285,196 @@ def _format_bib_entry(key: str, meta: Dict) -> str:
     return "\n".join(lines)
 
 
-def add_to_bib(bib_path: str, key: str, meta: Dict) -> None:
-    """既存の .bib ファイルにエントリを追記（重複キー時はスキップ）。"""
+def write_bib(bib_path: str, entries: List[Dict]) -> None:
+    """全エントリを .bib ファイルに書き出す（DOI ベース重複除去付き）。"""
     path = Path(bib_path)
-    existing = path.read_text(encoding="utf-8") if path.exists() else ""
 
-    if re.search(rf"@\w+\{{\s*{re.escape(key)}\s*,", existing):
-        print(f"  [skip] キー '{key}' は既に存在します。")
-        return
+    seen_keys: set = set()
+    seen_dois: set = set()
+    bib_blocks: List[str] = []
 
-    entry = _format_bib_entry(key, meta)
-    with open(path, "a", encoding="utf-8") as f:
-        if existing and not existing.endswith("\n"):
-            f.write("\n")
-        f.write("\n" + entry + "\n")
+    if path.exists():
+        existing = path.read_text(encoding="utf-8")
+        for m in re.finditer(r"@\w+\{\s*([^,]+)\s*,", existing):
+            seen_keys.add(m.group(1).strip())
+        for m in re.finditer(r"doi\s*=\s*\{([^}]+)\}", existing, re.IGNORECASE):
+            seen_dois.add(m.group(1).strip().lower())
 
-    print(f"  [add]  {key} → {bib_path}")
+    new_count = 0
+    for meta in entries:
+        doi = (meta.get("doi") or "").strip().lower()
+        if doi and doi in seen_dois:
+            log.info("  [skip/doi] DOI 重複: %s", doi)
+            continue
+
+        key = _make_cite_key(meta, meta.get("_source_file", "unknown"))
+        base_key = key
+        counter = 2
+        while key in seen_keys:
+            key = f"{base_key}_{counter}"
+            counter += 1
+
+        seen_keys.add(key)
+        if doi:
+            seen_dois.add(doi)
+        bib_blocks.append(_format_bib_entry(key, meta))
+        new_count += 1
+
+    if bib_blocks:
+        with open(path, "a", encoding="utf-8") as f:
+            existing_text = path.read_text(encoding="utf-8") if path.stat().st_size > 0 else ""
+            if existing_text and not existing_text.endswith("\n"):
+                f.write("\n")
+            f.write("\n" + "\n\n".join(bib_blocks) + "\n")
+
+    log.info("BibTeX 出力: %d 件追加 → %s", new_count, bib_path)
+
+
+# ---------------------------------------------------------------------------
+# PDF 収集
+# ---------------------------------------------------------------------------
+
+def collect_pdfs(paths: List[str], input_dir: Optional[str], recursive: bool = True) -> List[str]:
+    """CLI 引数とディレクトリ指定から PDF パスを収集する。"""
+    pdfs: List[str] = list(paths)
+    if input_dir:
+        dir_path = Path(input_dir)
+        if dir_path.is_dir():
+            glob_pattern = "**/*.pdf" if recursive else "*.pdf"
+            pdfs.extend(str(p) for p in sorted(dir_path.glob(glob_pattern)))
+        else:
+            log.warning("ディレクトリが見つかりません: %s", input_dir)
+    return pdfs
+
+
+# ---------------------------------------------------------------------------
+# 1ファイル処理 (ワーカー関数)
+# ---------------------------------------------------------------------------
+
+def _process_one(
+    pdf_path: str,
+    checkpoint: Checkpoint,
+    provider: str,
+    model: Optional[str],
+    base_url: Optional[str],
+    api_key: Optional[str],
+) -> Optional[Dict]:
+    """PDF 1 ファイルを処理。チェックポイント済みならスキップ。"""
+    sha = file_sha256(pdf_path)
+
+    if checkpoint.is_done(sha):
+        log.info("  [skip/hash] %s (処理済み)", Path(pdf_path).name)
+        return checkpoint.get(sha)
+
+    text = extract_text_from_pdf(pdf_path)
+    if len(text.strip()) < 100:
+        log.warning("  [skip/short] %s テキスト不足", Path(pdf_path).name)
+        return None
+
+    meta = get_metadata_via_ai(
+        text, provider=provider, model=model, base_url=base_url, api_key=api_key,
+    )
+    meta["_source_file"] = pdf_path
+    meta["_sha256"] = sha
+
+    checkpoint.put(sha, meta)
+    return meta
 
 
 # ---------------------------------------------------------------------------
 # メイン
 # ---------------------------------------------------------------------------
 
-def process_pdf(pdf_path: str, bib_path: str, model: str) -> Optional[Dict]:
-    """PDF 1 ファイルを処理して bib に追加。"""
-    print(f"\n--- {pdf_path} ---")
+def run_batch(
+    pdfs: List[str],
+    bib_path: str = "library.bib",
+    checkpoint_path: str = ".extract_bib_checkpoint.json",
+    provider: str = "openai",
+    model: Optional[str] = None,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    workers: int = 4,
+    save_every: int = 20,
+    on_progress: Optional[Any] = None,
+) -> List[Dict]:
+    """PDF リストをバッチ処理してチェックポイントに保存し、BibTeX を出力。
 
-    if not Path(pdf_path).exists():
-        print(f"  [error] ファイルが見つかりません: {pdf_path}")
-        return None
+    on_progress: callable(done, total, pdf_path, meta_or_none) — UI 向けコールバック
+    """
+    checkpoint = Checkpoint(checkpoint_path)
+    results: List[Dict] = []
+    done_count = 0
+    total = len(pdfs)
 
-    print("  テキスト抽出中 ...")
-    text = extract_text_from_pdf(pdf_path)
-    if len(text.strip()) < 100:
-        print("  [warn] テキストが短すぎます。スキャン PDF の可能性があります。")
-        return None
+    log.info("対象 PDF: %d 件 (workers=%d, provider=%s)", total, workers, provider)
 
-    print(f"  AI 解析中 (model={model}) ...")
-    meta = get_metadata_via_ai(text, model=model)
+    def _worker(pdf_path: str) -> tuple:
+        try:
+            meta = _process_one(pdf_path, checkpoint, provider, model, base_url, api_key)
+            return pdf_path, meta, None
+        except Exception as e:
+            return pdf_path, None, str(e)
 
-    print(f"  title   : {meta.get('title', '???')}")
-    print(f"  authors : {meta.get('authors', '???')}")
-    print(f"  doi     : {meta.get('doi', '???')}")
-    print(f"  materials: {meta.get('materials', '???')}")
-    print(f"  theory  : {meta.get('theory', '???')}")
-    print(f"  methods : {meta.get('methods', '???')}")
-    print(f"  summary : {(meta.get('summary_ja', '') or '')[:80]}...")
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {pool.submit(_worker, p): p for p in pdfs}
+        for future in as_completed(futures):
+            pdf_path, meta, error = future.result()
+            done_count += 1
 
-    key = _make_cite_key(meta, pdf_path)
-    add_to_bib(bib_path, key, meta)
-    return meta
+            if error:
+                log.error("  [error] %s: %s", Path(pdf_path).name, error)
+            elif meta:
+                results.append(meta)
+                log.info(
+                    "  [%d/%d] %s → %s",
+                    done_count, total,
+                    Path(pdf_path).name,
+                    meta.get("title", "???")[:60],
+                )
 
+            if on_progress:
+                on_progress(done_count, total, pdf_path, meta)
 
-def collect_pdfs(paths: List[str], input_dir: Optional[str]) -> List[str]:
-    """CLI 引数とディレクトリ指定から PDF パスを収集する。"""
-    pdfs: List[str] = list(paths)
-    if input_dir:
-        dir_path = Path(input_dir)
-        if dir_path.is_dir():
-            pdfs.extend(str(p) for p in sorted(dir_path.glob("*.pdf")))
-        else:
-            print(f"[warn] ディレクトリが見つかりません: {input_dir}")
-    return pdfs
+            if done_count % save_every == 0:
+                checkpoint.save()
+
+    checkpoint.save()
+
+    write_bib(bib_path, results)
+    log.info("=== 完了: %d/%d 件を処理 ===", len(results), total)
+    return results
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="PDF 論文から AI でメタデータを抽出し BibTeX に保存",
+        description="PDF 論文から AI でメタデータを抽出し BibTeX に保存 (v2: 大規模対応)",
     )
     parser.add_argument("pdfs", nargs="*", help="処理する PDF ファイル")
-    parser.add_argument(
-        "--input-dir", "-d",
-        help="PDF ファイルを含むディレクトリ",
-    )
-    parser.add_argument(
-        "--output", "-o",
-        default="library.bib",
-        help="出力 .bib ファイル (default: library.bib)",
-    )
-    parser.add_argument(
-        "--model", "-m",
-        default="gpt-4o",
-        help="OpenAI モデル名 (default: gpt-4o)",
-    )
+    parser.add_argument("--input-dir", "-d", help="PDF ファイルを含むディレクトリ")
+    parser.add_argument("--output", "-o", default="library.bib", help="出力 .bib ファイル")
+    parser.add_argument("--checkpoint", default=".extract_bib_checkpoint.json", help="チェックポイントファイル")
+    parser.add_argument("--provider", "-p", choices=["openai", "lmstudio"], default="openai")
+    parser.add_argument("--model", "-m", default=None, help="モデル名 (省略時: プロバイダデフォルト)")
+    parser.add_argument("--base-url", default=None, help="API ベース URL (LM Studio 等)")
+    parser.add_argument("--workers", "-w", type=int, default=4, help="並行ワーカー数")
+    parser.add_argument("--no-recursive", action="store_true", help="サブディレクトリを再帰探索しない")
     args = parser.parse_args()
 
-    pdfs = collect_pdfs(args.pdfs, args.input_dir)
+    pdfs = collect_pdfs(args.pdfs, args.input_dir, recursive=not args.no_recursive)
     if not pdfs:
         parser.print_help()
         print("\n[error] PDF ファイルを指定してください。")
         sys.exit(1)
 
-    print(f"対象 PDF: {len(pdfs)} 件  →  出力: {args.output}")
-
-    results: List[Dict] = []
-    for pdf in pdfs:
-        meta = process_pdf(pdf, args.output, args.model)
-        if meta:
-            results.append(meta)
-
-    print(f"\n=== 完了: {len(results)}/{len(pdfs)} 件を処理しました ===")
+    run_batch(
+        pdfs=pdfs,
+        bib_path=args.output,
+        checkpoint_path=args.checkpoint,
+        provider=args.provider,
+        model=args.model,
+        base_url=args.base_url,
+        workers=args.workers,
+    )
 
 
 if __name__ == "__main__":

--- a/extract_bib_app.py
+++ b/extract_bib_app.py
@@ -14,6 +14,7 @@ extract_bib_app.py — Streamlit UI for AI-powered PDF → BibTeX extraction (v2
 """
 
 import os
+import time
 from pathlib import Path
 from typing import Dict, List
 
@@ -145,17 +146,35 @@ with tab_extract:
                 results: List[Dict] = []
                 errors: List[Dict] = []
                 skipped = 0
+                total = len(pdf_list)
 
-                progress = st.progress(0, text="準備中...")
+                progress_bar = st.progress(0)
+                progress_text = st.empty()
                 status_area = st.empty()
                 stats_area = st.empty()
+                time_area = st.empty()
+
+                t_start = time.time()
 
                 for idx, pdf_path in enumerate(pdf_list):
                     fname = Path(pdf_path).name
-                    progress.progress(
-                        idx / len(pdf_list),
-                        text=f"({idx + 1}/{len(pdf_list)}) {fname}",
+                    done = idx + 1
+                    pct = done / total
+                    progress_bar.progress(pct)
+                    progress_text.markdown(
+                        f"**進捗: {done} / {total} 件 ({pct:.0%})**"
                     )
+
+                    elapsed = time.time() - t_start
+                    if idx > 0:
+                        speed = idx / elapsed
+                        remaining = (total - done) / speed
+                        elapsed_str = time.strftime("%M:%S", time.gmtime(elapsed))
+                        remaining_str = time.strftime("%M:%S", time.gmtime(remaining))
+                        time_area.caption(
+                            f"経過: {elapsed_str}  |  残り推定: {remaining_str}  |  "
+                            f"速度: {speed:.1f} 件/秒"
+                        )
 
                     try:
                         sha = file_sha256(pdf_path)
@@ -165,12 +184,22 @@ with tab_extract:
                             if cached:
                                 results.append(cached)
                             skipped += 1
+                            stats_area.markdown(
+                                f"成功 **{len(results)}**  |  "
+                                f"スキップ **{skipped}**  |  "
+                                f"エラー **{len(errors)}**"
+                            )
                             continue
 
                         status_area.info(f"テキスト抽出中: {fname}")
                         text = extract_text_from_pdf(pdf_path)
                         if len(text.strip()) < 100:
                             errors.append({"_file": pdf_path, "_error": "テキスト不足"})
+                            stats_area.markdown(
+                                f"成功 **{len(results)}**  |  "
+                                f"スキップ **{skipped}**  |  "
+                                f"エラー **{len(errors)}**"
+                            )
                             continue
 
                         status_area.info(f"AI 解析中: {fname}")
@@ -188,18 +217,25 @@ with tab_extract:
                         ckpt.put(sha, meta)
                         results.append(meta)
 
-                        if (idx + 1) % 20 == 0:
+                        if done % 20 == 0:
                             ckpt.save()
 
                     except Exception as e:
                         errors.append({"_file": pdf_path, "_error": str(e)})
 
                     stats_area.markdown(
-                        f"✅ {len(results)} 件成功  |  ⏭️ {skipped} 件スキップ  |  ❌ {len(errors)} 件エラー"
+                        f"成功 **{len(results)}**  |  "
+                        f"スキップ **{skipped}**  |  "
+                        f"エラー **{len(errors)}**"
                     )
 
                 ckpt.save()
-                progress.progress(1.0, text="完了!")
+                progress_bar.progress(1.0)
+                progress_text.markdown("**完了!**")
+                elapsed_total = time.time() - t_start
+                time_area.caption(
+                    f"合計時間: {time.strftime('%M:%S', time.gmtime(elapsed_total))}"
+                )
                 status_area.empty()
 
                 # BibTeX 組み立て

--- a/extract_bib_app.py
+++ b/extract_bib_app.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""
+extract_bib_app.py — Streamlit UI for AI-powered PDF → BibTeX extraction (v2)
+
+機能:
+  - ディレクトリ指定で配下の全 PDF を一括処理 (1万件スケール対応)
+  - SHA-256 チェックポイントで処理済みスキップ (ファイル移動に対応)
+  - OpenAI / LM Studio (ローカルLLM) 切り替え
+  - 蓄積メタデータの検索・フィルタ機能 (材料検索エンジン)
+  - BibTeX ダウンロード / ディスク保存
+
+起動:
+  streamlit run extract_bib_app.py
+"""
+
+import os
+from pathlib import Path
+from typing import Dict, List
+
+import streamlit as st
+
+from extract_bib import (
+    Checkpoint,
+    _format_bib_entry,
+    _make_cite_key,
+    extract_text_from_pdf,
+    file_sha256,
+    get_metadata_via_ai,
+)
+
+# ---------------------------------------------------------------------------
+# ページ設定
+# ---------------------------------------------------------------------------
+
+st.set_page_config(page_title="PDF → BibTeX Extractor", page_icon="📖", layout="wide")
+
+st.markdown(
+    """
+    <style>
+    @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap');
+    html, body, [class*="st-"], .stMarkdown, .stText, .stDataFrame,
+    h1, h2, h3, h4, h5, h6, p, span, div, label, input, button, textarea, select {
+        font-family: 'Noto Sans JP', sans-serif !important;
+    }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
+# ---------------------------------------------------------------------------
+# サイドバー: LLM 設定
+# ---------------------------------------------------------------------------
+
+with st.sidebar:
+    st.header("LLM 設定")
+    provider = st.radio("プロバイダ", ["OpenAI", "LM Studio (ローカル)"], horizontal=True)
+
+    if provider == "OpenAI":
+        provider_key = "openai"
+        api_key = st.text_input(
+            "OpenAI API Key",
+            value=os.getenv("OPENAI_API_KEY", ""),
+            type="password",
+        )
+        model = st.selectbox("モデル", ["gpt-4o", "gpt-4o-mini", "gpt-4-turbo"])
+        base_url = None
+    else:
+        provider_key = "lmstudio"
+        api_key = None
+        base_url = st.text_input("LM Studio URL", value="http://localhost:1234/v1")
+        model = st.text_input("モデル名", value="local-model")
+
+    st.divider()
+    st.header("出力設定")
+    output_name = st.text_input("BibTeX ファイル名", value="library.bib")
+    checkpoint_path = st.text_input("チェックポイント", value=".extract_bib_checkpoint.json")
+
+# ---------------------------------------------------------------------------
+# タブ構成
+# ---------------------------------------------------------------------------
+
+tab_extract, tab_search = st.tabs(["📥 PDF 一括抽出", "🔍 文献検索"])
+
+# ===================================================================
+# タブ 1: PDF 一括抽出
+# ===================================================================
+
+with tab_extract:
+    st.header("PDF → BibTeX 一括抽出")
+    st.markdown("ディレクトリを指定すると、配下の **全 PDF** を AI 解析し BibTeX を生成します。")
+
+    dir_path = st.text_input(
+        "PDF ディレクトリのパス",
+        placeholder="/home/user/papers",
+        help="サブディレクトリ内も再帰的に探索します",
+        key="extract_dir",
+    )
+    recursive = st.checkbox("サブディレクトリも探索", value=True)
+
+    col_scan, col_clear = st.columns(2)
+    with col_scan:
+        scan_clicked = st.button("PDF をスキャン", type="primary", use_container_width=True)
+    with col_clear:
+        if st.button("結果をクリア", use_container_width=True):
+            for k in ["pdf_list", "results", "bib_text"]:
+                st.session_state.pop(k, None)
+            st.rerun()
+
+    # --- スキャン ---
+    if scan_clicked and dir_path:
+        target = Path(dir_path)
+        if not target.is_dir():
+            st.error(f"ディレクトリが見つかりません: {dir_path}")
+        else:
+            pattern = "**/*.pdf" if recursive else "*.pdf"
+            pdfs = sorted(str(p) for p in target.glob(pattern))
+            if not pdfs:
+                st.warning("PDF ファイルが見つかりませんでした。")
+            else:
+                st.session_state["pdf_list"] = pdfs
+                for k in ["results", "bib_text"]:
+                    st.session_state.pop(k, None)
+                st.success(f"{len(pdfs)} 件の PDF を検出しました。")
+
+    # --- 検出一覧 & 実行 ---
+    if "pdf_list" in st.session_state:
+        pdf_list: List[str] = st.session_state["pdf_list"]
+
+        with st.expander(f"検出 PDF 一覧 ({len(pdf_list)} 件)", expanded=False):
+            for i, p in enumerate(pdf_list, 1):
+                st.text(f"{i}. {p}")
+
+        if st.button(
+            f"全 {len(pdf_list)} 件を解析して BibTeX 生成",
+            type="primary",
+            use_container_width=True,
+        ):
+            if provider_key == "openai" and not api_key:
+                st.error("OpenAI API Key を入力してください。")
+            else:
+                if api_key:
+                    os.environ["OPENAI_API_KEY"] = api_key
+
+                ckpt = Checkpoint(checkpoint_path)
+                results: List[Dict] = []
+                errors: List[Dict] = []
+                skipped = 0
+
+                progress = st.progress(0, text="準備中...")
+                status_area = st.empty()
+                stats_area = st.empty()
+
+                for idx, pdf_path in enumerate(pdf_list):
+                    fname = Path(pdf_path).name
+                    progress.progress(
+                        idx / len(pdf_list),
+                        text=f"({idx + 1}/{len(pdf_list)}) {fname}",
+                    )
+
+                    try:
+                        sha = file_sha256(pdf_path)
+
+                        if ckpt.is_done(sha):
+                            cached = ckpt.get(sha)
+                            if cached:
+                                results.append(cached)
+                            skipped += 1
+                            continue
+
+                        status_area.info(f"テキスト抽出中: {fname}")
+                        text = extract_text_from_pdf(pdf_path)
+                        if len(text.strip()) < 100:
+                            errors.append({"_file": pdf_path, "_error": "テキスト不足"})
+                            continue
+
+                        status_area.info(f"AI 解析中: {fname}")
+                        meta = get_metadata_via_ai(
+                            text,
+                            provider=provider_key,
+                            model=model,
+                            base_url=base_url,
+                            api_key=api_key,
+                        )
+                        meta["_source_file"] = pdf_path
+                        meta["_sha256"] = sha
+                        meta["_cite_key"] = _make_cite_key(meta, pdf_path)
+
+                        ckpt.put(sha, meta)
+                        results.append(meta)
+
+                        if (idx + 1) % 20 == 0:
+                            ckpt.save()
+
+                    except Exception as e:
+                        errors.append({"_file": pdf_path, "_error": str(e)})
+
+                    stats_area.markdown(
+                        f"✅ {len(results)} 件成功  |  ⏭️ {skipped} 件スキップ  |  ❌ {len(errors)} 件エラー"
+                    )
+
+                ckpt.save()
+                progress.progress(1.0, text="完了!")
+                status_area.empty()
+
+                # BibTeX 組み立て
+                bib_entries: List[str] = []
+                used_keys: set = set()
+                for r in results:
+                    key = r.get("_cite_key") or _make_cite_key(r, r.get("_source_file", ""))
+                    base_key = key
+                    counter = 2
+                    while key in used_keys:
+                        key = f"{base_key}_{counter}"
+                        counter += 1
+                    used_keys.add(key)
+                    bib_entries.append(_format_bib_entry(key, r))
+
+                bib_text = "\n\n".join(bib_entries) + "\n" if bib_entries else ""
+                st.session_state["results"] = results
+                st.session_state["bib_text"] = bib_text
+                st.session_state["errors"] = errors
+                st.session_state["skipped"] = skipped
+
+    # --- 結果表示 ---
+    if "results" in st.session_state:
+        results = st.session_state["results"]
+        bib_text = st.session_state.get("bib_text", "")
+        errors = st.session_state.get("errors", [])
+        skipped = st.session_state.get("skipped", 0)
+
+        st.subheader(f"結果: {len(results)} 件成功 / {skipped} 件スキップ / {len(errors)} 件エラー")
+
+        if results:
+            display_data = []
+            for r in results:
+                display_data.append({
+                    "Key": r.get("_cite_key", ""),
+                    "Title": (r.get("title") or "")[:80],
+                    "Year": r.get("year", ""),
+                    "Materials": r.get("materials", ""),
+                    "Theory": r.get("theory", ""),
+                    "Methods": r.get("methods", ""),
+                })
+            st.dataframe(display_data, use_container_width=True, height=400)
+
+        if errors:
+            with st.expander(f"エラー ({len(errors)} 件)", expanded=False):
+                for r in errors:
+                    st.error(f"{Path(r['_file']).name}: {r['_error']}")
+
+        if bib_text:
+            st.subheader("BibTeX 出力")
+            with st.expander("BibTeX プレビュー", expanded=False):
+                st.code(bib_text[:10000], language="bibtex")
+                if len(bib_text) > 10000:
+                    st.caption(f"（全 {len(bib_text)} 文字中、先頭 10,000 文字を表示）")
+
+            col_dl, col_save = st.columns(2)
+            with col_dl:
+                st.download_button(
+                    label=f"{output_name} をダウンロード",
+                    data=bib_text,
+                    file_name=output_name,
+                    mime="text/plain",
+                    use_container_width=True,
+                )
+            with col_save:
+                save_dir = st.text_input("保存先ディレクトリ", key="save_dir")
+                if st.button("ディスクに保存", use_container_width=True) and save_dir:
+                    save_path = Path(save_dir) / output_name
+                    try:
+                        save_path.parent.mkdir(parents=True, exist_ok=True)
+                        save_path.write_text(bib_text, encoding="utf-8")
+                        st.success(f"保存しました: {save_path}")
+                    except Exception as e:
+                        st.error(f"保存失敗: {e}")
+
+# ===================================================================
+# タブ 2: 文献検索
+# ===================================================================
+
+with tab_search:
+    st.header("🔍 文献検索エンジン")
+    st.markdown(
+        "チェックポイントに蓄積されたメタデータから文献を検索します。"
+    )
+
+    ckpt_search = Checkpoint(checkpoint_path)
+    all_entries = ckpt_search.all_entries()
+
+    if not all_entries:
+        st.info("まだメタデータがありません。「PDF 一括抽出」タブで PDF を処理してください。")
+    else:
+        st.caption(f"登録済み文献: {len(all_entries)} 件")
+
+        # --- 検索入力 ---
+        query = st.text_input("キーワード検索", placeholder="例: SrTiO3, DFT, Machine Learning...")
+        search_mode = st.radio("検索モード", ["OR (いずれか含む)", "AND (すべて含む)"], horizontal=True)
+
+        # --- フィルタ ---
+        col_f1, col_f2, col_f3 = st.columns(3)
+
+        all_materials = sorted({e.get("materials", "") for e in all_entries if e.get("materials")})
+        all_theories = sorted({e.get("theory", "") for e in all_entries if e.get("theory")})
+        all_methods = sorted({e.get("methods", "") for e in all_entries if e.get("methods")})
+
+        with col_f1:
+            filter_materials = st.multiselect("Materials フィルタ", all_materials)
+        with col_f2:
+            filter_theory = st.multiselect("Theory フィルタ", all_theories)
+        with col_f3:
+            filter_methods = st.multiselect("Methods フィルタ", all_methods)
+
+        # --- 検索実行 ---
+        def _matches_query(entry: Dict, keywords: List[str], mode: str) -> bool:
+            if not keywords:
+                return True
+            searchable = " ".join(
+                str(entry.get(f, ""))
+                for f in ["title", "authors", "materials", "theory", "methods", "summary_ja", "journal", "doi"]
+            ).lower()
+            if mode.startswith("AND"):
+                return all(kw.lower() in searchable for kw in keywords)
+            return any(kw.lower() in searchable for kw in keywords)
+
+        def _matches_filters(entry: Dict) -> bool:
+            if filter_materials and entry.get("materials", "") not in filter_materials:
+                return False
+            if filter_theory and entry.get("theory", "") not in filter_theory:
+                return False
+            if filter_methods and entry.get("methods", "") not in filter_methods:
+                return False
+            return True
+
+        keywords = [k.strip() for k in query.split(",") if k.strip()] if query else []
+        filtered = [
+            e for e in all_entries
+            if _matches_query(e, keywords, search_mode) and _matches_filters(e)
+        ]
+
+        st.subheader(f"検索結果: {len(filtered)} 件")
+
+        if filtered:
+            # テーブル表示
+            table_data = []
+            for e in filtered:
+                table_data.append({
+                    "Title": (e.get("title") or "")[:80],
+                    "Authors": (e.get("authors") or "")[:40],
+                    "Year": e.get("year", ""),
+                    "Materials": e.get("materials", ""),
+                    "Theory": e.get("theory", ""),
+                    "Methods": e.get("methods", ""),
+                    "DOI": e.get("doi", ""),
+                })
+            st.dataframe(table_data, use_container_width=True, height=400)
+
+            # 選択エントリの詳細
+            st.subheader("エントリ詳細")
+            for e in filtered:
+                title_short = (e.get("title") or "(no title)")[:80]
+                with st.expander(f"📄 {title_short}"):
+                    c1, c2 = st.columns(2)
+                    with c1:
+                        st.markdown(f"**Title:** {e.get('title', '')}")
+                        st.markdown(f"**Authors:** {e.get('authors', '')}")
+                        st.markdown(f"**Year:** {e.get('year', '')}")
+                        st.markdown(f"**Journal:** {e.get('journal', '')}")
+                        doi = e.get("doi", "")
+                        if doi:
+                            st.markdown(f"**DOI:** [{doi}](https://doi.org/{doi})")
+                    with c2:
+                        st.markdown(f"**Materials:** {e.get('materials', '')}")
+                        st.markdown(f"**Theory:** {e.get('theory', '')}")
+                        st.markdown(f"**Methods:** {e.get('methods', '')}")
+                    st.markdown(f"**日本語要約:** {e.get('summary_ja', '')}")
+
+            # 検索結果の BibTeX エクスポート
+            st.subheader("検索結果のエクスポート")
+            export_entries: List[str] = []
+            used_keys: set = set()
+            for e in filtered:
+                key = _make_cite_key(e, e.get("_source_file", ""))
+                base_key = key
+                counter = 2
+                while key in used_keys:
+                    key = f"{base_key}_{counter}"
+                    counter += 1
+                used_keys.add(key)
+                export_entries.append(_format_bib_entry(key, e))
+
+            export_bib = "\n\n".join(export_entries) + "\n"
+            st.download_button(
+                label=f"検索結果を BibTeX でダウンロード ({len(filtered)} 件)",
+                data=export_bib,
+                file_name=f"search_results_{len(filtered)}.bib",
+                mime="text/plain",
+                use_container_width=True,
+            )


### PR DESCRIPTION
## Summary

`extract_bib.py` を大規模対応にリライト + `extract_bib_app.py` (Streamlit UI) を新規追加。

### extract_bib.py v2 (CLI)
- **1万ファイル規模対応**: `ThreadPoolExecutor` による並行処理（`--workers` で調整可）
- **SHA-256 チェックポイント**: ファイルパスではなくコンテンツハッシュで処理済み管理 → PDF の置き場所が変わっても再処理しない
- **DOI ベース重複検出**: 同一論文の別ファイル名でも重複エントリを防止
- **OpenAI / LM Studio 両対応**: `--provider lmstudio --base-url http://localhost:1234/v1` で切替
- **リトライ付き API 呼び出し**: 指数バックオフ (最大3回)
- **バッチチェックポイント保存**: 20件ごとに自動保存、中断→再開が可能

### extract_bib_app.py (Streamlit UI)
- **📥 PDF 一括抽出タブ**: ディレクトリパス指定 → 配下の全PDF再帰スキャン → 一括AI解析
- **プログレスバー**: 進捗%, 経過時間, 残り時間推定, 処理速度をリアルタイム表示
- **🔍 文献検索タブ**: チェックポイントに蓄積されたメタデータを検索
  - キーワード検索 (AND/OR)
  - materials / theory / methods ドロップダウンフィルタ
  - 検索結果の BibTeX エクスポート
- **LLM 切替**: サイドバーで OpenAI ↔ LM Studio (ローカル) を切替
- **日本語フォント**: Noto Sans JP 適用

### 起動方法
```bash
# CLI
python extract_bib.py -d ./papers/ --workers 8

# Streamlit UI
streamlit run extract_bib_app.py
```

## Review & Testing Checklist for Human
- [ ] `OPENAI_API_KEY` を設定した環境でサンプル PDF ディレクトリに対して実行し、チェックポイント JSON とBibTeX が正しく生成されるか確認
- [ ] 同じディレクトリで再実行 → チェックポイントにより全ファイルスキップされることを確認
- [ ] PDF を別ディレクトリに移動して再実行 → SHA-256 ハッシュ一致でスキップされることを確認
- [ ] 文献検索タブでキーワード・フィルタ検索が動作し、BibTeX エクスポートできることを確認
- [ ] LM Studio モード（ローカルLLM）に切り替えて接続できることを確認

### Notes
- 依存パッケージ: `streamlit`, `openai`, `pymupdf4llm`（または `PyMuPDF`）
- チェックポイントファイル: `.extract_bib_checkpoint.json`（デフォルト）
- JabRef の `Preferences > Entry table columns` に `materials`, `theory` を追加すると一覧画面で確認可能


Link to Devin session: https://app.devin.ai/sessions/15af248a68bf4de888032e268f26847a
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->