### PR TITLE
feat: PINN学習直後にプロファイル表示、FDM再最適化はボタンで後から実行

### DIFF
--- a/co_ni_ta_pinn_diffusion_reliability.py
+++ b/co_ni_ta_pinn_diffusion_reliability.py
@@ -6484,7 +6484,7 @@ FDM教師データと疑似実験点が生成された直後の確認図です�
                 n_time_lines=4,
                 annealing_time_h=float(paper_time_h),
             ),
-            width="stretch",
+            use_container_width=True,
         )
         st.plotly_chart(
             fdm_teacher_preview_difference_plot(
@@ -6494,7 +6494,7 @@ FDM教師データと疑似実験点が生成された直後の確認図です�
                 data.c_exp,
                 span_um=float(span_um),
             ),
-            width="stretch",
+            use_container_width=True,
         )
 
         preview_cols = st.columns(4)
@@ -6850,7 +6850,7 @@ if type(result).__name__ == "TrainResultRS":
             "estimated_left": float(theta_l_disp[k]),
             "estimated_right": float(theta_r_disp[k]),
         })
-    st.dataframe(pd.DataFrame(omega_rows), width="stretch")
+    st.dataframe(pd.DataFrame(omega_rows), use_container_width=True)
 
     if inputs.get("refine_info_rs") is not None:
         ri = inputs["refine_info_rs"]
@@ -6941,7 +6941,7 @@ if type(result).__name__ == "TrainResultRS":
             ))
         fig.update_xaxes(title="Distance (µm)")
         fig.update_yaxes(title="Mole Fraction", range=[-0.04, 1.04])
-        st.plotly_chart(clean_layout(fig, "Regular-solution profile: Co / Ni-Ta", 560), width="stretch")
+        st.plotly_chart(clean_layout(fig, "Regular-solution profile: Co / Ni-Ta", 560), use_container_width=True)
 
         st.markdown("### Multi-time profiles")
         indices_rs = sorted(set(np.linspace(0, len(t) - 1, 5).astype(int).tolist()))
@@ -6961,7 +6961,7 @@ if type(result).__name__ == "TrainResultRS":
             fig_t.update_yaxes(title="Mole fraction", range=[-0.04, 1.04])
             st.plotly_chart(
                 clean_layout(fig_t, f"t = {format_time_label(float(t[idx_time]), float(t[-1]), paper_time_h_disp)}", 400),
-                width="stretch",
+                use_container_width=True,
             )
 
     with tab_rs2:
@@ -6972,7 +6972,7 @@ if type(result).__name__ == "TrainResultRS":
                 fig_loss.add_trace(go.Scatter(x=rs_hist["epoch"], y=rs_hist[col], mode="lines", name=col))
         fig_loss.update_xaxes(title="epoch")
         fig_loss.update_yaxes(title="loss", type="log")
-        st.plotly_chart(clean_layout(fig_loss, "Loss functions (regular-solution)", 430), width="stretch")
+        st.plotly_chart(clean_layout(fig_loss, "Loss functions (regular-solution)", 430), use_container_width=True)
 
         st.markdown("### Omega convergence")
         fig_omega = go.Figure()
@@ -6985,9 +6985,9 @@ if type(result).__name__ == "TrainResultRS":
                 fig_omega.add_trace(go.Scatter(x=rs_hist["epoch"], y=rs_hist[omega_cols_r[k]], mode="lines", name=f"{pname} right"))
         fig_omega.update_xaxes(title="epoch")
         fig_omega.update_yaxes(title="Omega value")
-        st.plotly_chart(clean_layout(fig_omega, "Omega pair-interaction convergence", 450), width="stretch")
+        st.plotly_chart(clean_layout(fig_omega, "Omega pair-interaction convergence", 450), use_container_width=True)
 
-        st.dataframe(rs_hist, width="stretch")
+        st.dataframe(rs_hist, use_container_width=True)
 
     with tab_rs3:
         st.markdown("### Omega-based reliability (regular-solution)")
@@ -7069,7 +7069,7 @@ if type(result).__name__ == "TrainResultRS":
                     "mean": float(np.mean(vals)),
                     "std": float(np.std(vals)),
                 })
