### PR TITLE
fix: gaussian_nll_multitime_rs boolean index error (t_exp 2D→1D)

### DIFF
--- a/fig11_co_ni_ta_pinn_reliability_v23_multitime_pseudoexp.py
+++ b/fig11_co_ni_ta_pinn_reliability_v23_multitime_pseudoexp.py
@@ -1596,12 +1596,15 @@ def gaussian_nll_multitime_rs(
 
     C_fdm = _reorder_c_internal_to_display_np(C_fdm_int)
 
+    t_exp_1d = np.asarray(t_exp).ravel()
+    x_exp_1d = np.asarray(x_exp).ravel()
+
     sigma_eff = max(float(sigma), 1.0e-8)
     total_nll = 0.0
-    unique_times = np.unique(t_exp)
+    unique_times = np.unique(t_exp_1d)
     for t_val in unique_times:
-        mask = np.abs(t_exp - t_val) < 1.0e-10
-        x_pts = x_exp[mask]
+        mask = np.abs(t_exp_1d - t_val) < 1.0e-10
+        x_pts = x_exp_1d[mask]
         c_pts = c_exp[mask]
 
         ti_closest = int(np.argmin(np.abs(t_grid - t_val)))
@@ -1613,7 +1616,7 @@ def gaussian_nll_multitime_rs(
         residual = c_pts[:, :n_ind] - c_pred[:, :n_ind]
         total_nll += 0.5 * np.sum((residual / sigma_eff) ** 2)
 
-    n_total = int(np.sum(np.abs(t_exp) >= 0)) * n_ind
+    n_total = len(t_exp_1d) * n_ind
     total_nll += n_total * np.log(sigma_eff)
 
     if prior_mean is not None and prior_std is not None:


### PR DESCRIPTION
## Summary

`gaussian_nll_multitime_rs` の FDM尤度再最適化で `IndexError: boolean index did not match indexed array along dimension 1` が発生する問題を修正。

**原因**: `t_exp_all` と `x_exp_all` は `(N, 1)` shape で格納されている。`mask = np.abs(t_exp - t_val) < 1e-10` が shape `(N, 1)` を返し、`c_exp[mask]` (shape `(N, 3)`) のインデックスで次元不整合。

**修正**: `t_exp` と `x_exp` を `.ravel()` で 1D に変換してからマスク演算を行う。`n_total` の計算も `len(t_exp_1d)` に統一。

## Review & Testing Checklist for Human

- [ ] Regular-solution モードで PINN 学習後、「FDM尤度でΩを再最適化」が IndexError なく完了するか確認
- [ ] Laplace/MCMC 信頼性評価も正常に動作するか確認

### Notes

- この問題は PR #170 以前から存在していた可能性がある（`t_exp_all` が `(N,1)` shape である限り発生）

Link to Devin session: https://app.devin.ai/sessions/b65d78c9984846d6b1b1ea7067923710
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->