### PR TITLE
chore: デフォルト解析モードを化学ポテンシャルモードに変更

### DIFF
--- a/fig11_co_ni_ta_pinn_reliability_v23_multitime_pseudoexp.py
+++ b/fig11_co_ni_ta_pinn_reliability_v23_multitime_pseudoexp.py
@@ -3997,7 +3997,7 @@ with st.sidebar:
     pinn_analysis_mode = st.selectbox(
         "PINN analysis mode",
         ["Fickian D matrix", "Regular-solution chemical potential"],
-        index=0,
+        index=1,
         help=(
             "Fickian D matrix: traditional approach, flux = -D grad(c). "
             "Regular-solution chemical potential: flux = M grad(mu), where mu "


### PR DESCRIPTION
## Summary

PINN analysis mode のデフォルト選択を `index=0` (Fickian D matrix) → `index=1` (Regular-solution chemical potential) に変更。

## Review & Testing Checklist for Human

- [ ] アプリ起動時に「Regular-solution chemical potential」が選択されていることを確認

### Notes

1行変更のみ。

Link to Devin session: https://app.devin.ai/sessions/b65d78c9984846d6b1b1ea7067923710
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->