-            st.dataframe(pd.DataFrame(summary_rows), width="stretch")
+            st.dataframe(pd.DataFrame(summary_rows), use_container_width=True)
 
             st.markdown("#### Posterior credible band")
             with st.spinner("Computing credible band from Omega samples..."):
@@ -7117,7 +7117,7 @@ if type(result).__name__ == "TrainResultRS":
             fig_band.update_yaxes(title="Mole Fraction", range=[-0.04, 1.04])
             st.plotly_chart(
                 clean_layout(fig_band, "Posterior credible band (regular-solution Omega)", 560),
-                width="stretch",
+                use_container_width=True,
             )
 
             if bool(inputs.get("rs_run_mcmc", False)):
@@ -7153,7 +7153,7 @@ if type(result).__name__ == "TrainResultRS":
                 fig_trace.update_yaxes(title="Omega value")
                 st.plotly_chart(
                     clean_layout(fig_trace, "MCMC trace for Omega parameters", 450),
-                    width="stretch",
+                    use_container_width=True,
                 )
 
     with tab_rs4:
@@ -7165,7 +7165,7 @@ if type(result).__name__ == "TrainResultRS":
             "x_exp": np.asarray(rs_data.x_exp_all[:50]).ravel(),
             "t_exp": np.asarray(rs_data.t_exp_all[:50]).ravel(),
             **{f"c_exp_{comp}": np.asarray(rs_data.c_exp_all[:50, j]).ravel() for j, comp in enumerate(COMPONENTS)},
-        }), width="stretch")
+        }), use_container_width=True)
 
     with tab_rs5:
         st.markdown("### 論文用 matplotlib 図 (Publication-quality figures)")
@@ -7176,7 +7176,7 @@ if type(result).__name__ == "TrainResultRS":
             dist, C_fdm_rs[-1], C_pinn_rs[-1], dist_exp, rs_data.c_exp_all,
             title="Regular-solution profile: Co / Ni-Ta",
         )
-        st.image(_pub_fig_to_bytes(fig_pub_profile), width="stretch")
+        st.image(_pub_fig_to_bytes(fig_pub_profile), use_container_width=True)
         buf_profile = io.BytesIO()
         fig_pub_profile.savefig(buf_profile, format="png", dpi=300, bbox_inches="tight", facecolor="white")
         st.download_button("Download profile (PNG, 300 dpi)", buf_profile.getvalue(),
@@ -7190,7 +7190,7 @@ if type(result).__name__ == "TrainResultRS":
             n_slices=5, n_cols=3,
             tau_max=float(t[-1]), annealing_time_h=paper_time_h_disp,
         )
