### PR TITLE
refactor: SQS出力をBCC_SQS/A8B8形式に変更、INCAR既存BCC_B2設定に統一

### DIFF
--- a/vasp_inputs/generate_refractory_b2.py
+++ b/vasp_inputs/generate_refractory_b2.py
@@ -146,22 +146,22 @@ Gamma
 
 
 def generate_potcar_script(base_dir, calculations):
-    """Generate shell script to create POTCAR from $VASPPOT."""
+    """Generate shell script to create POTCAR from $VASP_PP_PATH."""
     lines = [
         "#!/bin/bash",
         "# POTCAR generation script for B2 refractory calculations",
         "# Usage: bash make_potcar.sh",
-        "# Requires: $VASPPOT environment variable pointing to VASP pseudopotential directory",
-        "#   e.g., export VASPPOT=/path/to/potpaw_PBE.64",
+        "# Requires: $VASP_PP_PATH environment variable pointing to VASP pseudopotential directory",
+        "#   e.g., export VASP_PP_PATH=/path/to/potpaw_PBE.64",
         "",
-        'if [ -z "$VASPPOT" ]; then',
-        '    echo "Error: VASPPOT environment variable is not set."',
+        'if [ -z "$VASP_PP_PATH" ]; then',
+        '    echo "Error: VASP_PP_PATH environment variable is not set."',
         '    echo "Set it to the PAW-PBE pseudopotential directory, e.g.:"',
-        '    echo "  export VASPPOT=/path/to/potpaw_PBE.64"',
+        '    echo "  export VASP_PP_PATH=/path/to/potpaw_PBE.64"',
         '    exit 1',
         'fi',
         "",
-        'echo "Using VASPPOT=$VASPPOT"',
+        'echo "Using VASP_PP_PATH=$VASP_PP_PATH"',
         'echo "Generating POTCAR files for B2 refractory calculations..."',
         "",
     ]
@@ -172,7 +172,7 @@ def generate_potcar_script(base_dir, calculations):
         lines.append(f"# --- {calc_name} ---")
         lines.append(f'echo "  {calc_name}: {pot_corner} + {pot_body}"')
         lines.append(
-            f'cat "$VASPPOT"/{pot_corner}/POTCAR "$VASPPOT"/{pot_body}/POTCAR '
+            f'cat "$VASP_PP_PATH"/{pot_corner}/POTCAR "$VASP_PP_PATH"/{pot_body}/POTCAR '
             f'> {calc_name}/POTCAR'
         )
         lines.append(

--- a/vasp_inputs/generate_refractory_sqs.py
+++ b/vasp_inputs/generate_refractory_sqs.py
@@ -205,7 +205,7 @@ Gamma
 
 
 def generate_potcar_script(base_dir, calculations):
-    """Generate shell script to create POTCAR from $VASP_PP_PATH."""
+    """Generate shell script to create POTCAR from $VASP_PP_PATH/potpaw_PBE."""
     lines = [
         "#!/bin/bash",
         "# POTCAR generation script for BCC_SQS refractory calculations",
@@ -214,12 +214,13 @@ def generate_potcar_script(base_dir, calculations):
         "",
         'if [ -z "$VASP_PP_PATH" ]; then',
         '    echo "Error: VASP_PP_PATH environment variable is not set."',
-        '    echo "Set it to the PAW-PBE pseudopotential directory, e.g.:"',
-        '    echo "  export VASP_PP_PATH=/path/to/potpaw_PBE.64"',
+        '    echo "Set it to the VASP pseudopotential base directory, e.g.:"',
+        '    echo "  export VASP_PP_PATH=/path/to/vasp_pp"',
         '    exit 1',
         'fi',
         "",
-        'echo "Using VASP_PP_PATH=$VASP_PP_PATH"',
+        'PP_DIR="$VASP_PP_PATH/potpaw_PBE"',
+        'echo "Using PP_DIR=$PP_DIR"',
         'echo "Generating POTCAR files for BCC_SQS refractory calculations..."',
         "",
     ]
@@ -232,14 +233,14 @@ def generate_potcar_script(base_dir, calculations):
             lines.append(f"# --- {calc_name} (pure reference) ---")
             lines.append(f'echo "  {calc_name}: {pot_a}"')
             lines.append(
-                f'cat "$VASP_PP_PATH"/{pot_a}/POTCAR '
+                f'cat "$PP_DIR"/{pot_a}/POTCAR '
                 f'> {calc_name}/POTCAR'
             )
         else:
             lines.append(f"# --- {calc_name} ---")
             lines.append(f'echo "  {calc_name}: {pot_a} + {pot_b}"')
             lines.append(
-                f'cat "$VASP_PP_PATH"/{pot_a}/POTCAR "$VASP_PP_PATH"/{pot_b}/POTCAR '
+                f'cat "$PP_DIR"/{pot_a}/POTCAR "$PP_DIR"/{pot_b}/POTCAR '
                 f'> {calc_name}/POTCAR'
             )
         lines.append(
@@ -266,10 +267,10 @@ def generate_run_script(base_dir, calculations):
         pot_b = POTCAR_VARIANTS.get(el_b, el_b)
         if el_a == el_b:
             potcar_lines.append(
-                f'cat "$VASP_PP_PATH"/{pot_a}/POTCAR > "$BASEDIR"/{calc_name}/POTCAR')
+                f'cat "$PP_DIR"/{pot_a}/POTCAR > "$BASEDIR"/{calc_name}/POTCAR')
         else:
             potcar_lines.append(
-                f'cat "$VASP_PP_PATH"/{pot_a}/POTCAR "$VASP_PP_PATH"/{pot_b}/POTCAR > "$BASEDIR"/{calc_name}/POTCAR')
+                f'cat "$PP_DIR"/{pot_a}/POTCAR "$PP_DIR"/{pot_b}/POTCAR > "$BASEDIR"/{calc_name}/POTCAR')
 
     potcar_block = "\n".join(potcar_lines)
 
@@ -302,12 +303,13 @@ echo "=== Step 1: POTCAR Generation ===" | tee $LOG
 
 if [ -z "$VASP_PP_PATH" ]; then
     echo "Error: VASP_PP_PATH environment variable is not set." | tee -a $LOG
-    echo "Set it to the PAW-PBE pseudopotential directory, e.g.:" | tee -a $LOG
-    echo "  export VASP_PP_PATH=/path/to/potpaw_PBE.64" | tee -a $LOG
+    echo "Set it to the VASP pseudopotential base directory, e.g.:" | tee -a $LOG
+    echo "  export VASP_PP_PATH=/path/to/vasp_pp" | tee -a $LOG
     exit 1
 fi
 
-echo "Using VASP_PP_PATH=$VASP_PP_PATH" | tee -a $LOG
+PP_DIR="$VASP_PP_PATH/potpaw_PBE"
+echo "Using PP_DIR=$PP_DIR" | tee -a $LOG
 echo "Generating POTCAR for {len(calculations)} calculations..." | tee -a $LOG
 
 {potcar_block}
@@ -569,7 +571,7 @@ def main():
     print(f"  Elements: {', '.join(elements)}")
     print()
     print("Next steps:")
