### PR TITLE
chore: デフォルト解析モードをRegular-solutionに変更

### DIFF
--- a/fig11_co_ni_ta_pinn_reliability_v23_multitime_pseudoexp.py
+++ b/fig11_co_ni_ta_pinn_reliability_v23_multitime_pseudoexp.py
@@ -4021,7 +4021,7 @@ with st.sidebar:
     pinn_analysis_mode = st.selectbox(
         "PINN analysis mode",
         ["Fickian D matrix", "Regular-solution chemical potential"],
-        index=0,
+        index=1,
         help=(
             "Fickian D matrix: traditional approach, flux = -D grad(c). "
             "Regular-solution chemical potential: flux = M grad(mu), where mu "


### PR DESCRIPTION
## Summary

PINN analysis modeのデフォルトを「Fickian D matrix」(index=0)から「Regular-solution chemical potential」(index=1)に変更。

## Review & Testing Checklist for Human
- [ ] アプリ起動時にRegular-solutionモードがデフォルト選択されていること

### Notes
1行変更のみ。

Link to Devin session: https://app.devin.ai/sessions/b65d78c9984846d6b1b1ea7067923710
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->