-        st.image(_pub_fig_to_bytes(fig_pub_mt), width="stretch")
+        st.image(_pub_fig_to_bytes(fig_pub_mt), use_container_width=True)
         buf_mt = io.BytesIO()
         fig_pub_mt.savefig(buf_mt, format="png", dpi=300, bbox_inches="tight", facecolor="white")
         st.download_button("Download multi-time (PNG, 300 dpi)", buf_mt.getvalue(),
@@ -7199,7 +7199,7 @@ if type(result).__name__ == "TrainResultRS":
 
         st.markdown("#### 3. Training loss & Ω convergence")
         fig_pub_conv = pub_omega_convergence_figure(rs_hist, pair_names)
-        st.image(_pub_fig_to_bytes(fig_pub_conv), width="stretch")
+        st.image(_pub_fig_to_bytes(fig_pub_conv), use_container_width=True)
         buf_conv = io.BytesIO()
         fig_pub_conv.savefig(buf_conv, format="png", dpi=300, bbox_inches="tight", facecolor="white")
         st.download_button("Download convergence (PNG, 300 dpi)", buf_conv.getvalue(),
@@ -7209,7 +7209,7 @@ if type(result).__name__ == "TrainResultRS":
         if inputs.get("refine_info_rs") is not None and inputs["refine_info_rs"].get("nll_history"):
             st.markdown("#### 4. FDM refinement NLL convergence")
             fig_pub_nll = pub_nll_convergence_figure(inputs["refine_info_rs"]["nll_history"])
-            st.image(_pub_fig_to_bytes(fig_pub_nll), width="stretch")
+            st.image(_pub_fig_to_bytes(fig_pub_nll), use_container_width=True)
             buf_nll = io.BytesIO()
             fig_pub_nll.savefig(buf_nll, format="png", dpi=300, bbox_inches="tight", facecolor="white")
             st.download_button("Download NLL convergence (PNG, 300 dpi)", buf_nll.getvalue(),
@@ -7223,7 +7223,7 @@ if type(result).__name__ == "TrainResultRS":
                 dist, C_pinn_rs[-1], _band_rs_pub,
                 title="Posterior 95% credible band (Regular-solution Ω)",
             )
-            st.image(_pub_fig_to_bytes(fig_pub_band), width="stretch")
+            st.image(_pub_fig_to_bytes(fig_pub_band), use_container_width=True)
             buf_band = io.BytesIO()
             fig_pub_band.savefig(buf_band, format="png", dpi=300, bbox_inches="tight", facecolor="white")
             st.download_button("Download credible band (PNG, 300 dpi)", buf_band.getvalue(),
@@ -7305,7 +7305,7 @@ if inputs.get("diffusion_model_mode") == "left/right D":
             {"region": label, "parameter": "D_TaNi", "normalized value": Dtmp[1, 0]},
             {"region": label, "parameter": "D_TaTa", "normalized value": Dtmp[1, 1]},
         ])
-    st.dataframe(pd.DataFrame(lr_rows), width="stretch")
+    st.dataframe(pd.DataFrame(lr_rows), use_container_width=True)
 
 if C_zero is not None:
     z1, z2, z3 = st.columns(3)
@@ -7344,7 +7344,7 @@ with tab1:
             span_um=span_um,
             C_zero_final=None if C_zero is None else C_zero[-1],
         ),
-        width="stretch",
+        use_container_width=True,
     )
     st.markdown("### Predicted vs experiment diagnostics")
     if inputs.get("diffusion_model_mode") == "left/right D":
@@ -7356,7 +7356,7 @@ with tab1:
     with st.expander("Show mixed predicted-vs-experiment plot", expanded=False):
         st.plotly_chart(
             predicted_vs_experiment_plot(C_pinn[-1], x, data.x_exp, data.c_exp),
-            width="stretch",
+            use_container_width=True,
         )
 
     region_diag_width = float(inputs.get("phase_interface_width", 0.03))
@@ -7378,7 +7378,7 @@ with tab1:
                     component_name=comp,
                     region_width=region_diag_width,
                 ),
-                width="stretch",
+                use_container_width=True,
             )
 
     with st.expander("Residual summary by component and region", expanded=False):
@@ -7390,7 +7390,7 @@ with tab1:
                 data.c_exp,
                 region_width=region_diag_width,
             ),
-            width="stretch",
+            use_container_width=True,
         )
 
     st.markdown("### Multi-time profiles, separated by time")
@@ -7415,33 +7415,33 @@ with tab1:
                     C_zero_time=None if C_zero is None else C_zero[idx_time],
                     annealing_time_h=paper_time_h_for_display,
                 ),
-                width="stretch",
+                use_container_width=True,
             )
 
     with st.expander("Show combined multi-time overview", expanded=False):
         st.plotly_chart(
             multi_time_profile_plot(x, t, C_fdm, C_pinn, indices, span_um=span_um, annealing_time_h=paper_time_h_for_display),
-            width="stretch",
+            use_container_width=True,
         )
 
 with tab2:
-    st.plotly_chart(final_difference_plot(x, C_diff[-1], span_um=span_um), width="stretch")
+    st.plotly_chart(final_difference_plot(x, C_diff[-1], span_um=span_um), use_container_width=True)
     if C_zero is not None:
         st.plotly_chart(
             zero_interaction_difference_plot(x, C_pinn[-1], C_zero[-1], span_um=span_um),
-            width="stretch",
+            use_container_width=True,
         )
     h1, h2, h3 = st.columns(3)
