### PR TITLE
fix: TernaryRegularSolutionPINN diffusion_matrix AttributeError

### DIFF
--- a/fig11_co_ni_ta_pinn_reliability_v23_multitime_pseudoexp.py
+++ b/fig11_co_ni_ta_pinn_reliability_v23_multitime_pseudoexp.py
@@ -4871,7 +4871,7 @@ st.success("Loaded completed calculation from session state. Rendering result ta
 # =========================================================================
 # Chemical potential result display
 # =========================================================================
-if isinstance(result, TrainResultRS):
+if type(result).__name__ == "TrainResultRS":
     rs_result = result
     rs_model = rs_result.model
     rs_data = rs_result.data
@@ -5155,7 +5155,7 @@ if isinstance(result, TrainResultRS):
 # Fickian D matrix result display (original)
 # =========================================================================
 
-if isinstance(result, TrainResultRS):
+if type(result).__name__ == "TrainResultRS":
     st.error("Regular-solution result detected but display section was skipped. Please re-run.")
     st.stop()
 

--- a/fig11_co_ni_ta_pinn_reliability_v23_multitime_pseudoexp.py
+++ b/fig11_co_ni_ta_pinn_reliability_v23_multitime_pseudoexp.py
@@ -5144,9 +5144,9 @@ if type(result).__name__ == "TrainResultRS":
         st.markdown(f"Pseudo-exp points: {len(rs_data.x_exp_all)}")
         st.markdown(f"Training obs: {len(rs_data.x_obs)}")
         st.dataframe(pd.DataFrame({
-            "x_exp": rs_data.x_exp_all[:50],
-            "t_exp": rs_data.t_exp_all[:50],
-            **{f"c_exp_{comp}": rs_data.c_exp_all[:50, j] for j, comp in enumerate(COMPONENTS)},
+            "x_exp": np.asarray(rs_data.x_exp_all[:50]).ravel(),
+            "t_exp": np.asarray(rs_data.t_exp_all[:50]).ravel(),
+            **{f"c_exp_{comp}": np.asarray(rs_data.c_exp_all[:50, j]).ravel() for j, comp in enumerate(COMPONENTS)},
         }), use_container_width=True)
 
     st.stop()

--- a/fig11_co_ni_ta_pinn_reliability_v23_multitime_pseudoexp.py
+++ b/fig11_co_ni_ta_pinn_reliability_v23_multitime_pseudoexp.py
@@ -4871,7 +4871,7 @@ st.success("Loaded completed calculation from session state. Rendering result ta
 # =========================================================================
 # Chemical potential result display
 # =========================================================================
-if inputs.get("use_chemical_potential", False) and isinstance(result, TrainResultRS):
+if isinstance(result, TrainResultRS):
     rs_result = result
     rs_model = rs_result.model
     rs_data = rs_result.data
@@ -5154,6 +5154,10 @@ if inputs.get("use_chemical_potential", False) and isinstance(result, TrainResul
 # =========================================================================
 # Fickian D matrix result display (original)
 # =========================================================================
+
+if isinstance(result, TrainResultRS):
+    st.error("Regular-solution result detected but display section was skipped. Please re-run.")
+    st.stop()
 
 model = result.model
 data = result.data


### PR DESCRIPTION
## Summary

RS（Regular-solution化学ポテンシャル）モードで学習後に結果を表示する際の `AttributeError: 'TernaryRegularSolutionPINN' object has no attribute 'diffusion_matrix'` を修正。

### 根本原因
Streamlitはスクリプト全体を毎回再実行するため、`@dataclass class TrainResultRS` は実行ごとに**新しいクラスオブジェクト**として再生成されます。しかし `st.session_state` に保存された結果は**前回の実行時のクラス**で作成されているため、`isinstance(result, TrainResultRS)` が常に `False` を返し、RS表示ブロックがスキップされてFickian側の `model.diffusion_matrix()` に到達していました。

### 修正内容
1. **`isinstance()` → `type().__name__`**: クラス名文字列で比較することで、Streamlit再実行でクラスオブジェクトが変わっても正しくルーティング
2. **RS Data タブの DataFrame修正**: `t_exp_all` が `(N, 1)` shapeの場合に `ravel()` で1Dに変換

### コミット
- `de0e80e`: 初期修正（isinstance、安全ガード追加）
- `d799562`: isinstance → type().__name__ に変更（Streamlit互換）
- `6ca0ba1`: RS DataタブのDataFrame shape修正

## Review & Testing Checklist for Human
- [ ] RSモードで学習→結果表示（Omega interaction termsテーブル、プロファイルプロット）がエラーなく表示されること
- [ ] Fickianモードが従来通り動作すること（diffusion_matrixテーブル表示）
- [ ] RS Dataタブで生データテーブルがエラーなく表示されること

### Notes
テスト結果はPRコメントに添付済み。

Link to Devin session: https://app.devin.ai/sessions/b65d78c9984846d6b1b1ea7067923710
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->