### PR TITLE
fix: extract_results.pyに壊れたCONTCARのエラーハンドリング追加

### DIFF
--- a/vasp_inputs/generate_refractory_sqs.py
+++ b/vasp_inputs/generate_refractory_sqs.py
@@ -449,13 +449,16 @@ for d in dirs:
     if len(parts) == 2 and parts[0] == parts[1]:
         el = parts[0]
         contcar = os.path.join(BASE_DIR, d, "CONTCAR")
-        if os.path.exists(contcar):
+        if not os.path.exists(contcar):
+            print(f"  {d:8s}: CONTCAR not found (not converged?)")
+            continue
+        try:
             a_eff, vol_total = extract_lattice_from_contcar(contcar)
             vol_per_atom = vol_total / 16.0
             pure_volumes[el] = vol_per_atom
             print(f"  {d:8s}: V/atom = {vol_per_atom:.4f} Å³")
-        else:
-            print(f"  {d:8s}: CONTCAR not found (not converged?)")
+        except (IndexError, ValueError) as e:
+            print(f"  {d:8s}: CONTCAR broken ({e})")
 
 print(f"\\n  Found {len(pure_volumes)} pure element references.")
 
@@ -486,7 +489,11 @@ for d in dirs:
     el_a = elements[0]
     el_b = elements[1] if len(elements) > 1 else elements[0]
 
-    a_eff, vol_total = extract_lattice_from_contcar(contcar)
+    try:
+        a_eff, vol_total = extract_lattice_from_contcar(contcar)
+    except (IndexError, ValueError) as e:
+        print(f"  {d}: CONTCAR broken ({e})")
+        continue
     vol_per_atom = vol_total / 16.0
 
     # Compute Omega_sf using SQS same-element references


### PR DESCRIPTION
## Summary

`extract_results.py`にtry/exceptを追加し、空または破損したCONTCARファイル（未収束計算）をスキップするように修正。

- Step 1（同種参照抽出）: CONTCAR読み込みでIndexError/ValueErrorが発生した場合、"CONTCAR broken"を表示してスキップ
- Step 2（二元ペア抽出）: 同様にエラーハンドリング追加

これにより全39元素780計算の一括抽出時に、一部の未収束計算があってもスクリプトが中断しない。

## Review & Testing Checklist for Human

- [ ] `cd BCC_SQS && python extract_results.py` で破損CONTCARがスキップされることを確認
- [ ] 正常なCONTCARのΩ_sf値が正しく計算されることを確認

### Notes

Ce8Ce8等の計算で空のCONTCARが生成されていたことが原因。NSW=120で収束しなかったケース。

Link to Devin session: https://app.devin.ai/sessions/aa336d0f2b374126a139328ec9469942
Requested by: @minimumtone