-    h1.plotly_chart(heatmap_diff_plot(x, t, C_diff, 0, span_um=span_um), width="stretch")
-    h2.plotly_chart(heatmap_diff_plot(x, t, C_diff, 1, span_um=span_um), width="stretch")
-    h3.plotly_chart(heatmap_diff_plot(x, t, C_diff, 2, span_um=span_um), width="stretch")
+    h1.plotly_chart(heatmap_diff_plot(x, t, C_diff, 0, span_um=span_um), use_container_width=True)
+    h2.plotly_chart(heatmap_diff_plot(x, t, C_diff, 1, span_um=span_um), use_container_width=True)
+    h3.plotly_chart(heatmap_diff_plot(x, t, C_diff, 2, span_um=span_um), use_container_width=True)
 with tab3:
     c1, c2 = st.columns(2)
-    c1.plotly_chart(loss_plot(hist), width="stretch")
-    c2.plotly_chart(D_history_plot(hist, D_true), width="stretch")
+    c1.plotly_chart(loss_plot(hist), use_container_width=True)
+    c2.plotly_chart(D_history_plot(hist, D_true), use_container_width=True)
 
     st.markdown("### Diffusion matrix")
-    st.dataframe(diffusion_matrix_table(D_true, D_pinn), width="stretch")
+    st.dataframe(diffusion_matrix_table(D_true, D_pinn), use_container_width=True)
 
     xr, tr, R = residual_grid(model, data.t_start, float(inputs["t_max"]))
     r_ni = float(np.sqrt(np.mean(R[:, :, 0] ** 2)))
@@ -7451,7 +7451,7 @@ with tab3:
     q2.metric("PDE residual RMSE Ta", f"{r_ta:.3e}")
 
     st.markdown("### Training history")
-    st.dataframe(hist, width="stretch")
+    st.dataframe(hist, use_container_width=True)
 
 with tab4:
     st.markdown(
@@ -7538,7 +7538,7 @@ with tab4:
                 "prior_mean_lr": prior_mean_lr,
             }
         )
-        st.dataframe(theta_lr_df, width="stretch")
+        st.dataframe(theta_lr_df, use_container_width=True)
 
         with st.spinner("Low-cost left/right reliability: 6D Laplace approximation..."):
             low_rel_lr = cached_laplace_reliability_lr(
@@ -7579,7 +7579,7 @@ with tab4:
                         "eig(cov clipped)": low_rel_lr.get("cov_eigval_clipped", np.array([])),
                     }
                 ),
-                width="stretch",
+                use_container_width=True,
             )
 
         if h_non_pd_lr:
@@ -7629,10 +7629,10 @@ with tab4:
         lr_tables = [reliability_summary_table_lr(f"Laplace left/right {len(theta_hat_lr)}D", low_rel_lr)]
         if high_rel_lr is not None and len(high_rel_lr["samples"]) > 5:
             lr_tables.append(reliability_summary_table_lr(f"MCMC left/right {len(theta_hat_lr)}D", high_rel_lr))
-        st.dataframe(pd.concat(lr_tables, ignore_index=True), width="stretch")
+        st.dataframe(pd.concat(lr_tables, ignore_index=True), use_container_width=True)
 
         if high_rel_lr is not None and len(high_rel_lr["samples"]) > 5:
-            st.plotly_chart(mcmc_trace_plot_lr(high_rel_lr["samples"]), width="stretch")
+            st.plotly_chart(mcmc_trace_plot_lr(high_rel_lr["samples"]), use_container_width=True)
 
         st.markdown("#### Left/right credible bands on profile")
         st.caption("Each posterior sample is evaluated by the two-region FDM, not by averaged single-D FDM.")
@@ -7657,7 +7657,7 @@ with tab4:
                 span_um=span_um,
                 title=f"Left/right {len(theta_hat_lr)}D Laplace credible band on Fig.11-style profile",
             ),
-            width="stretch",
+            use_container_width=True,
         )
 
         if high_rel_lr is not None and len(high_rel_lr["samples"]) > 5:
@@ -7682,7 +7682,7 @@ with tab4:
                     span_um=span_um,
                     title=f"Left/right {len(theta_hat_lr)}D MCMC credible band on Fig.11-style profile",
                 ),
-                width="stretch",
+                use_container_width=True,
             )
 
         st.info(
@@ -7749,7 +7749,7 @@ with tab4:
                     "eig(cov clipped)": low_rel.get("cov_eigval_clipped", np.array([])),
                 }
             )
