### PR TITLE
fix: 「FDM尤度」→「FDM順問題による尤度」に表現修正

### DIFF
--- a/co_ni_ta_pinn_diffusion_reliability.py
+++ b/co_ni_ta_pinn_diffusion_reliability.py
@@ -6120,8 +6120,8 @@ D_norm = D_phys * t_scale / L_scale^2
         rs_fdm_save_every = st.number_input("FDM save_every", min_value=1, max_value=10000, value=100, step=10)
         rs_n_collocation = st.number_input("collocation points/epoch", min_value=8, max_value=50000, value=2000, step=500)
         rs_w_omega_prior = st.slider("Omega prior regularization weight", 0.0, 50.0, 0.0, 0.5)
-        do_fdm_refine = st.checkbox("PINN後にFDM尤度でΩを再最適化", value=True,
-                                     help="相互作用項の精度を上げるための重要ステップ。")
+        do_fdm_refine = st.checkbox("PINN後にFDM順問題による尤度でΩを再最適化", value=True,
+                                     help="候補Ωで RS FDM を順計算し、疑似実験点との残差（負の対数尤度）を最小化してΩを精密化します。")
         fdm_refine_maxiter = st.number_input("FDM再最適化 maxiter", min_value=10, max_value=2000, value=180, step=10)
         rs_like_sigma = st.slider("likelihood sigma (RS)", 0.001, 0.080, 0.008, 0.001)
         rs_hessian_step = st.slider("Laplace Hessian step (RS)", 0.005, 0.150, 0.030, 0.005)
@@ -6483,7 +6483,7 @@ FDM教師データと疑似実験点が生成された直後の確認図です�
 
         refine_info_rs = None
         if do_fdm_refine:
-            st.info("FDM尤度でΩを再最適化しています...")
+            st.info("FDM順問題による尤度でΩを再最適化しています...")
             refine_status = st.empty()
             refine_bar = st.progress(0.0)
             _omega_pair_names = ["Ω_CoNi", "Ω_CoTa", "Ω_NiTa"]


### PR DESCRIPTION
## Summary

UIラベルとヘルプテキストの表現を修正：

- `PINN後にFDM尤度でΩを再最適化` → `PINN後にFDM順問題による尤度でΩを再最適化`
- help: `候補Ωで RS FDM を順計算し、疑似実験点との残差（負の対数尤度）を最小化してΩを精密化します。`
- 進捗表示: `FDM順問題による尤度でΩを再最適化しています...`

「FDM尤度」だけでは「FDMで生成した疑似実験点」と混同しやすいため、「FDM順問題による尤度」に変更し、仕組み（候補Ω → FDM順計算 → 残差評価 → Ω精密化）を明記。

## Review & Testing Checklist for Human
- [ ] RS mode の UI で「PINN後にFDM順問題による尤度でΩを再最適化」チェックボックスの表示とヘルプを確認

### Notes
ラベルのみの変更。ロジック変更なし。

Link to Devin session: https://app.devin.ai/sessions/b65d78c9984846d6b1b1ea7067923710
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->