### PR TITLE
fix: RS mode に direct_output と adaptive_weights を伝播

### DIFF
--- a/fig11_co_ni_ta_pinn_reliability_v23_multitime_pseudoexp.py
+++ b/fig11_co_ni_ta_pinn_reliability_v23_multitime_pseudoexp.py
@@ -1618,6 +1618,7 @@ class TernaryRegularSolutionPINN(nn.Module):
         train_omega: bool = True,
         log_M_endmembers_init: Optional[np.ndarray] = None,
         train_mobility: bool = False,
+        direct_output: bool = False,
     ):
         super().__init__()
         self.n_components = 3
@@ -1629,7 +1630,7 @@ class TernaryRegularSolutionPINN(nn.Module):
         self.RT = RT
         self.use_comp_dep_mobility = log_M_endmembers_init is not None
 
-        self.net = MLP(width, depth, activation)
+        self.net = MLP(width, depth, activation, direct_output=direct_output)
 
         if theta_left_init is None:
             theta_left_init = np.ones(self.n_pairs, dtype=float)
@@ -6026,6 +6027,7 @@ FDM教師データと疑似実験点が生成された直後の確認図です�
             train_omega=True,
             log_M_endmembers_init=log_M_endmembers_init,
             train_mobility=rs_train_mob,
+            direct_output=bool(ui_direct_output),
         )
 
         st.info("Step 2/2: PINNsでΩ相互作用項を推定しています (chemical potential mode)...")
@@ -6044,6 +6046,8 @@ FDM教師データと疑似実験点が生成された直後の確認図です�
             w_omega_prior=float(rs_w_omega_prior),
             omega_prior_left=theta_left_init_vals,
             omega_prior_right=theta_right_init_vals if learn_lr_omega else None,
+            adaptive_weights=bool(ui_adaptive_weights),
+            rba_update_every=50,
         )
 
         theta_l_disp, theta_r_disp = rs_model.theta_display()


### PR DESCRIPTION
## Summary

Regular-solution (RS) mode で UI の「Direct [Ni, Ta] output」と「Self-adaptive loss weighting (RBA)」が効いていなかったバグを修正。

**変更点:**
1. `TernaryRegularSolutionPINN.__init__` に `direct_output` 引数追加 → `MLP(..., direct_output=direct_output)` に伝播
2. RS model 生成時に `direct_output=bool(ui_direct_output)` を渡す
3. `train_pinn_rs()` 呼び出しに `adaptive_weights=bool(ui_adaptive_weights), rba_update_every=50` を渡す

**効果:**
- Direct output ON → sigmoid + rescale projection が RS mode でも有効（softplus+normalize の Jacobian 汚染回避）
- RBA ON → gradient-norm ベースの自動 loss 重み調整が RS mode でも機能（physics loss 支配を防止）

## Review & Testing Checklist for Human

- [ ] RS mode で「Direct [Ni,Ta] output = ON」「Self-adaptive loss weighting = ON」にして学習実行 → 学習が進行し、loss plot で data loss が下がることを確認
- [ ] RS mode + Direct output ON で出力組成が simplex 上（Co+Ni+Ta≈1, 全≥0）であることを確認

### Notes
- Fickian D matrix mode では既に正しく渡されていた。RS mode のみの修正。
- ユーザー報告の「PINNs が学習しない」問題の主因の一つ。推奨初期設定: `w_physics=1, w_data=50, w_ic=30, w_bc=20` + Direct output ON + RBA ON。

Link to Devin session: https://app.devin.ai/sessions/b65d78c9984846d6b1b1ea7067923710
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->