-            st.dataframe(hdiag_df, width="stretch")
+            st.dataframe(hdiag_df, use_container_width=True)
 
         if h_non_pd:
             st.error(
@@ -7867,17 +7867,17 @@ with tab4:
             rel_table = low_table
 
         st.markdown("### Posterior interval of inferred interaction coefficients")
-        st.dataframe(rel_table, width="stretch")
+        st.dataframe(rel_table, use_container_width=True)
 
         st.plotly_chart(
             posterior_parameter_plot(low_rel["samples"], None if high_rel is None else high_rel["samples"]),
-            width="stretch",
+            use_container_width=True,
         )
 
         if high_rel is not None and len(high_rel["samples"]) > 5:
             st.markdown("### MCMC trace diagnostic")
             st.caption("保存されたMCMCサンプル列です。大きなドリフトが残っている場合は、burn-in不足や混合不良の可能性があります。")
-            st.plotly_chart(mcmc_trace_plot(high_rel["samples"]), width="stretch")
+            st.plotly_chart(mcmc_trace_plot(high_rel["samples"]), use_container_width=True)
 
         st.markdown("### Likelihood/posterior credible bands on profile")
         st.caption(
@@ -7904,7 +7904,7 @@ with tab4:
                 span_um=span_um,
                 title="Low-cost Laplace credible band on Fig.11-style profile",
             ),
-            width="stretch",
+            use_container_width=True,
         )
 
         if high_rel is not None and len(high_rel["samples"]) > 5:
@@ -7928,7 +7928,7 @@ with tab4:
                     span_um=span_um,
                     title="High-cost MCMC credible band on Fig.11-style profile",
                 ),
-                width="stretch",
+                use_container_width=True,
             )
 
         st.markdown("### Likelihood / posterior contour")
@@ -7971,7 +7971,7 @@ with tab4:
             )
         st.plotly_chart(
             likelihood_contour_plot(gx, gy, gz, xl, yl, theta_hat, axis_i, axis_j),
-            width="stretch",
+            use_container_width=True,
         )
 
         st.markdown(
@@ -8027,14 +8027,14 @@ This tab is designed for preparing the TOFA abstract. It summarizes whether the 
 
     st.markdown("### Known true D vs PINNs-estimated D")
     st.caption("For synthetic validation, true D is known from the FDM teacher. This table is not used for real experimental data.")
-    st.dataframe(abstract_metrics["D_compare"], width="stretch")
+    st.dataframe(abstract_metrics["D_compare"], use_container_width=True)
 
     st.markdown("### Profile error and improvement over zero-interaction")
-    st.plotly_chart(abstract_validation_plot(abstract_metrics), width="stretch")
-    st.dataframe(abstract_metrics["rmse_improvement"], width="stretch")
+    st.plotly_chart(abstract_validation_plot(abstract_metrics), use_container_width=True)
+    st.dataframe(abstract_metrics["rmse_improvement"], use_container_width=True)
 
     with st.expander("Component/region residual summary", expanded=False):
-        st.dataframe(abstract_metrics["profile_rmse"], width="stretch")
+        st.dataframe(abstract_metrics["profile_rmse"], use_container_width=True)
 
     st.download_button(
         "Download abstract D comparison CSV",
@@ -8059,9 +8059,9 @@ This tab is designed for preparing the TOFA abstract. It summarizes whether the 
         )
         st.plotly_chart(
             multi_time_pseudo_exp_rmse_plot(mt_rmse_df, paper_time_h_for_display, float(t[-1])),
-            width="stretch",
+            use_container_width=True,
         )
-        st.dataframe(mt_rmse_df, width="stretch")
+        st.dataframe(mt_rmse_df, use_container_width=True)
         st.info(
             "Multi-time pseudo-exp is active. This gives the inverse problem time-evolution constraints, "
             "which is usually more informative for cross-interdiffusion terms than a final-profile-only validation."
@@ -8138,7 +8138,7 @@ D_physical = D_normalized * L_scale^2 / t_scale
         "D_TaTa_self [m2/s]": inputs.get("self_D_Ta_phys", 0.0),
         "prior weight": inputs.get("diag_prior_weight", 0.0),
     }
-    st.dataframe(pd.DataFrame([self_info]), width="stretch")
+    st.dataframe(pd.DataFrame([self_info]), use_container_width=True)
     if (
         inputs.get("diffusion_model_mode") == "left/right D"
         and inputs.get("diag_constraint_mode") == "fix diagonal terms"
@@ -8159,7 +8159,7 @@ D_physical = D_normalized * L_scale^2 / t_scale
                     "self log normalized": [inputs["self_log_diag"][0], inputs["self_log_diag"][1]],
                 }
             ),