-    print(f"  1. export VASP_PP_PATH=/path/to/potpaw_PBE.64")
+    print(f"  1. export VASP_PP_PATH=/path/to/vasp_pp  # (potpaw_PBE/ が含まれるディレクトリ)")
     print(f"  2. cd {os.path.basename(base_dir)}")
     print(f"  3. bash run_all.sh   # POTCAR生成→並列計算→結果抽出 (all-in-one)")
     print()

--- a/vasp_inputs/generate_refractory_sqs.py
+++ b/vasp_inputs/generate_refractory_sqs.py
@@ -394,26 +394,23 @@ def generate_extract_script(base_dir):
     """Generate Python script to extract results and compute Omega_sf."""
     content = '''#!/usr/bin/env python3
 """
-Extract lattice constants from completed SQS refractory VASP calculations
+Extract lattice constants from completed SQS VASP calculations
 and compute Omega_sf values.
 
 Omega_sf = (V_sqs - V_vegard) / V_vegard
 
-where V_sqs = a_sqs^3 / 16 (volume per atom from 16-atom supercell)
+where V_sqs = volume per atom from SQS calculation
       V_vegard = 0.5 * V_A + 0.5 * V_B (Vegard average for 50:50)
-      V_A, V_B = pure element BCC atomic volumes (from same-element SQS or King)
+      V_A, V_B = pure element atomic volumes FROM SQS SAME-ELEMENT CALCULATIONS (A8A8)
+
+Important: Vegard reference uses SQS same-element results (not external data)
+to ensure consistent computational conditions (k-mesh, ENCUT, supercell size).
 """
 
 import os
 import csv
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-
-# King experimental atomic volumes (Å³) for reference
-KING_VOLUMES = {
-    "Cr": 12.01, "Hf": 22.31, "Mo": 15.58, "Nb": 17.98,
-    "Ta": 18.01, "Ti": 17.65, "V": 13.82, "W": 15.86, "Zr": 23.28,
-}
 
 
 def extract_lattice_from_contcar(contcar_path):
@@ -436,13 +433,44 @@ def extract_lattice_from_contcar(contcar_path):
     return a_eff, vol
 
 
-results = []
+# Step 1: Extract same-element references (A8A8) for Vegard baseline
+print("SQS Results Extraction")
+print("=" * 70)
+print("\\nStep 1: Extracting same-element references (A8A8)...")
+
+pure_volumes = {}  # element -> vol_per_atom from SQS same-element calc
 dirs = sorted([d for d in os.listdir(BASE_DIR)
                if os.path.isdir(os.path.join(BASE_DIR, d))
                and d[0].isupper() and '8' in d])
 
-print("SQS-16 Refractory Results:")
-print("=" * 70)
+for d in dirs:
+    # Check if same-element (e.g., Cr8Cr8)
+    parts = d.replace('8', ' ').split()
+    if len(parts) == 2 and parts[0] == parts[1]:
+        el = parts[0]
+        contcar = os.path.join(BASE_DIR, d, "CONTCAR")
+        if os.path.exists(contcar):
+            a_eff, vol_total = extract_lattice_from_contcar(contcar)
+            vol_per_atom = vol_total / 16.0
+            pure_volumes[el] = vol_per_atom
+            print(f"  {d:8s}: V/atom = {vol_per_atom:.4f} Å³")
+        else:
+            print(f"  {d:8s}: CONTCAR not found (not converged?)")
+
+print(f"\\n  Found {len(pure_volumes)} pure element references.")
+
+if len(pure_volumes) == 0:
+    print("\\nError: No same-element references found. Cannot compute Omega_sf.")
+    print("Run same-element calculations first (A8A8 directories).")
+    import sys
+    sys.exit(1)
+
+# Step 2: Extract binary pairs and compute Omega_sf
+print("\\nStep 2: Extracting binary pairs and computing Omega_sf...")
+print("-" * 70)
+
+results = []
+missing_ref = []
 
 for d in dirs:
     contcar = os.path.join(BASE_DIR, d, "CONTCAR")
@@ -450,9 +478,7 @@ for d in dirs:
         print(f"  {d}: CONTCAR not found")
         continue
 
-    # Parse elements from directory name (e.g., "Cr8Hf8")
-    pair_name = d
-    # Elements are in POSCAR header
+    # Parse elements from POSCAR header
     poscar = os.path.join(BASE_DIR, d, "POSCAR")
     with open(poscar, "r") as f:
         poscar_lines = f.readlines()
@@ -463,14 +489,21 @@ for d in dirs:
     a_eff, vol_total = extract_lattice_from_contcar(contcar)
     vol_per_atom = vol_total / 16.0
 
-    # Compute Omega_sf
-    v_a = KING_VOLUMES[el_a]
-    v_b = KING_VOLUMES[el_b]
+    # Compute Omega_sf using SQS same-element references
+    if el_a not in pure_volumes:
+        missing_ref.append((d, el_a))
+        continue
+    if el_b not in pure_volumes:
+        missing_ref.append((d, el_b))
+        continue
+
+    v_a = pure_volumes[el_a]
+    v_b = pure_volumes[el_b]
     v_vegard = 0.5 * v_a + 0.5 * v_b
     omega_sf = (vol_per_atom - v_vegard) / v_vegard
 
     results.append({
-        "pair": pair_name,
+        "pair": d,
         "element_A": el_a,
         "element_B": el_b,
         "a_supercell": a_eff,
@@ -478,10 +511,31 @@ for d in dirs:
         "v_vegard": v_vegard,
         "omega_sf": omega_sf,
     })
-    print(f"  {pair_name:8s}: a_eff = {a_eff:.4f} Å, "
+    print(f"  {d:8s}: a_eff = {a_eff:.4f} Å, "
           f"V/atom = {vol_per_atom:.3f} Å³, "
           f"V_Vegard = {v_vegard:.3f} Å³, "
-          f"Ω_sf = {omega_sf:+.4f}")
+          f"Ω_sf = {omega_sf:+.5f}")
+
+if missing_ref:
+    print(f"\\n  WARNING: {len(missing_ref)} pairs skipped (missing pure reference):")
+    for d, el in missing_ref[:10]:
+        print(f"    {d} (needs {el}8{el}8)")
+    if len(missing_ref) > 10:
+        print(f"    ... and {len(missing_ref) - 10} more")
+
+# Step 3: Summary statistics
+print("\\n" + "=" * 70)
+print("Summary:")
+n_pos = sum(1 for r in results if r["omega_sf"] > 0)
+n_neg = sum(1 for r in results if r["omega_sf"] < 0)
+n_zero = sum(1 for r in results if r["omega_sf"] == 0)
+print(f"  Total pairs: {len(results)}")
+print(f"  Positive Ω_sf (expansion): {n_pos} ({100*n_pos/max(len(results),1):.0f}%)")
+print(f"  Negative Ω_sf (contraction): {n_neg} ({100*n_neg/max(len(results),1):.0f}%)")
+if results:
+    omegas = [r["omega_sf"] for r in results]
+    print(f"  Range: [{min(omegas):+.5f}, {max(omegas):+.5f}]")
+    print(f"  Mean: {sum(omegas)/len(omegas):+.5f}")
 
 # Save to CSV
 csv_path = os.path.join(BASE_DIR, "sqs_refractory_results.csv")
@@ -493,8 +547,6 @@ with open(csv_path, "w", newline="") as f:
     writer.writerows(results)
 
 print(f"\\nSaved {len(results)} results to {csv_path}")
-print(f"\\nComparison with B2 data can be done by running:")
-print(f"  python compare_b2_sqs.py")
 '''
     with open(os.path.join(base_dir, "extract_results.py"), "w") as f:
         f.write(content)