-            width="stretch",
+            use_container_width=True,
         )
     else:
         st.info("Self-diffusion anchors were not used in this run. Enable them in the sidebar before running if values are available.")
@@ -8176,7 +8176,7 @@ D_physical = D_normalized * L_scale^2 / t_scale
             length_um=paper_length_um_eff,
             time_h=paper_time_h_eff,
         ),
-        width="stretch",
+        use_container_width=True,
     )
     if inputs.get("diffusion_model_mode") == "left/right D":
         st.caption("Left/right region matrices in physical units:")
@@ -8189,7 +8189,7 @@ D_physical = D_normalized * L_scale^2 / t_scale
                 {"region": label, "parameter": "D_TaNi", "physical [m2/s]": Dtmp_phys[1, 0]},
                 {"region": label, "parameter": "D_TaTa", "physical [m2/s]": Dtmp_phys[1, 1]},
             ])
-        st.dataframe(pd.DataFrame(lr_phys_rows), width="stretch")
+        st.dataframe(pd.DataFrame(lr_phys_rows), use_container_width=True)
 
     st.markdown("### Upload CALPHAD / DICTRA interdiffusion matrix CSV")
     st.caption("Required columns: D_NiNi, D_NiTa, D_TaNi, D_TaTa. Optional: T_C, x_Co, x_Ni, x_Ta, frame, dependent.")
@@ -8220,10 +8220,10 @@ D_physical = D_normalized * L_scale^2 / t_scale
                 time_h=paper_time_h_eff,
             )
             st.markdown("#### Representative comparison table")
-            st.dataframe(compare_df, width="stretch")
-            st.plotly_chart(D_matrix_bar_plot(compare_df), width="stretch")
+            st.dataframe(compare_df, use_container_width=True)
+            st.plotly_chart(D_matrix_bar_plot(compare_df), use_container_width=True)
             if len(calphad_df) > 1:
-                st.plotly_chart(calphad_D_composition_plot(calphad_df, D_pinn_phys), width="stretch")
+                st.plotly_chart(calphad_D_composition_plot(calphad_df, D_pinn_phys), use_container_width=True)
 
             st.download_button(
                 "Download PINNs vs CALPHAD D comparison CSV",
@@ -8268,7 +8268,7 @@ D_physical = D_normalized * L_scale^2 / t_scale
                         {"parameter": "M_eff_TaTa", "value": M_eff[1, 1]},
                     ]
                 ),
-                width="stretch",
+                use_container_width=True,
             )
 
     st.markdown("### Upload DICTRA / CALPHAD profile CSV")
@@ -8290,7 +8290,7 @@ D_physical = D_normalized * L_scale^2 / t_scale
                     C_zero_final=None if C_zero is None else C_zero[-1],
                     span_um=span_um,
                 ),
-                width="stretch",
+                use_container_width=True,
             )
 
 

--- a/co_ni_ta_pinn_diffusion_reliability.py
+++ b/co_ni_ta_pinn_diffusion_reliability.py
@@ -6618,25 +6618,8 @@ FDM教師データと疑似実験点が生成された直後の確認図です�
         )
 
         refine_info_rs = None