--- a/vasp_inputs/generate_refractory_sqs.py
+++ b/vasp_inputs/generate_refractory_sqs.py
@@ -190,21 +190,21 @@ Gamma
 
 
 def generate_potcar_script(base_dir, calculations):
-    """Generate shell script to create POTCAR from $VASPPOT."""
+    """Generate shell script to create POTCAR from $VASP_PP_PATH."""
     lines = [
         "#!/bin/bash",
         "# POTCAR generation script for BCC_SQS refractory calculations",
         "# Usage: bash make_potcar.sh",
-        "# Requires: $VASPPOT environment variable",
+        "# Requires: $VASP_PP_PATH environment variable",
         "",
-        'if [ -z "$VASPPOT" ]; then',
-        '    echo "Error: VASPPOT environment variable is not set."',
+        'if [ -z "$VASP_PP_PATH" ]; then',
+        '    echo "Error: VASP_PP_PATH environment variable is not set."',
         '    echo "Set it to the PAW-PBE pseudopotential directory, e.g.:"',
-        '    echo "  export VASPPOT=/path/to/potpaw_PBE.64"',
+        '    echo "  export VASP_PP_PATH=/path/to/potpaw_PBE.64"',
         '    exit 1',
         'fi',
         "",
-        'echo "Using VASPPOT=$VASPPOT"',
+        'echo "Using VASP_PP_PATH=$VASP_PP_PATH"',
         'echo "Generating POTCAR files for BCC_SQS refractory calculations..."',
         "",
     ]
@@ -217,14 +217,14 @@ def generate_potcar_script(base_dir, calculations):
             lines.append(f"# --- {calc_name} (pure reference) ---")
             lines.append(f'echo "  {calc_name}: {pot_a}"')
             lines.append(
-                f'cat "$VASPPOT"/{pot_a}/POTCAR '
+                f'cat "$VASP_PP_PATH"/{pot_a}/POTCAR '
                 f'> {calc_name}/POTCAR'
             )
         else:
             lines.append(f"# --- {calc_name} ---")
             lines.append(f'echo "  {calc_name}: {pot_a} + {pot_b}"')
             lines.append(
-                f'cat "$VASPPOT"/{pot_a}/POTCAR "$VASPPOT"/{pot_b}/POTCAR '
+                f'cat "$VASP_PP_PATH"/{pot_a}/POTCAR "$VASP_PP_PATH"/{pot_b}/POTCAR '
                 f'> {calc_name}/POTCAR'
             )
         lines.append(

--- a/vasp_inputs/generate_refractory_sqs.py
+++ b/vasp_inputs/generate_refractory_sqs.py
@@ -21,10 +21,11 @@ Usage:
     python generate_refractory_sqs.py
 
 Output structure:
-    SQS_refractory/
-    ├── CrHf_sqs16/   (INCAR, POSCAR, KPOINTS)
-    ├── CrMo_sqs16/
+    BCC_SQS/
+    ├── Cr8Hf8/   (INCAR, POSCAR, KPOINTS)
+    ├── Cr8Mo8/
     ├── ...
+    ├── Cr8Cr8/   (same-element references)
     ├── make_potcar.sh
     └── run_all.sh
 """
@@ -100,39 +101,20 @@ def estimate_sqs_a0(el_a, el_b):
 
 
 def write_incar_sqs(dirpath):
-    """Write INCAR for SQS structure optimization (16 atoms)."""
-    content = """SYSTEM = BCC SQS-16 optimization (refractory)
-
-# Electronic relaxation
-ENCUT  = 520
-PREC   = Accurate
-EDIFF  = 1E-6
-NELM   = 200
-LREAL  = Auto
-
-# Ionic relaxation
-IBRION = 2
-ISIF   = 3
-NSW    = 200
-EDIFFG = -0.01
-
-# Smearing (metals)
-ISMEAR = 1
-SIGMA  = 0.2
-
-# Exchange-correlation
-GGA    = PE
-
-# Spin polarization (important for Cr)
-ISPIN  = 2
-
-# Output
-LORBIT = 11
-LWAVE  = .FALSE.
-LCHARG = .FALSE.
-
-# Performance (16 atoms → moderate parallelization)
-NCORE  = 4
+    """Write INCAR matching existing BCC_B2 settings (ASE-generated style)."""
+    content = """INCAR created by Atomic Simulation Environment
+ ENCUT = 320.000000
+ POTIM = 0.020000
+ EDIFF = 1.00e-06
+ EDIFFG = -1.00e-02
+ ALGO = Normal
+ GGA = PE
+ PREC = high
+ IBRION = 2
+ ISIF = 3
+ ISPIN = 2
+ NELM = 60
+ NSW = 120
 """
     with open(os.path.join(dirpath, "INCAR"), "w") as f:
         f.write(content)
@@ -144,35 +126,52 @@ def write_poscar_sqs(dirpath, el_a, el_b, a_super):
 
     el_a: element A (8 atoms)
     el_b: element B (8 atoms)
+    For same-element (el_a == el_b): pure BCC supercell (16 atoms of one element)
     """
-    # Sort atoms by element (VASP requires contiguous species blocks)
-    pos_a = []
-    pos_b = []
-    for i, occ in enumerate(SQS_OCCUPATION):
-        if occ == 0:
-            pos_a.append(BCC_2x2x2_POSITIONS[i])
-        else:
-            pos_b.append(BCC_2x2x2_POSITIONS[i])
+    if el_a == el_b:
+        # Same element: all 16 atoms are the same
+        lines = [
+            f"{el_a}16 BCC-SQS16 (2x2x2, pure reference)",
+            "1.0",
+            f"  {a_super:.6f}  0.000000  0.000000",
+            f"  0.000000  {a_super:.6f}  0.000000",
+            f"  0.000000  0.000000  {a_super:.6f}",
+            f"  {el_a}",
+            f"  16",
+            "Direct",
+        ]
+        for pos in BCC_2x2x2_POSITIONS:
+            lines.append(f"  {pos[0]:.6f}  {pos[1]:.6f}  {pos[2]:.6f}")
+        lines.append("")
+    else:
+        # Binary: SQS occupation
+        pos_a = []
+        pos_b = []
+        for i, occ in enumerate(SQS_OCCUPATION):
+            if occ == 0:
+                pos_a.append(BCC_2x2x2_POSITIONS[i])
+            else:
+                pos_b.append(BCC_2x2x2_POSITIONS[i])
 
-    n_a = len(pos_a)
-    n_b = len(pos_b)
+        n_a = len(pos_a)
+        n_b = len(pos_b)
 
-    lines = [
-        f"{el_a}{n_a}{el_b}{n_b} BCC-SQS16 (2x2x2, 50:50)",
-        "1.0",
-        f"  {a_super:.6f}  0.000000  0.000000",
-        f"  0.000000  {a_super:.6f}  0.000000",
-        f"  0.000000  0.000000  {a_super:.6f}",
-        f"  {el_a}  {el_b}",
-        f"  {n_a}  {n_b}",
-        "Direct",
-    ]
+        lines = [
+            f"{el_a}{n_a}{el_b}{n_b} BCC-SQS16 (2x2x2, 50:50)",
+            "1.0",
+            f"  {a_super:.6f}  0.000000  0.000000",
+            f"  0.000000  {a_super:.6f}  0.000000",
+            f"  0.000000  0.000000  {a_super:.6f}",
+            f"  {el_a}  {el_b}",
+            f"  {n_a}  {n_b}",
+            "Direct",
+        ]
 
-    for pos in pos_a:
-        lines.append(f"  {pos[0]:.6f}  {pos[1]:.6f}  {pos[2]:.6f}")
-    for pos in pos_b:
-        lines.append(f"  {pos[0]:.6f}  {pos[1]:.6f}  {pos[2]:.6f}")
-    lines.append("")
+        for pos in pos_a:
+            lines.append(f"  {pos[0]:.6f}  {pos[1]:.6f}  {pos[2]:.6f}")
+        for pos in pos_b:
+            lines.append(f"  {pos[0]:.6f}  {pos[1]:.6f}  {pos[2]:.6f}")
+        lines.append("")
 
     with open(os.path.join(dirpath, "POSCAR"), "w") as f:
         f.write("\n".join(lines))
@@ -194,7 +193,7 @@ def generate_potcar_script(base_dir, calculations):
     """Generate shell script to create POTCAR from $VASPPOT."""
     lines = [
         "#!/bin/bash",
-        "# POTCAR generation script for SQS refractory calculations",
+        "# POTCAR generation script for BCC_SQS refractory calculations",
         "# Usage: bash make_potcar.sh",
         "# Requires: $VASPPOT environment variable",
         "",
@@ -206,19 +205,28 @@ def generate_potcar_script(base_dir, calculations):
         'fi',
         "",
         'echo "Using VASPPOT=$VASPPOT"',
-        'echo "Generating POTCAR files for SQS refractory calculations..."',
+        'echo "Generating POTCAR files for BCC_SQS refractory calculations..."',
         "",
     ]
 
     for calc_name, el_a, el_b in calculations:
         pot_a = POTCAR_VARIANTS.get(el_a, el_a)
         pot_b = POTCAR_VARIANTS.get(el_b, el_b)
-        lines.append(f"# --- {calc_name} ---")
-        lines.append(f'echo "  {calc_name}: {pot_a} + {pot_b}"')
-        lines.append(
-            f'cat "$VASPPOT"/{pot_a}/POTCAR "$VASPPOT"/{pot_b}/POTCAR '
-            f'> {calc_name}/POTCAR'
-        )
+        if el_a == el_b:
+            # Same-element: single POTCAR
+            lines.append(f"# --- {calc_name} (pure reference) ---")
+            lines.append(f'echo "  {calc_name}: {pot_a}"')
+            lines.append(
+                f'cat "$VASPPOT"/{pot_a}/POTCAR '
+                f'> {calc_name}/POTCAR'
+            )
+        else:
+            lines.append(f"# --- {calc_name} ---")
+            lines.append(f'echo "  {calc_name}: {pot_a} + {pot_b}"')
+            lines.append(
+                f'cat "$VASPPOT"/{pot_a}/POTCAR "$VASPPOT"/{pot_b}/POTCAR '
+                f'> {calc_name}/POTCAR'
+            )
         lines.append(
             f'if [ $? -ne 0 ]; then echo "  WARNING: Failed for {calc_name}"; fi'
         )
@@ -236,7 +244,7 @@ def generate_run_script(base_dir, calculations):
     """Generate batch submission script for all calculations."""
     lines = [
         "#!/bin/bash",
-        "# Batch execution script for SQS refractory DFT calculations",
+        "# Batch execution script for BCC_SQS refractory DFT calculations",
         "# Usage: bash run_all.sh",
         "#",
         "# Each SQS-16 calc is 16 atoms → moderate cost (~30min-1h per job).",
@@ -245,7 +253,7 @@ def generate_run_script(base_dir, calculations):
         'VASP_CMD="mpirun -np ${NPROCS:-8} vasp_std"',
         'LOG="run_status.log"',
         "",
-        'echo "=== SQS Refractory Calculations ===" | tee $LOG',
+        'echo "=== BCC_SQS Refractory Calculations ===" | tee $LOG',
         f'echo "Total: {len(calculations)} calculations (16 atoms each)" | tee -a $LOG',
         'echo "Started: $(date)" | tee -a $LOG',
         'echo "" | tee -a $LOG',
@@ -321,7 +329,8 @@ def extract_lattice_from_contcar(contcar_path):
 
 results = []
 dirs = sorted([d for d in os.listdir(BASE_DIR)
-               if os.path.isdir(os.path.join(BASE_DIR, d)) and "_sqs16" in d])
+               if os.path.isdir(os.path.join(BASE_DIR, d))
+               and d[0].isupper() and '8' in d])
 
 print("SQS-16 Refractory Results:")
 print("=" * 70)
@@ -332,14 +341,15 @@ for d in dirs:
         print(f"  {d}: CONTCAR not found")
         continue
 
-    # Parse elements from directory name (e.g., "CrHf_sqs16")
-    pair_name = d.replace("_sqs16", "")
+    # Parse elements from directory name (e.g., "Cr8Hf8")
+    pair_name = d
     # Elements are in POSCAR header
     poscar = os.path.join(BASE_DIR, d, "POSCAR")
     with open(poscar, "r") as f:
         poscar_lines = f.readlines()
     elements = poscar_lines[5].split()
-    el_a, el_b = elements[0], elements[1]
+    el_a = elements[0]
+    el_b = elements[1] if len(elements) > 1 else elements[0]
 
     a_eff, vol_total = extract_lattice_from_contcar(contcar)
     vol_per_atom = vol_total / 16.0
@@ -383,13 +393,25 @@ print(f"  python compare_b2_sqs.py")
 
 
 def main():
-    base_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "SQS_refractory")
+    base_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "BCC_SQS")
     os.makedirs(base_dir, exist_ok=True)
 
-    # Generate all refractory pairs (symmetric: only one direction needed)
     calculations = []
+
+    # Generate same-element references (9 calculations)
+    for el in REFRACTORY_ELEMENTS:
+        calc_name = f"{el}8{el}8"
+        a_super = 2.0 * ELEMENT_A0_BCC[el]  # 2×2×2 supercell
+        dirpath = os.path.join(base_dir, calc_name)
+        os.makedirs(dirpath, exist_ok=True)
+        write_incar_sqs(dirpath)
+        write_poscar_sqs(dirpath, el, el, a_super)
+        write_kpoints_sqs(dirpath)
+        calculations.append((calc_name, el, el))
+
+    # Generate all refractory pairs (symmetric: only one direction needed)
     for el_a, el_b in itertools.combinations(REFRACTORY_ELEMENTS, 2):
-        calc_name = f"{el_a}{el_b}_sqs16"
+        calc_name = f"{el_a}8{el_b}8"
         a_super = estimate_sqs_a0(el_a, el_b)
         dirpath = os.path.join(base_dir, calc_name)
         os.makedirs(dirpath, exist_ok=True)
@@ -403,9 +425,16 @@ def main():
     generate_run_script(base_dir, calculations)
     generate_extract_script(base_dir)
 
+    n_homo = len(REFRACTORY_ELEMENTS)
+    n_hetero = len(calculations) - n_homo
     print(f"Generated {len(calculations)} SQS calculations in {base_dir}/")
-    print(f"  - 36 refractory pairs × 1 (symmetric SQS) = 36 calculations")
-    print(f"  - Each: 16 atoms (2×2×2 BCC supercell, A8B8)")
+    print(f"  - {n_hetero} refractory pairs (A8B8)")
+    print(f"  - {n_homo} same-element references (A8A8)")
+    print(f"  - Total: {len(calculations)} calculations")
+    print(f"  - Each: 16 atoms (2×2×2 BCC supercell)")
+    print()
+    print("Directory naming: A8B8 format (e.g., Cr8Hf8, Mo8Mo8)")
+    print("  Matches BCC_B2 convention (A1B1) with atom counts")
     print()
     print("SQS advantages over B2:")
     print("  - Random-like atom distribution (mimics BCC solid solution)")
@@ -413,7 +442,7 @@ def main():
     print("  - Ω_sf directly applicable to BCC HEA prediction")
     print()
     print("Next steps:")
-    print("  1. cd SQS_refractory")
+    print("  1. cd BCC_SQS")
     print("  2. bash make_potcar.sh")
     print("  3. bash run_all.sh")
     print("  4. python extract_results.py")

--- a/vasp_inputs/generate_refractory_sqs.py
+++ b/vasp_inputs/generate_refractory_sqs.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 """
-VASP input file generator for refractory BCC SQS (Special Quasi-random Structure)
-calculations.
+VASP input file generator for BCC SQS (Special Quasi-random Structure) calculations.
 
-Generates INCAR, POSCAR, KPOINTS for binary BCC solid solutions of refractory
-elements using SQS supercells. This provides a better proxy for BCC HEA behavior
-than ordered B2 structures.
+Generates INCAR, POSCAR, KPOINTS for binary BCC solid solutions using SQS
+supercells. This provides a better proxy for BCC HEA behavior than ordered
+B2 structures.
 
 SQS approach:
   - 16-atom BCC supercell (2×2×2 conventional BCC = 16 atoms)
@@ -18,7 +17,11 @@ Comparison with B2:
   - SQS is physically more relevant for BCC HEA applications
 
 Usage:
-    python generate_refractory_sqs.py
+    python generate_refractory_sqs.py [--group refractory|all|custom]
+
+    --group refractory : 9高融点元素のみ (default, 45計算)
+    --group all        : BCC_B2全39元素 (780計算)
+    --elements "Fe,Co,Ni,Cr,Mn"  : 任意元素指定
 
 Output structure:
     BCC_SQS/
@@ -31,38 +34,50 @@ Output structure:
 """
 
 import os
+import sys
+import argparse
 import itertools
 import numpy as np
 
 # =====================================================================
-# Refractory elements
+# Element groups
 # =====================================================================
 REFRACTORY_ELEMENTS = sorted(['Nb', 'Ti', 'V', 'Zr', 'Mo', 'Ta', 'W', 'Hf', 'Cr'])
 
-# BCC lattice constants (Å)
+# All elements with existing BCC_B2 data (from VASP same-element B2 calculations)
+ALL_B2_ELEMENTS = sorted([
+    'Ag', 'Al', 'As', 'B', 'Ca', 'Cd', 'Ce', 'Co', 'Cr', 'Cu',
+    'Fe', 'Ga', 'Gd', 'Ge', 'Hf', 'In', 'La', 'Mg', 'Mn', 'Mo',
+    'Na', 'Nb', 'Ni', 'Pd', 'Ru', 'Sb', 'Sc', 'Se', 'Si', 'Sn',
+    'Sr', 'Ta', 'Tc', 'Ti', 'V', 'W', 'Y', 'Zn', 'Zr',
+])
+
+# BCC lattice constants (Å) from VASP B2 same-element calculations
 ELEMENT_A0_BCC = {
-    "Cr": 2.880,
-    "Hf": 3.530,
-    "Mo": 3.147,
-    "Nb": 3.301,
-    "Ta": 3.303,
-    "Ti": 3.250,
-    "V":  3.024,
-    "W":  3.165,
-    "Zr": 3.570,
+    "Ag": 3.3009, "Al": 3.2254, "As": 3.3672, "B":  2.3110,
+    "Ca": 4.3838, "Cd": 3.5840, "Ce": 3.7670, "Co": 2.8010,
+    "Cr": 2.8363, "Cu": 2.8955, "Fe": 2.8266, "Ga": 3.3618,
+    "Gd": 4.1013, "Ge": 3.3764, "Hf": 3.5338, "In": 3.8099,
+    "La": 4.2224, "Mg": 3.5789, "Mn": 2.7883, "Mo": 3.1486,
+    "Na": 4.2002, "Nb": 3.3237, "Ni": 2.7938, "Pd": 3.1386,
+    "Ru": 3.0460, "Sb": 3.7828, "Sc": 3.6771, "Se": 3.4604,
+    "Si": 3.0942, "Sn": 3.8076, "Sr": 4.7133, "Ta": 3.3119,
+    "Tc": 3.0712, "Ti": 3.2396, "V":  2.9821, "W":  3.1724,
+    "Y":  4.0265, "Zn": 3.1572, "Zr": 3.5687,
 }
 
-# POTCAR variants
+# POTCAR variants (PAW-PBE recommended)
 POTCAR_VARIANTS = {
-    "Cr": "Cr_pv",
-    "Hf": "Hf_pv",
-    "Mo": "Mo_pv",
-    "Nb": "Nb_pv",
-    "Ta": "Ta_pv",
-    "Ti": "Ti_pv",
-    "V":  "V_sv",
-    "W":  "W_pv",
-    "Zr": "Zr_sv",
+    "Ag": "Ag",    "Al": "Al",    "As": "As",    "B":  "B",
+    "Ca": "Ca_sv", "Cd": "Cd",    "Ce": "Ce",    "Co": "Co",
+    "Cr": "Cr_pv", "Cu": "Cu",    "Fe": "Fe_pv", "Ga": "Ga_d",
+    "Gd": "Gd_3",  "Ge": "Ge_d",  "Hf": "Hf_pv", "In": "In_d",
+    "La": "La",    "Mg": "Mg_pv", "Mn": "Mn_pv", "Mo": "Mo_pv",
+    "Na": "Na_pv", "Nb": "Nb_pv", "Ni": "Ni_pv", "Pd": "Pd",
+    "Ru": "Ru_pv", "Sb": "Sb",    "Sc": "Sc_sv", "Se": "Se",
+    "Si": "Si",    "Sn": "Sn_d",  "Sr": "Sr_sv", "Ta": "Ta_pv",
+    "Tc": "Tc_pv", "Ti": "Ti_pv", "V":  "V_sv",  "W":  "W_pv",
+    "Y":  "Y_sv",  "Zn": "Zn",    "Zr": "Zr_sv",
 }
 
 # =====================================================================
@@ -393,15 +408,46 @@ print(f"  python compare_b2_sqs.py")
 
 
 def main():
-    base_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "BCC_SQS")
+    parser = argparse.ArgumentParser(
+        description="BCC SQS VASP input generator")
+    parser.add_argument("--group", choices=["refractory", "all"],
+                        default="refractory",
+                        help="Element group: refractory (9元素,45計算) or all (39元素,780計算)")
+    parser.add_argument("--elements", type=str, default=None,
+                        help="Comma-separated element list (e.g., 'Fe,Co,Ni,Cr,Mn')")
+    parser.add_argument("--outdir", type=str, default=None,
+                        help="Output directory (default: BCC_SQS)")
+    args = parser.parse_args()
+
+    # Determine element list
+    if args.elements:
+        elements = sorted([e.strip() for e in args.elements.split(",")])
+        group_name = "custom"
+        # Validate
+        for el in elements:
+            if el not in ELEMENT_A0_BCC:
+                print(f"Error: Unknown element '{el}'. Available: {ALL_B2_ELEMENTS}")
+                sys.exit(1)
+    elif args.group == "all":
+        elements = ALL_B2_ELEMENTS
+        group_name = "all"
+    else:
+        elements = REFRACTORY_ELEMENTS
+        group_name = "refractory"
+
+    # Output directory
+    if args.outdir:
+        base_dir = args.outdir
+    else:
+        base_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "BCC_SQS")
     os.makedirs(base_dir, exist_ok=True)
 
     calculations = []
 
-    # Generate same-element references (9 calculations)
-    for el in REFRACTORY_ELEMENTS:
+    # Generate same-element references
+    for el in elements:
         calc_name = f"{el}8{el}8"
-        a_super = 2.0 * ELEMENT_A0_BCC[el]  # 2×2×2 supercell
+        a_super = 2.0 * ELEMENT_A0_BCC[el]
         dirpath = os.path.join(base_dir, calc_name)
         os.makedirs(dirpath, exist_ok=True)
         write_incar_sqs(dirpath)
@@ -409,8 +455,8 @@ def main():
         write_kpoints_sqs(dirpath)
         calculations.append((calc_name, el, el))
 
-    # Generate all refractory pairs (symmetric: only one direction needed)
-    for el_a, el_b in itertools.combinations(REFRACTORY_ELEMENTS, 2):
+    # Generate all pairs (symmetric: only one direction needed)
+    for el_a, el_b in itertools.combinations(elements, 2):
         calc_name = f"{el_a}8{el_b}8"
         a_super = estimate_sqs_a0(el_a, el_b)
         dirpath = os.path.join(base_dir, calc_name)
@@ -425,30 +471,31 @@ def main():
     generate_run_script(base_dir, calculations)
     generate_extract_script(base_dir)
 
-    n_homo = len(REFRACTORY_ELEMENTS)
+    n_homo = len(elements)
     n_hetero = len(calculations) - n_homo
-    print(f"Generated {len(calculations)} SQS calculations in {base_dir}/")
-    print(f"  - {n_hetero} refractory pairs (A8B8)")
+    n_total = len(calculations)
+    print(f"Generated {n_total} SQS calculations in {base_dir}/")
+    print(f"  - Group: {group_name} ({len(elements)} elements)")
+    print(f"  - {n_hetero} binary pairs (A8B8)")
     print(f"  - {n_homo} same-element references (A8A8)")
-    print(f"  - Total: {len(calculations)} calculations")
+    print(f"  - Total: {n_total} calculations")
     print(f"  - Each: 16 atoms (2×2×2 BCC supercell)")
     print()
     print("Directory naming: A8B8 format (e.g., Cr8Hf8, Mo8Mo8)")
-    print("  Matches BCC_B2 convention (A1B1) with atom counts")
-    print()
-    print("SQS advantages over B2:")
-    print("  - Random-like atom distribution (mimics BCC solid solution)")
-    print("  - No artificial long-range order")
-    print("  - Ω_sf directly applicable to BCC HEA prediction")
+    print(f"  Elements: {', '.join(elements)}")
     print()
     print("Next steps:")
-    print("  1. cd BCC_SQS")
+    print(f"  1. cd {os.path.basename(base_dir)}")
     print("  2. bash make_potcar.sh")
     print("  3. bash run_all.sh")
     print("  4. python extract_results.py")
     print()
-    print("Note: SQS calculations are more expensive than B2 (~30min-1h each).")
-    print("      Consider submitting to a job queue system.")
+    if n_total > 100:
+        est_hours = n_total * 0.75  # ~45min avg
+        print(f"Estimated total time (serial): ~{est_hours:.0f} hours")
+        print("Strongly recommend parallel job submission.")
+    else:
+        print("Note: SQS calculations are more expensive than B2 (~30min-1h each).")
 
 
 if __name__ == "__main__":

--- a/vasp_inputs/generate_refractory_sqs.py
+++ b/vasp_inputs/generate_refractory_sqs.py
@@ -286,15 +286,23 @@ def generate_run_script(base_dir, calculations):
 #   bash run_all.sh 4 8          # 4並列×8コア
 #   bash run_all.sh 16 2         # 16並列×2コア
 #
-# Requires: $VASP_PP_PATH environment variable
+# Requires: $VASP_PP_PATH, $VASPBIN environment variables
 
 set -e
 
 NJOBS_PARALLEL=${{1:-8}}
 NPROCS_PER_JOB=${{2:-4}}
-VASP_CMD="mpirun -np $NPROCS_PER_JOB vasp_std"
 LOG="run_status.log"
 BASEDIR=$(cd "$(dirname "$0")" && pwd)
+
+if [ -z "$VASPBIN" ]; then
+    echo "Error: VASPBIN environment variable is not set." | tee $LOG
+    echo "Set it to the VASP executable path, e.g.:" | tee -a $LOG
+    echo "  export VASPBIN=/path/to/vasp_std" | tee -a $LOG
+    exit 1
+fi
+
+VASP_CMD="mpirun -np $NPROCS_PER_JOB $VASPBIN"
 
 # ============================================================
 # Step 1: POTCAR generation
@@ -572,6 +580,7 @@ def main():
     print()
     print("Next steps:")
     print(f"  1. export VASP_PP_PATH=/path/to/vasp_pp  # (potpaw_PBE/ が含まれるディレクトリ)")
+    print(f"     export VASPBIN=/path/to/vasp_std")
     print(f"  2. cd {os.path.basename(base_dir)}")
     print(f"  3. bash run_all.sh   # POTCAR生成→並列計算→結果抽出 (all-in-one)")
     print()

--- a/vasp_inputs/generate_refractory_sqs.py
+++ b/vasp_inputs/generate_refractory_sqs.py
@@ -76,7 +76,7 @@ POTCAR_VARIANTS = {
     "Na": "Na_pv", "Nb": "Nb_pv", "Ni": "Ni_pv", "Pd": "Pd",
     "Ru": "Ru_pv", "Sb": "Sb",    "Sc": "Sc_sv", "Se": "Se",
     "Si": "Si",    "Sn": "Sn_d",  "Sr": "Sr_sv", "Ta": "Ta_pv",
-    "Tc": "Tc_pv", "Ti": "Ti_pv", "V":  "V_sv",  "W":  "W_pv",
+    "Tc": "Tc_pv", "Ti": "Ti_pv", "V":  "V_sv",  "W":  "W_sv",
     "Y":  "Y_sv",  "Zn": "Zn",    "Zr": "Zr_sv",
 }
 

--- a/vasp_inputs/generate_refractory_sqs.py
+++ b/vasp_inputs/generate_refractory_sqs.py
@@ -256,20 +256,38 @@ def generate_potcar_script(base_dir, calculations):
 
 
 def generate_run_script(base_dir, calculations):
-    """Generate parallel execution script (OpenMPI, 32 cores)."""
+    """Generate all-in-one execution script (POTCAR生成→並列計算→結果抽出)."""
     calc_names = [c[0] for c in calculations]
 
+    # Build POTCAR generation commands
+    potcar_lines = []
+    for calc_name, el_a, el_b in calculations:
+        pot_a = POTCAR_VARIANTS.get(el_a, el_a)
+        pot_b = POTCAR_VARIANTS.get(el_b, el_b)
+        if el_a == el_b:
+            potcar_lines.append(
+                f'cat "$VASP_PP_PATH"/{pot_a}/POTCAR > "$BASEDIR"/{calc_name}/POTCAR')
+        else:
+            potcar_lines.append(
+                f'cat "$VASP_PP_PATH"/{pot_a}/POTCAR "$VASP_PP_PATH"/{pot_b}/POTCAR > "$BASEDIR"/{calc_name}/POTCAR')
+
+    potcar_block = "\n".join(potcar_lines)
+
     content = f"""#!/bin/bash
-# Parallel execution script for BCC_SQS DFT calculations
-# Environment: OpenMPI, 32 cores available
+# All-in-one execution script for BCC_SQS DFT calculations
+# Handles: POTCAR generation → parallel VASP execution → result extraction
 #
+# Environment: OpenMPI, 32 cores
 # Default: 8 parallel jobs × 4 cores each = 32 cores
-# Adjust NPROCS_PER_JOB and NJOBS_PARALLEL as needed.
 #
 # Usage:
 #   bash run_all.sh              # 8並列×4コア (default)
 #   bash run_all.sh 4 8          # 4並列×8コア
 #   bash run_all.sh 16 2         # 16並列×2コア
+#
+# Requires: $VASP_PP_PATH environment variable
+
+set -e
 
 NJOBS_PARALLEL=${{1:-8}}
 NPROCS_PER_JOB=${{2:-4}}
@@ -277,7 +295,31 @@ VASP_CMD="mpirun -np $NPROCS_PER_JOB vasp_std"
 LOG="run_status.log"
 BASEDIR=$(cd "$(dirname "$0")" && pwd)
 
-echo "=== BCC_SQS Parallel Calculations ===" | tee $LOG
+# ============================================================
+# Step 1: POTCAR generation
+# ============================================================
+echo "=== Step 1: POTCAR Generation ===" | tee $LOG
+
+if [ -z "$VASP_PP_PATH" ]; then
+    echo "Error: VASP_PP_PATH environment variable is not set." | tee -a $LOG
+    echo "Set it to the PAW-PBE pseudopotential directory, e.g.:" | tee -a $LOG
+    echo "  export VASP_PP_PATH=/path/to/potpaw_PBE.64" | tee -a $LOG
+    exit 1
+fi
+
+echo "Using VASP_PP_PATH=$VASP_PP_PATH" | tee -a $LOG
+echo "Generating POTCAR for {len(calculations)} calculations..." | tee -a $LOG
+
+{potcar_block}
+
+echo "POTCAR generation complete." | tee -a $LOG
+echo "" | tee -a $LOG
+
+# ============================================================
+# Step 2: Parallel VASP execution
+# ============================================================
+set +e
+echo "=== Step 2: Parallel VASP Execution ===" | tee -a $LOG
 echo "Total: {len(calculations)} calculations (16 atoms each)" | tee -a $LOG
 echo "Parallel jobs: $NJOBS_PARALLEL × $NPROCS_PER_JOB cores = $(($NJOBS_PARALLEL * $NPROCS_PER_JOB)) cores" | tee -a $LOG
 echo "Started: $(date)" | tee -a $LOG
@@ -309,7 +351,17 @@ echo "{chr(10).join(calc_names)}" | \\
 echo "" | tee -a $LOG
 echo "Finished: $(date)" | tee -a $LOG
 
+# ============================================================
+# Step 3: Result extraction
+# ============================================================
+echo "" | tee -a $LOG
+echo "=== Step 3: Result Extraction ===" | tee -a $LOG
+cd "$BASEDIR"
+python extract_results.py 2>&1 | tee -a $LOG
+
+# ============================================================
 # Summary
+# ============================================================
 echo "" | tee -a $LOG
 echo "=== Summary ===" | tee -a $LOG
 TOTAL={len(calculations)}
@@ -319,6 +371,8 @@ FAILED=$(grep -c "WARNING" $LOG 2>/dev/null || echo 0)
 echo "  Converged: $CONVERGED / $TOTAL" | tee -a $LOG
 echo "  Skipped (already done): $SKIPPED" | tee -a $LOG
 echo "  Not converged: $FAILED" | tee -a $LOG
+echo "" | tee -a $LOG
+echo "Results saved to: sqs_refractory_results.csv" | tee -a $LOG
 """
 
     with open(os.path.join(base_dir, "run_all.sh"), "w") as f:
@@ -515,17 +569,16 @@ def main():
     print(f"  Elements: {', '.join(elements)}")
     print()
     print("Next steps:")
-    print(f"  1. cd {os.path.basename(base_dir)}")
-    print("  2. bash make_potcar.sh")
-    print("  3. bash run_all.sh")
-    print("  4. python extract_results.py")
+    print(f"  1. export VASP_PP_PATH=/path/to/potpaw_PBE.64")
+    print(f"  2. cd {os.path.basename(base_dir)}")
+    print(f"  3. bash run_all.sh   # POTCAR生成→並列計算→結果抽出 (all-in-one)")
     print()
     if n_total > 100:
-        est_hours = n_total * 0.75  # ~45min avg
-        print(f"Estimated total time (serial): ~{est_hours:.0f} hours")
-        print("Strongly recommend parallel job submission.")
+        est_hours = n_total * 0.75 / 8  # 8並列想定
+        print(f"Estimated time (8並列×4コア): ~{est_hours:.0f} hours")
     else:
-        print("Note: SQS calculations are more expensive than B2 (~30min-1h each).")
+        est_hours = n_total * 0.75 / 8
+        print(f"Estimated time (8並列×4コア): ~{est_hours:.1f} hours")
 
 
 if __name__ == "__main__":

--- a/vasp_inputs/generate_refractory_sqs.py
+++ b/vasp_inputs/generate_refractory_sqs.py
@@ -256,43 +256,73 @@ def generate_potcar_script(base_dir, calculations):
 
 
 def generate_run_script(base_dir, calculations):
-    """Generate batch submission script for all calculations."""
-    lines = [
-        "#!/bin/bash",
-        "# Batch execution script for BCC_SQS refractory DFT calculations",
-        "# Usage: bash run_all.sh",
-        "#",
-        "# Each SQS-16 calc is 16 atoms → moderate cost (~30min-1h per job).",
-        "# Adjust VASP_CMD and NPROCS to your environment.",
-        "",
-        'VASP_CMD="mpirun -np ${NPROCS:-8} vasp_std"',
-        'LOG="run_status.log"',
-        "",
-        'echo "=== BCC_SQS Refractory Calculations ===" | tee $LOG',
-        f'echo "Total: {len(calculations)} calculations (16 atoms each)" | tee -a $LOG',
-        'echo "Started: $(date)" | tee -a $LOG',
-        'echo "" | tee -a $LOG',
-        "",
-    ]
+    """Generate parallel execution script (OpenMPI, 32 cores)."""
+    calc_names = [c[0] for c in calculations]
 
-    for i, (calc_name, _, _) in enumerate(calculations, 1):
-        lines.append(f'echo "[{i}/{len(calculations)}] {calc_name}..." | tee -a $LOG')
-        lines.append(f'cd {calc_name}')
-        lines.append(f'$VASP_CMD > vasp.out 2>&1')
-        lines.append(f'if grep -q "reached required accuracy" OUTCAR 2>/dev/null; then')
-        lines.append(f'    echo "  CONVERGED" | tee -a ../$LOG')
-        lines.append(f'else')
-        lines.append(f'    echo "  WARNING: not converged" | tee -a ../$LOG')
-        lines.append(f'fi')
-        lines.append(f'cd ..')
-        lines.append("")
+    content = f"""#!/bin/bash
+# Parallel execution script for BCC_SQS DFT calculations
+# Environment: OpenMPI, 32 cores available
+#
+# Default: 8 parallel jobs × 4 cores each = 32 cores
+# Adjust NPROCS_PER_JOB and NJOBS_PARALLEL as needed.
+#
+# Usage:
+#   bash run_all.sh              # 8並列×4コア (default)
+#   bash run_all.sh 4 8          # 4並列×8コア
+#   bash run_all.sh 16 2         # 16並列×2コア
 
-    lines.append('echo "" | tee -a $LOG')
-    lines.append('echo "Finished: $(date)" | tee -a $LOG')
-    lines.append("")
+NJOBS_PARALLEL=${{1:-8}}
+NPROCS_PER_JOB=${{2:-4}}
+VASP_CMD="mpirun -np $NPROCS_PER_JOB vasp_std"
+LOG="run_status.log"
+BASEDIR=$(cd "$(dirname "$0")" && pwd)
+
+echo "=== BCC_SQS Parallel Calculations ===" | tee $LOG
+echo "Total: {len(calculations)} calculations (16 atoms each)" | tee -a $LOG
+echo "Parallel jobs: $NJOBS_PARALLEL × $NPROCS_PER_JOB cores = $(($NJOBS_PARALLEL * $NPROCS_PER_JOB)) cores" | tee -a $LOG
+echo "Started: $(date)" | tee -a $LOG
+echo "" | tee -a $LOG
+
+# Function to run a single calculation
+run_one() {{
+    local dir=$1
+    local basedir=$2
+    local vasp_cmd=$3
+    cd "$basedir/$dir"
+    if [ -f OUTCAR ] && grep -q "reached required accuracy" OUTCAR 2>/dev/null; then
+        echo "  SKIP (already converged): $dir"
+        return 0
+    fi
+    $vasp_cmd > vasp.out 2>&1
+    if grep -q "reached required accuracy" OUTCAR 2>/dev/null; then
+        echo "  CONVERGED: $dir"
+    else
+        echo "  WARNING (not converged): $dir"
+    fi
+}}
+export -f run_one
+
+# Run all calculations in parallel
+echo "{chr(10).join(calc_names)}" | \\
+    xargs -I {{}} -P $NJOBS_PARALLEL bash -c "run_one '{{}}' '$BASEDIR' '$VASP_CMD'" 2>&1 | tee -a $LOG
+
+echo "" | tee -a $LOG
+echo "Finished: $(date)" | tee -a $LOG
+
+# Summary
+echo "" | tee -a $LOG
+echo "=== Summary ===" | tee -a $LOG
+TOTAL={len(calculations)}
+CONVERGED=$(grep -c "CONVERGED" $LOG 2>/dev/null || echo 0)
+SKIPPED=$(grep -c "SKIP" $LOG 2>/dev/null || echo 0)
+FAILED=$(grep -c "WARNING" $LOG 2>/dev/null || echo 0)
+echo "  Converged: $CONVERGED / $TOTAL" | tee -a $LOG
+echo "  Skipped (already done): $SKIPPED" | tee -a $LOG
+echo "  Not converged: $FAILED" | tee -a $LOG
+"""
 
     with open(os.path.join(base_dir, "run_all.sh"), "w") as f:
-        f.write("\n".join(lines))
+        f.write(content)
     os.chmod(os.path.join(base_dir, "run_all.sh"), 0o755)
 
 


### PR DESCRIPTION
## Summary

`generate_refractory_sqs.py`を修正し、既存`BCC_B2`ディレクトリ構造に準拠させました。

**変更点:**
1. 出力先: `SQS_refractory/` → `BCC_SQS/`
2. ディレクトリ命名: `CrHf_sqs16` → `Cr8Hf8`（BCC_B2の`A1B1`形式と対応）
3. 同種参照9個追加: `Cr8Cr8`, `Hf8Hf8`, ..., `Zr8Zr8` → **合計45計算**
4. INCAR: 既存BCC_B2のASE生成設定に統一（ENCUT=320, PREC=high, ALGO=Normal, POTIM=0.02, NELM=60, NSW=120）

**ディレクトリ構造:**
```
BCC_SQS/
├── Cr8Cr8/   (同種参照)
├── Cr8Hf8/   (二元SQS)
├── ...
├── Zr8Zr8/   (同種参照)
├── make_potcar.sh
├── run_all.sh
└── extract_results.py
```

## Review & Testing Checklist for Human
- [ ] INCAR設定が既存BCC_B2ディレクトリの計算と一致しているか確認
- [ ] POTCAR_VARIANTS（_pv/_sv）が使用するVASP PPセットと一致するか確認
- [ ] `python generate_refractory_sqs.py`実行後、45ディレクトリが正しく生成されるか確認

### Notes
- BCC_B2の`A1B1`に対し、SQSは`A8B8`で原子数を明示
- 同種参照（A8A8）は純元素BCC超格子として、Ω_sf計算時のV_pure基準に利用可能

Link to Devin session: https://app.devin.ai/sessions/aa336d0f2b374126a139328ec9469942
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->