-        if do_fdm_refine:
-            st.info("FDM順問題による尤度でΩを再最適化しています...")
-            refine_status = st.empty()
-            refine_bar = st.progress(0.0)
-            _omega_pair_names = ["Ω_CoNi", "Ω_CoTa", "Ω_NiTa"]
-            theta_refined, refine_info_rs = refine_omega_by_fdm_likelihood(
-                nll_fun_rs, theta_hat_rs, maxiter=int(fdm_refine_maxiter), verbose=False,
-                progress_status=refine_status, progress_bar=refine_bar,
-                pair_names=_omega_pair_names,
-            )
-            if np.all(np.isfinite(theta_refined)):
-                theta_hat_rs = theta_refined
-                overwrite_model_omega_from_theta(rs_model, theta_hat_rs, learn_lr_omega)
-            _ri = refine_info_rs
-            st.success(
-                f"FDM refinement 完了: NLL {_ri['nll_before']:.2f} → {_ri['nll_after']:.2f}  "
-                f"({_ri['nfev']} evals, {_ri.get('elapsed_s', 0):.1f}s, "
-                f"{'converged' if _ri['success'] else 'maxiter reached'})"
-            )
+        # FDM refinement is deferred to the result display section
+        # so the user can inspect profiles immediately after PINN training.
 
         rs_result = TrainResultRS(
             model=rs_model,
@@ -6652,7 +6635,10 @@ FDM教師データと疑似実験点が生成された直後の確認図です�
             "use_chemical_potential": True,
             "learn_lr_omega": bool(learn_lr_omega),
             "theta_hat_rs": theta_hat_rs.tolist(),
-            "refine_info_rs": refine_info_rs,
+            "refine_info_rs": None,
+            "do_fdm_refine": bool(do_fdm_refine),
+            "fdm_refine_maxiter": int(fdm_refine_maxiter),
+            "prior_mean_rs": prior_mean_rs.tolist(),
             "fdm_teacher_mode": str(fdm_teacher_mode),
             "span_um": span_um,
             "noise": noise,
@@ -6873,6 +6859,59 @@ if type(result).__name__ == "TrainResultRS":
         rc1.metric("NLL before", f"{ri['nll_before']:.2f}")
         rc2.metric("NLL after", f"{ri['nll_after']:.2f}")
         rc3.metric("Evaluations", f"{ri['nfev']}")
+    elif inputs.get("do_fdm_refine", False):
+        st.markdown("### FDM順問題による尤度でΩを再最適化")
+        st.caption(
+            "PINN学習後のΩ推定値を出発点として、FDM順問題の尤度を最小化してΩを精密化します。"
+        )
+        if st.button("Ωを再最適化する", key="btn_fdm_refine_rs"):
+            _eg_ref = 5.0e-3
+            c0_full_ref = make_initial_profile_ternary_rs(
+                x,
+                np.array([1.0 - _eg_ref, _eg_ref / 2, _eg_ref / 2]),
+                np.array([_eg_ref / 2, 0.9, 0.1]),
+                x0=0.5, width=float(inputs["phase_interface_width"]),
+            )
+            _learn_lr = bool(inputs["learn_lr_omega"])
+            _prior_mean = np.array(inputs["prior_mean_rs"], dtype=float)
+            nll_fun_ref = lambda th: gaussian_nll_multitime_rs(
+                th, 3, _learn_lr, c0_full_ref, x,
+                rs_data.x_exp_all, rs_data.t_exp_all, rs_data.c_exp_all,
+                sigma=float(inputs["rs_like_sigma"]),
+                dt=float(inputs["rs_fdm_dt"]),
+                nsteps=int(inputs["rs_fdm_nsteps"]),
+                save_every=int(inputs["rs_fdm_save_every"]),
+                mobility=rs_result.mobility,
+                RT=float(inputs["rs_RT"]),
+                x_interface=0.5,
+                omega_width=float(inputs.get("rs_omega_blend_width", inputs["phase_interface_width"])),
+                prior_mean=_prior_mean, prior_std=5.0,
+                log_M_endmembers=inputs.get("log_M_endmembers"),
+            )
+            _theta_hat = np.array(inputs["theta_hat_rs"], dtype=float)
+            st.info("FDM順問題による尤度でΩを再最適化しています...")
+            refine_status = st.empty()
+            refine_bar = st.progress(0.0)
+            _omega_pair_names = ["Ω_CoNi", "Ω_CoTa", "Ω_NiTa"]
+            theta_refined, refine_info = refine_omega_by_fdm_likelihood(
+                nll_fun_ref, _theta_hat,
+                maxiter=int(inputs.get("fdm_refine_maxiter", 180)),
+                verbose=False,
+                progress_status=refine_status, progress_bar=refine_bar,
+                pair_names=_omega_pair_names,
+            )
+            if np.all(np.isfinite(theta_refined)):
+                overwrite_model_omega_from_theta(rs_model, theta_refined, _learn_lr)
+                inputs["theta_hat_rs"] = theta_refined.tolist()
+            inputs["refine_info_rs"] = refine_info
+            st.session_state.fig11_inputs_v12 = inputs
+            _ri = refine_info
+            st.success(
+                f"FDM refinement 完了: NLL {_ri['nll_before']:.2f} → {_ri['nll_after']:.2f}  "
+                f"({_ri['nfev']} evals, {_ri.get('elapsed_s', 0):.1f}s, "
+                f"{'converged' if _ri['success'] else 'maxiter reached'})"
+            )
+            safe_streamlit_rerun()
 
     tab_rs1, tab_rs2, tab_rs3, tab_rs4, tab_rs5 = st.tabs(
         ["Profiles", "Training", "Omega reliability", "Data", "Publication figures"]

--- a/co_ni_ta_pinn_diffusion_reliability.py
+++ b/co_ni_ta_pinn_diffusion_reliability.py
@@ -6866,10 +6866,12 @@ if type(result).__name__ == "TrainResultRS":
         )
         if st.button("Ωを再最適化する", key="btn_fdm_refine_rs"):
             _eg_ref = 5.0e-3
+            _c_left_ref = np.array([1.0 - _eg_ref, _eg_ref / 2, _eg_ref / 2])
+            _c_left_ref /= _c_left_ref.sum()
+            _c_right_ref = np.array([_eg_ref / 2, 0.9, 0.1])
+            _c_right_ref /= _c_right_ref.sum()
             c0_full_ref = make_initial_profile_ternary_rs(
-                x,
-                np.array([1.0 - _eg_ref, _eg_ref / 2, _eg_ref / 2]),
-                np.array([_eg_ref / 2, 0.9, 0.1]),
+                x, _c_left_ref, _c_right_ref,
                 x0=0.5, width=float(inputs["phase_interface_width"]),
             )
             _learn_lr = bool(inputs["learn_lr_omega"])

--- a/co_ni_ta_pinn_diffusion_reliability.py
+++ b/co_ni_ta_pinn_diffusion_reliability.py
@@ -6319,7 +6319,7 @@ D_norm = D_phys * t_scale / L_scale^2
             ["logD_NiNi vs logD_TaTa", "logD_NiNi vs rho_raw", "logD_TaTa vs rho_raw"],
         )
 
-    run = st.button("Run Fig.11-style FDM → PINN", type="primary", width="stretch")
+    run = st.button("Run Fig.11-style FDM → PINN", type="primary")
 
 
 if "fig11_result_v12" not in st.session_state:


### PR DESCRIPTION
## Summary

PINN学習完了後すぐに拡散プロファイルを表示するように変更しました。

**変更前:** PINN学習 → FDM尤度再最適化 → プロファイル表示（再最適化完了まで待つ必要あり）

**変更後:** PINN学習 → **すぐにプロファイル表示** → 「Ωを再最適化する」ボタンで任意のタイミングで再最適化を実行

### 具体的な変更
- FDM re-optimization を学習フローから分離し、結果表示セクションのボタンに移動
- ボタン押下時に NLL 関数を再構成して `refine_omega_by_fdm_likelihood` を実行
- 再最適化完了後はモデルと `inputs` を更新して結果を反映
- 再最適化しない場合でも、すべてのプロファイル・training history・reliability評価が正常に表示される

## Review & Testing Checklist for Human

- [ ] RS mode で PINN 学習実行後、すぐにプロファイルが表示されることを確認
- [ ] 「Ωを再最適化する」ボタンを押して、NLL が改善されることを確認
- [ ] 再最適化後にプロファイルが更新されていることを確認
- [ ] Fickian D matrix mode が従来通り動作することを確認（回帰テスト）

### Notes
- Ω reliability (Laplace/MCMC) タブは再最適化前後どちらでも動作します
- `do_fdm_refine` チェックボックスが OFF の場合、ボタンは表示されません

Link to Devin session: https://app.devin.ai/sessions/b65d78c9984846d6b1b1ea7067923710
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->