### PR TITLE
feat: 単一HTMLファイル版HEA格子定数予測ツール（サーバー不要）

### DIFF
--- a/webapp/HEA_Lattice_Predictor.html
+++ b/webapp/HEA_Lattice_Predictor.html
@@ -1,0 +1,901 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>HEA格子定数予測 — DFT-SSモデル</title>
+<style>
+  :root {
+    --primary: #2563eb;
+    --primary-dark: #1d4ed8;
+    --bg: #f8fafc;
+    --card: #ffffff;
+    --border: #e2e8f0;
+    --text: #1e293b;
+    --text-light: #64748b;
+    --success: #16a34a;
+    --warning: #d97706;
+    --error: #dc2626;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+  }
+  .container { max-width: 960px; margin: 0 auto; padding: 20px; }
+  header {
+    background: linear-gradient(135deg, var(--primary), #7c3aed);
+    color: white;
+    padding: 24px 0;
+    margin-bottom: 24px;
+  }
+  header h1 { font-size: 1.5rem; font-weight: 700; }
+  header p { opacity: 0.9; font-size: 0.9rem; margin-top: 4px; }
+  .card {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 24px;
+    margin-bottom: 20px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+  }
+  .card h2 {
+    font-size: 1.1rem;
+    margin-bottom: 16px;
+    color: var(--primary);
+    border-bottom: 2px solid var(--primary);
+    padding-bottom: 8px;
+  }
+  .form-row {
+    display: flex;
+    gap: 12px;
+    align-items: end;
+    margin-bottom: 12px;
+    flex-wrap: wrap;
+  }
+  .form-group { display: flex; flex-direction: column; }
+  .form-group label {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--text-light);
+    margin-bottom: 4px;
+  }
+  select, input[type="number"], input[type="text"] {
+    padding: 8px 12px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font-size: 0.95rem;
+    outline: none;
+    transition: border-color 0.2s;
+  }
+  select:focus, input:focus {
+    border-color: var(--primary);
+    box-shadow: 0 0 0 3px rgba(37,99,235,0.1);
+  }
+  select { min-width: 100px; }
+  input[type="number"] { width: 100px; }
+  button {
+    padding: 8px 20px;
+    border: none;
+    border-radius: 6px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s;
+  }
+  .btn-primary {
+    background: var(--primary);
+    color: white;
+  }
+  .btn-primary:hover { background: var(--primary-dark); }
+  .btn-primary:disabled { background: #94a3b8; cursor: not-allowed; }
+  .btn-secondary {
+    background: #f1f5f9;
+    color: var(--text);
+    border: 1px solid var(--border);
+  }
+  .btn-secondary:hover { background: #e2e8f0; }
+  .btn-danger {
+    background: var(--error);
+    color: white;
+    padding: 4px 10px;
+    font-size: 0.8rem;
+  }
+  .btn-danger:hover { background: #b91c1c; }
+  .btn-add {
+    background: var(--success);
+    color: white;
+    padding: 8px 16px;
+  }
+  .btn-add:hover { background: #15803d; }
+
+  #element-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+  .element-tag {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: #eff6ff;
+    border: 1px solid #bfdbfe;
+    border-radius: 8px;
+    padding: 6px 12px;
+    font-size: 0.9rem;
+  }
+  .element-tag .elem-symbol {
+    font-weight: 700;
+    color: var(--primary);
+    min-width: 28px;
+  }
+  .element-tag input {
+    width: 70px;
+    padding: 4px 8px;
+    font-size: 0.85rem;
+  }
+
+  .struct-radio {
+    display: flex;
+    gap: 16px;
+    margin-bottom: 16px;
+  }
+  .struct-radio label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 16px;
+    border: 2px solid var(--border);
+    border-radius: 8px;
+    cursor: pointer;
+    font-weight: 600;
+    transition: all 0.2s;
+  }
+  .struct-radio input[type="radio"] { display: none; }
+  .struct-radio input[type="radio"]:checked + label {
+    border-color: var(--primary);
+    background: #eff6ff;
+    color: var(--primary);
+  }
+
+  .result-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin-bottom: 16px;
+  }
+  .result-item {
+    background: #f8fafc;
+    border-radius: 8px;
+    padding: 16px;
+    text-align: center;
+  }
+  .result-item .label {
+    font-size: 0.8rem;
+    color: var(--text-light);
+    margin-bottom: 4px;
+  }
+  .result-item .value {
+    font-size: 1.8rem;
+    font-weight: 700;
+    color: var(--primary);
+  }
+  .result-item .unit {
+    font-size: 0.9rem;
+    color: var(--text-light);
+  }
+  .result-item.highlight {
+    background: linear-gradient(135deg, #eff6ff, #dbeafe);
+    border: 2px solid var(--primary);
+  }
+
+  .detail-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.85rem;
+    margin-top: 12px;
+  }
+  .detail-table th, .detail-table td {
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--border);
+    text-align: left;
+  }
+  .detail-table th {
+    background: #f1f5f9;
+    font-weight: 600;
+    color: var(--text-light);
+  }
+  .detail-table tr:hover { background: #f8fafc; }
+
+  .warning-box {
+    background: #fffbeb;
+    border: 1px solid #fde68a;
+    border-radius: 8px;
+    padding: 12px 16px;
+    font-size: 0.85rem;
+    color: var(--warning);
+    margin-top: 12px;
+  }
+
+  .preset-section {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-bottom: 16px;
+  }
+  .preset-btn {
+    padding: 4px 12px;
+    font-size: 0.8rem;
+    background: #f1f5f9;
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    cursor: pointer;
+    transition: all 0.2s;
+  }
+  .preset-btn:hover { background: #e2e8f0; border-color: var(--primary); }
+
+  .eq-box {
+    background: #f8fafc;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 16px;
+    margin-bottom: 16px;
+    font-size: 0.85rem;
+    line-height: 1.8;
+  }
+  .eq-box .eq { text-align: center; font-size: 1rem; margin: 8px 0; font-style: italic; }
+
+  #results { display: none; }
+  .spinner {
+    display: inline-block;
+    width: 16px; height: 16px;
+    border: 2px solid #fff;
+    border-top-color: transparent;
+    border-radius: 50%;
+    animation: spin 0.6s linear infinite;
+    vertical-align: middle;
+    margin-right: 6px;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+
+  .composition-bar {
+    height: 24px;
+    border-radius: 6px;
+    overflow: hidden;
+    display: flex;
+    margin-bottom: 12px;
+  }
+  .composition-bar div {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: white;
+    min-width: 0;
+    transition: width 0.3s;
+  }
+
+  @media (max-width: 640px) {
+    .result-grid { grid-template-columns: 1fr; }
+    .form-row { flex-direction: column; }
+  }
+</style>
+</head>
+<body>
+
+<header>
+  <div class="container">
+    <h1>HEA格子定数予測ツール</h1>
+    <p>DFT構造特異的モデル（Alonsoモデル + DFT Ω<sub>sf</sub>）— サーバー不要・オフライン動作</p>
+  </div>
+</header>
+
+<div class="container">
+
+  <!-- Model description -->
+  <div class="card">
+    <h2>モデル概要</h2>
+    <div class="eq-box">
+      <strong>Alonsoモデル（DFT-SS）:</strong>
+      <div class="eq">
+        V<sub>uc</sub> = Z [ Σ c<sub>i</sub>V<sub>i</sub> + γ<sub>s</sub> · Σ<sub>i</sub> Σ<sub>j≠i</sub> c<sub>i</sub> c<sub>j</sub> V<sub>j</sub> Ω<sub>sf</sub><sup>(s)</sup>(i,j) ]
+      </div>
+      <ul style="margin-left:20px; font-size:0.85rem;">
+        <li>第1項: Vegard則（線形混合）</li>
+        <li>第2項: DFT体積サイズ因子 Ω<sub>sf</sub> による化学結合補正</li>
+        <li>γ<sub>BCC</sub> = <span id="info-gamma-bcc">--</span>, γ<sub>FCC</sub> = <span id="info-gamma-fcc">--</span> (校正定数)</li>
+        <li>B2ペア: <span id="info-b2">--</span>対, L1<sub>2</sub>ペア: <span id="info-l12">--</span>対</li>
+      </ul>
+    </div>
+  </div>
+
+  <!-- Input -->
+  <div class="card">
+    <h2>組成入力</h2>
+
+    <div class="preset-section">
+      <span style="font-size:0.8rem; color:var(--text-light); align-self:center;">プリセット:</span>
+      <button class="preset-btn" onclick="loadPreset('cantor')">CoCrFeNiMn (Cantor)</button>
+      <button class="preset-btn" onclick="loadPreset('refractory')">NbMoTaW</button>
+      <button class="preset-btn" onclick="loadPreset('cocrfeni')">CoCrFeNi</button>
+      <button class="preset-btn" onclick="loadPreset('senkov')">NbTiVZrHf</button>
+      <button class="preset-btn" onclick="loadPreset('alcrfev')">AlCrFeMoV</button>
+    </div>
+
+    <!-- Structure selection -->
+    <div style="margin-bottom:12px;">
+      <label style="font-size:0.8rem; font-weight:600; color:var(--text-light);">結晶構造:</label>
+      <div class="struct-radio">
+        <input type="radio" name="struct" id="struct-bcc" value="BCC" checked>
+        <label for="struct-bcc">BCC</label>
+        <input type="radio" name="struct" id="struct-fcc" value="FCC">
+        <label for="struct-fcc">FCC</label>
+      </div>
+    </div>
+
+    <!-- Element addition -->
+    <div class="form-row">
+      <div class="form-group">
+        <label>元素追加:</label>
+        <select id="elem-select"></select>
+      </div>
+      <div class="form-group">
+        <label>原子分率 (at%):</label>
+        <input type="number" id="frac-input" value="25" min="0" max="100" step="0.1">
+      </div>
+      <button class="btn-add" onclick="addElement()">追加</button>
+      <button class="btn-secondary" onclick="addEquimolar()">等モル追加</button>
+    </div>
+
+    <!-- Element list -->
+    <div id="element-list"></div>
+
+    <!-- Composition bar -->
+    <div id="comp-bar" class="composition-bar" style="display:none;"></div>
+
+    <!-- Total display -->
+    <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:16px;">
+      <span style="font-size:0.85rem; color:var(--text-light);">
+        合計: <strong id="total-frac">0</strong> at% (元素数: <span id="n-elements">0</span>)
+      </span>
+      <div style="display:flex; gap:8px;">
+        <button class="btn-secondary" onclick="normalizeAll()">正規化 (100%)</button>
+        <button class="btn-secondary" onclick="clearAll()">クリア</button>
+      </div>
+    </div>
+
+    <button class="btn-primary" id="predict-btn" onclick="predict()" style="width:100%; padding:12px; font-size:1.05rem;">
+      格子定数を予測
+    </button>
+  </div>
+
+  <!-- Results -->
+  <div class="card" id="results">
+    <h2>予測結果</h2>
+
+    <div id="result-comp-bar" class="composition-bar" style="margin-bottom:16px;"></div>
+
+    <div class="result-grid">
+      <div class="result-item highlight">
+        <div class="label">DFT-SSモデル予測</div>
+        <div class="value" id="res-predicted">--</div>
+        <div class="unit">Å</div>
+      </div>
+      <div class="result-item">
+        <div class="label">Vegard則（線形混合）</div>
+        <div class="value" id="res-vegard">--</div>
+        <div class="unit">Å</div>
+      </div>
+    </div>
+
+    <div class="result-grid" style="grid-template-columns: repeat(3, 1fr);">
+      <div class="result-item">
+        <div class="label">構造</div>
+        <div class="value" id="res-struct" style="font-size:1.2rem;">--</div>
+      </div>
+      <div class="result-item">
+        <div class="label">γ<sub>s</sub></div>
+        <div class="value" id="res-gamma" style="font-size:1.2rem;">--</div>
+      </div>
+      <div class="result-item">
+        <div class="label">Vegardからの補正</div>
+        <div class="value" id="res-correction" style="font-size:1.2rem;">--</div>
+        <div class="unit">Å³/atom</div>
+      </div>
+    </div>
+
+    <div id="warning-area"></div>
+
+    <!-- Pair details -->
+    <details style="margin-top:16px;">
+      <summary style="cursor:pointer; font-weight:600; font-size:0.9rem; color:var(--primary);">
+        元素対 Ω<sub>sf</sub> の詳細
+      </summary>
+      <table class="detail-table" id="pair-table">
+        <thead>
+          <tr><th>元素対</th><th>Ω<sub>sf</sub></th><th>体積寄与 (Å³)</th></tr>
+        </thead>
+        <tbody id="pair-tbody"></tbody>
+      </table>
+      <div id="missing-pairs" style="margin-top:8px;"></div>
+    </details>
+  </div>
+
+</div>
+
+<script>
+// ==================== Embedded Model Data ====================
+const MODEL_DATA = {
+  "king_atomic_volumes": {
+    "Al": 16.602, "Cu": 11.81, "Ni": 10.941, "Pd": 14.716, "Pt": 15.095,
+    "Au": 16.966, "Ag": 17.061, "Ir": 14.155, "Rh": 13.754, "Co": 11.073,
+    "Ti": 17.649, "Zr": 23.279, "Hf": 22.312, "Ru": 13.571, "Os": 13.977,
+    "Re": 14.712, "Mn": 12.21, "Zn": 15.207, "Fe": 11.776, "Cr": 12.008,
+    "V": 13.824, "Nb": 17.978, "Mo": 15.583, "Ta": 18.014, "W": 15.85,
+    "Si": 20.024, "Ge": 22.634, "Be": 8.111, "Mg": 23.24, "Y": 33.018,
+    "La": 37.168, "Ce": 34.367, "Sc": 24.987, "B": 7.241, "P": 23.0,
+    "Sn": 27.053, "Pb": 30.321, "Er": 30.66, "Tb": 32.09, "Dy": 31.54,
+    "Ca": 43.63
+  },
+  "omega_sf_b2": {
+    "Hf,Os": -0.054548678369834895, "Hf,Pt": -0.015992825746184217,
+    "Au,Er": -0.05888661353594308, "Pt,Tb": -0.08618549027995584,
+    "Os,Zr": -0.050529662850280974, "Ir,Zr": -0.02672836607283577,
+    "Pt,Zr": -0.015159120388696695, "Ru,Ta": 0.013985246002607853,
+    "Au,Y": -0.07341306939000744, "Hf,Ru": -0.05746457478149689,
+    "Hf,Rh": -0.041402691596552854, "Hf,Pd": -0.01887983382598414,
+    "Os,V": -0.015020100882768632, "Os,Ti": -0.07125600449243569,
+    "Re,Ti": -0.07205529663441895, "Pt,Ti": -0.02413632941205709,
+    "Au,Mn": 0.13262422208500235, "Au,Ti": 0.008312685040275637,
+    "Co,W": -0.0017118523977122154, "Au,Sc": -0.0734037708609675,
+    "Os,Si": -0.24562305904376652, "Al,Ir": -0.11632156832293783,
+    "Al,Os": -0.10957726767269693, "Al,Pt": -0.06837624722651604,
+    "Au,Zn": -0.011416892098767693, "Al,Re": -0.0827551399853597,
+    "Co,Hf": -0.06337360501747838, "Er,Pd": -0.08312271607870524,
+    "Al,Au": -0.001938761787494461, "Dy,Pd": -0.07643149410062322,
+    "Hf,Zn": -0.052972212009571015, "Ag,La": 0.015818440674531177,
+    "Nb,Ru": 0.02040542481666123, "Ru,Zr": -0.0511751009627818,
+    "Rh,Zr": -0.03818612316227936, "Sn,Zr": -0.09478111302922346,
+    "Pd,Zr": -0.005581572920139683, "Cu,Er": -0.05319152073230016,
+    "Er,Zn": -0.04895255289720212, "Cu,Dy": -0.053128587368162436,
+    "La,V": 0.018997676539547228, "Cu,Tb": -0.05014127075411266,
+    "Ag,Y": -0.04370288818830102, "Dy,Zn": -0.039650615042909676,
+    "Tb,Zn": -0.03835366145519711, "Ru,V": -0.01523237350604671,
+    "Ru,Ti": -0.07322344506638752, "Mn,Rh": 0.0691269071962021,
+    "Al,Dy": -0.038396058780181604, "La,Zn": 0.009394344150360964,
+    "Mn,Sn": -0.026476933831821304, "Al,Tb": -0.0350340112560322,
+    "Co,Mo": 0.010749885312723199, "Sc,Sn": -0.0978587589794431,
+    "Pd,Ti": -0.016802843277140524, "Co,Zr": -0.05894042476923241,
+    "Pd,Sc": -0.09300779242482154, "Ru,Si": -0.2522466776630986,
+    "Cu,Pd": 0.012743228523070279, "Rh,Si": -0.21452028211009416,
+    "Rh,Zn": -0.0607615421241893, "Al,Ru": -0.10906246994650984,
+    "Ag,Sc": -0.04379451451305039, "Al,Rh": -0.11866046345569388,
+    "Ti,Y": -0.03719110674642061, "Zn,Zr": -0.04030973510442682,
+    "Cu,Y": -0.07572911276887946, "Al,Pd": -0.08491267727311957,
+    "Ca,Pd": -0.25848304449510157, "Ag,Zn": -0.02075595771126076,
+    "Y,Zn": -0.05930431054805095, "Mn,V": -0.1076853163780223,
+    "Co,Cr": -0.003431935012533755, "Al,Y": -0.058953671868290355,
+    "Co,V": -0.03355409610866239, "Mn,Ni": 0.06258875074540422,
+    "Co,Ti": -0.08299073165741178, "Cr,Ni": 0.04518703618630007,
+    "Co,Sc": -0.15004607106593504, "Co,Ni": -0.0050582562283386,
+    "Cu,Ti": -0.015403881601999937, "Mn,Zn": -0.021931028725467698,
+    "Cu,Sc": -0.07252588682256968, "Co,Si": -0.310318909676558,
+    "Al,Co": -0.17873561852809366, "Hf,Ir": -0.03998428971979893,
+    "Al,Ti": -0.06107884395389979, "Al,Ni": -0.13917996453608295,
+    "Co,Ta": -0.01474359375712595, "Al,Sc": -0.07834228374866255,
+    "Ir,Ti": -0.046856792463782757, "Al,Cu": -0.05350741087145067,
+    "Fe,V": -0.046386111865126395, "Ir,Sc": -0.14707355456050897,
+    "Co,Nb": 0.0052993763599497815, "Fe,Ti": -0.1371871547434364,
+    "Ir,Y": -0.15017959205331607, "Rh,Ti": -0.04315512661156265,
+    "Ru,Sc": -0.1495471242407463, "Co,Mn": -0.010311829595711348,
+    "Fe,Rh": 0.054487352650539056, "Rh,Sc": -0.1393549254751723,
+    "Co,Fe": -0.02963917693648368, "Rh,Y": -0.14077396302840545,
+    "Er,Ir": -0.1386194228992621, "Al,Si": -0.14287336799313488,
+    "Pt,Sc": -0.11114349619278757, "Mn,Pd": 0.11795680482812695,
+    "Ni,Ti": -0.05978206284620505, "Er,Rh": -0.13210483095149925,
+    "Dy,Rh": -0.12377866315741382, "Rh,Tb": -0.12129243700429007,
+    "Al,Mn": -0.11573376930627619, "Ni,Sc": -0.12661188005703927,
+    "Al,Fe": -0.17814262609625756, "Cu,Zr": -0.013924225329404353,
+    "Be,Rh": -0.02094433153788104, "Be,Ti": -0.0259705124982886,
+    "Sn,Y": -0.08969876655777437, "Be,Co": -0.11367932976259998,
+    "Ca,Mg": -0.06664379132608397, "Hf,Mg": -0.07118019573241852,
+    "Be,Ni": -0.08046010350078393, "Be,Pd": -0.020450719977548354,
+    "Cr,Mg": 0.0343105524392187, "Mg,Zr": -0.06029570970929603,
+    "Mg,Rh": -0.19374866711765715, "Au,Tb": -0.0487981759632393,
+    "Au,Dy": -0.05137204882111095, "Ti,Zn": -0.06844582233476537,
+    "Mg,Ti": -0.0782051470241114, "Sc,Zn": -0.07591308788826798,
+    "Mg,Y": -0.022637884875808915, "Mg,Pd": -0.16559490754903378,
+    "Ag,Dy": -0.027481541911671407, "Ag,Er": -0.03498718960448429,
+    "Ag,Tb": -0.024499546931198976, "Be,Cu": -0.03648077395722821,
+    "Mg,Sc": -0.041719530783363455, "Ca,Ni": -0.2681069326728903,
+    "Ni,Zn": -0.08026561938783873, "La,Mg": 0.03219761746172854,
+    "Mg,Tb": -0.010886653177510978, "Dy,Mg": -0.012004665213105569,
+    "Er,Mg": -0.01401558673748872, "Au,Mg": -0.12126358067999367,
+    "Mg,Sn": -0.04600457593114017, "Cu,Zn": -0.060462816571076244,
+    "Al,Mg": -0.0272096045371138, "Ag,Mg": -0.10047291977698003,
+    "Ca,Zn": -0.1677334548323653, "Mg,Zn": -0.08641425228716285
+  },
+  "omega_sf_l12": {
+    "Pb,Pt": -0.0829251644754835, "Ir,Ta": -0.008157103830164193,
+    "Er,Pt": -0.10714553744197251, "Dy,Pt": -0.10440575464211488,
+    "Pb,Y": -0.07389836643354927, "Pt,Tb": -0.10398386480172411,
+    "La,Pt": -0.09184176252597039, "Ir,Zr": -0.046665710417294046,
+    "Pt,Zr": -0.04532755962317811, "Pt,Sn": -0.08680964499998971,
+    "Pt,Y": -0.11676997258806977, "Ag,Pt": 0.022161828409680496,
+    "Au,Pd": 0.04188625144611993, "Ir,V": -0.010319773789660945,
+    "Cr,Ir": 0.019896282550094242, "Pt,Ti": -0.03756426533968059,
+    "Cr,Pt": 0.033042350913476626, "Al,Pt": -0.03865305280124867,
+    "Pb,Pd": -0.08619659580387064, "Rh,Ta": -0.016579086591482634,
+    "Hf,Rh": -0.05027716601713991, "La,Sn": -0.07307255265981569,
+    "Er,Pd": -0.09593001792764869, "Dy,Pd": -0.09352495627918195,
+    "Pd,Tb": -0.09299694244719396, "Al,Dy": -0.04881708738343841,
+    "La,Pd": -0.08283383185310542, "Nb,Ru": 0.0018317794895957634,
+    "Al,Tb": -0.03932622175243091, "Rh,Zr": -0.049528320024005056,
+    "Pd,Sn": -0.09199385708762486, "Au,V": -0.011221189391379305,
+    "Pd,Y": -0.10412139115412311, "Au,Ti": -0.03937084884168458,
+    "Rh,V": -0.01525606498231672, "Cr,Rh": 0.01890896076381826,
+    "Cu,Pt": 0.0005591853928547767, "Pd,Ti": -0.038342605547014984,
+    "Nb,Si": -0.08218984599081802, "Pd,Sc": -0.08357130871676474,
+    "Al,Zr": -0.04238056485135301, "Mn,Rh": -0.07696454501591342,
+    "Al,Y": -0.05756663078831645, "Sn,Ti": -0.10410548705690745,
+    "Al,Er": -0.06826993003668902, "Cu,Pd": -0.00037721616966256664,
+    "Co,Ti": -0.09284939945971718, "Ge,Ni": -0.17502683816489087,
+    "Mn,Ni": -0.007213428714551145, "Ni,Si": -0.20117558701851357,
+    "Al,Ni": -0.10272963340972566, "Mn,Zn": -0.044440543135400176,
+    "Al,Sc": -0.06243380180698618, "V,Zn": -0.07676904123705329,
+    "Al,Cu": -0.06179159696149868, "Hf,Ir": -0.04736862304351773,
+    "Ir,Nb": -0.0067174820533266524, "Ir,Ti": -0.043140784736288955,
+    "Ge,Nb": -0.09189427424857373, "Ir,Sc": -0.09831520923121592,
+    "Fe,Ir": 0.01471546953473713, "Al,V": -0.0666095711393156,
+    "Al,Ti": -0.07429740810100538, "Pt,V": 0.0010737485036556849,
+    "Co,Ta": -0.06953471244533754, "Nb,Rh": -0.010949360209940855,
+    "Mn,Pt": 0.09556588002978292, "Dy,Ir": -0.10337134964442005,
+    "Rh,Ti": -0.04514839849161539, "Ge,Mn": -0.19742599330225974,
+    "Fe,Pt": 0.04762966414555246, "Fe,Ni": -0.010414293169110191,
+    "Rh,Sc": -0.0983343699294001, "Fe,Pd": 0.04318143682635117,
+    "Fe,Sn": -0.11546740228529284, "Pt,Sc": -0.09905849622927712,
+    "Co,Pt": 0.03624342734521039, "Ti,Zn": -0.05730023079103995,
+    "Ni,Pt": 0.014824931970415907, "Ni,Sn": -0.14841614092538785,
+    "Pt,Zn": -0.008166106880210423, "Sn,Y": -0.09018455288282297,
+    "La,Pb": -0.06991000916741365, "Mg,Pd": -0.09159940329407579,
+    "Sn,Tb": -0.08438118288596676, "Dy,Sn": -0.08414603848425437,
+    "Er,Sn": -0.08461391951954408, "Pb,Tb": -0.06942161823079473,
+    "Dy,Pb": -0.069976692356711, "Er,Pb": -0.06853168998213391,
+    "Au,Cu": 0.007305835270689348, "Ca,Sn": -0.14324939552886573,
+    "Nb,Zn": -0.05315831537425912, "Ca,Pb": -0.158345858962426,
+    "Ag,Mg": -0.059282059092637444
+  },
+  "gamma_bcc": 1.451709391288831,
+  "gamma_fcc": 1.0823509829304174
+};
+
+// ==================== Derived Data ====================
+const KING_VOLUMES = MODEL_DATA.king_atomic_volumes;
+const OMEGA_B2 = MODEL_DATA.omega_sf_b2;
+const OMEGA_L12 = MODEL_DATA.omega_sf_l12;
+const GAMMA_BCC = MODEL_DATA.gamma_bcc;
+const GAMMA_FCC = MODEL_DATA.gamma_fcc;
+
+const availableElements = Object.keys(KING_VOLUMES).sort();
+
+// ==================== Prediction Logic ====================
+function predictLattice(comp, struct) {
+  const elements = Object.keys(comp);
+  const rawFracs = elements.map(e => comp[e]);
+  const total = rawFracs.reduce((s, v) => s + v, 0);
+  if (total <= 0) throw new Error("Composition fractions must be positive");
+  const fracs = rawFracs.map(v => v / total);
+
+  const missing = elements.filter(e => !(e in KING_VOLUMES));
+  if (missing.length > 0) {
+    throw new Error("Unknown elements: " + missing.join(", "));
+  }
+
+  const vols = elements.map(e => KING_VOLUMES[e]);
+  const nAuc = struct === "FCC" ? 4 : 2;
+  const omegaSf = struct === "FCC" ? OMEGA_L12 : OMEGA_B2;
+  const gamma = struct === "FCC" ? GAMMA_FCC : GAMMA_BCC;
+
+  // Vegard's law
+  let vVegard = 0;
+  for (let i = 0; i < elements.length; i++) {
+    vVegard += fracs[i] * vols[i];
+  }
+  const aVegard = Math.pow(nAuc * vVegard, 1/3);
+
+  // Omega_sf correction
+  const nElem = elements.length;
+  let correction = 0;
+  const pairDetails = [];
+  const missingPairsSet = new Set();
+
+  for (let i = 0; i < nElem; i++) {
+    for (let j = 0; j < nElem; j++) {
+      if (i === j) continue;
+      const pair = [elements[i], elements[j]].sort().join(",");
+      const omega = (pair in omegaSf) ? omegaSf[pair] : 0.0;
+      const contrib = fracs[i] * fracs[j] * vols[j] * omega;
+      correction += contrib;
+      if (omega !== 0) {
+        pairDetails.push({
+          pair: elements[i] + "-" + elements[j],
+          omega_sf: omega,
+          contribution: contrib
+        });
+      } else {
+        if (!missingPairsSet.has(pair)) {
+          missingPairsSet.add(pair);
+        }
+      }
+    }
+  }
+
+  const vTotal = nAuc * (vVegard + gamma * correction);
+  let aPred, warning;
+  if (vTotal <= 0) {
+    aPred = aVegard;
+    warning = "Negative volume; fell back to Vegard";
+  } else {
+    aPred = Math.pow(vTotal, 1/3);
+    warning = null;
+  }
+
+  const missingPairs = Array.from(missingPairsSet).map(p => p.replace(",", "-"));
+  const vegardFallback = missingPairs.length > 0;
+
+  const compNorm = {};
+  elements.forEach((e, i) => { compNorm[e] = parseFloat(fracs[i].toFixed(4)); });
+
+  return {
+    a_vegard: parseFloat(aVegard.toFixed(4)),
+    a_predicted: parseFloat(aPred.toFixed(4)),
+    structure: struct,
+    n_auc: nAuc,
+    gamma: parseFloat(gamma.toFixed(4)),
+    v_vegard_per_atom: parseFloat(vVegard.toFixed(4)),
+    v_total_per_cell: vTotal > 0 ? parseFloat(vTotal.toFixed(4)) : null,
+    correction_term: parseFloat((gamma * correction).toFixed(6)),
+    pair_contributions: pairDetails,
+    missing_pairs: missingPairs,
+    vegard_fallback: vegardFallback,
+    warning: warning,
+    composition: compNorm
+  };
+}
+
+// ==================== UI Logic ====================
+const ELEMENT_COLORS = {
+  'Al':'#ef4444','Co':'#3b82f6','Cr':'#10b981','Cu':'#f59e0b','Fe':'#6366f1',
+  'Mn':'#ec4899','Ni':'#14b8a6','Ti':'#8b5cf6','V':'#f97316','Nb':'#06b6d4',
+  'Mo':'#84cc16','Ta':'#e11d48','W':'#7c3aed','Zr':'#0ea5e9','Hf':'#d946ef',
+  'Pd':'#fbbf24','Pt':'#a3e635','Au':'#facc15','Ag':'#94a3b8','Ir':'#2dd4bf',
+  'Rh':'#fb923c','Ru':'#818cf8','Os':'#4ade80','Re':'#f472b6','Si':'#38bdf8',
+  'Ge':'#a78bfa','Mg':'#34d399','Sc':'#fda4af','Sn':'#c084fc','Zn':'#fcd34d',
+  'Be':'#67e8f9','B':'#86efac','P':'#d8b4fe','Pb':'#cbd5e1','Y':'#fca5a5',
+  'La':'#bef264','Ce':'#fdba74','Er':'#c4b5fd','Tb':'#a5b4fc','Dy':'#99f6e4','Ca':'#fde68a'
+};
+
+let composition = {};
+
+function init() {
+  document.getElementById('info-gamma-bcc').textContent = GAMMA_BCC.toFixed(4);
+  document.getElementById('info-gamma-fcc').textContent = GAMMA_FCC.toFixed(4);
+  document.getElementById('info-b2').textContent = Object.keys(OMEGA_B2).length;
+  document.getElementById('info-l12').textContent = Object.keys(OMEGA_L12).length;
+  populateSelect();
+}
+
+function populateSelect() {
+  const sel = document.getElementById('elem-select');
+  sel.innerHTML = '';
+  const used = Object.keys(composition);
+  availableElements.filter(e => !used.includes(e)).forEach(e => {
+    const opt = document.createElement('option');
+    opt.value = e; opt.textContent = e;
+    sel.appendChild(opt);
+  });
+}
+
+function addElement() {
+  const elem = document.getElementById('elem-select').value;
+  const frac = parseFloat(document.getElementById('frac-input').value);
+  if (!elem || isNaN(frac) || frac <= 0) return;
+  composition[elem] = frac;
+  renderElements();
+  populateSelect();
+}
+
+function addEquimolar() {
+  const elem = document.getElementById('elem-select').value;
+  if (!elem || elem in composition) return;
+  composition[elem] = 0;
+  const n = Object.keys(composition).length;
+  const eq = parseFloat((100 / n).toFixed(2));
+  Object.keys(composition).forEach(e => composition[e] = eq);
+  renderElements();
+  populateSelect();
+}
+
+function removeElement(elem) {
+  delete composition[elem];
+  renderElements();
+  populateSelect();
+}
+
+function updateFrac(elem, val) {
+  composition[elem] = parseFloat(val) || 0;
+  updateTotal();
+  renderBar();
+}
+
+function normalizeAll() {
+  const total = Object.values(composition).reduce((s, v) => s + v, 0);
+  if (total <= 0) return;
+  Object.keys(composition).forEach(e => {
+    composition[e] = parseFloat((composition[e] / total * 100).toFixed(2));
+  });
+  renderElements();
+}
+
+function clearAll() {
+  composition = {};
+  renderElements();
+  populateSelect();
+  document.getElementById('results').style.display = 'none';
+}
+
+function renderElements() {
+  const list = document.getElementById('element-list');
+  list.innerHTML = '';
+  Object.entries(composition).forEach(([elem, frac]) => {
+    const tag = document.createElement('div');
+    tag.className = 'element-tag';
+    tag.innerHTML = `
+      <span class="elem-symbol">${elem}</span>
+      <input type="number" value="${frac}" min="0" max="100" step="0.1"
+             onchange="updateFrac('${elem}', this.value)">
+      <span style="font-size:0.8rem; color:var(--text-light);">at%</span>
+      <button class="btn-danger" onclick="removeElement('${elem}')">✕</button>
+    `;
+    list.appendChild(tag);
+  });
+  updateTotal();
+  renderBar();
+}
+
+function updateTotal() {
+  const total = Object.values(composition).reduce((s, v) => s + v, 0);
+  document.getElementById('total-frac').textContent = total.toFixed(1);
+  document.getElementById('n-elements').textContent = Object.keys(composition).length;
+}
+
+function renderBar() {
+  const bar = document.getElementById('comp-bar');
+  const total = Object.values(composition).reduce((s, v) => s + v, 0);
+  if (total <= 0 || Object.keys(composition).length === 0) {
+    bar.style.display = 'none';
+    return;
+  }
+  bar.style.display = 'flex';
+  bar.innerHTML = '';
+  Object.entries(composition).forEach(([elem, frac]) => {
+    const pct = (frac / total * 100);
+    if (pct <= 0) return;
+    const div = document.createElement('div');
+    div.style.width = pct + '%';
+    div.style.background = ELEMENT_COLORS[elem] || '#64748b';
+    div.textContent = pct > 8 ? elem : '';
+    bar.appendChild(div);
+  });
+}
+
+function renderResultBar(comp) {
+  const bar = document.getElementById('result-comp-bar');
+  bar.innerHTML = '';
+  const entries = Object.entries(comp).sort((a,b) => b[1]-a[1]);
+  entries.forEach(([elem, frac]) => {
+    const pct = frac * 100;
+    if (pct <= 0) return;
+    const div = document.createElement('div');
+    div.style.width = pct + '%';
+    div.style.background = ELEMENT_COLORS[elem] || '#64748b';
+    div.textContent = pct > 6 ? `${elem} ${pct.toFixed(1)}%` : (pct > 3 ? elem : '');
+    bar.appendChild(div);
+  });
+}
+
+function predict() {
+  const elems = Object.keys(composition);
+  if (elems.length < 2) {
+    alert('少なくとも2元素を追加してください');
+    return;
+  }
+  const total = Object.values(composition).reduce((s, v) => s + v, 0);
+  if (total <= 0) {
+    alert('組成分率が正でなければなりません');
+    return;
+  }
+
+  const struct = document.querySelector('input[name="struct"]:checked').value;
+  const comp = {};
+  elems.forEach(e => comp[e] = composition[e] / total);
+
+  try {
+    const data = predictLattice(comp, struct);
+
+    // Show results
+    document.getElementById('results').style.display = 'block';
+    document.getElementById('res-predicted').textContent = data.a_predicted.toFixed(4);
+    document.getElementById('res-vegard').textContent = data.a_vegard.toFixed(4);
+    document.getElementById('res-struct').textContent = data.structure;
+    document.getElementById('res-gamma').textContent = data.gamma.toFixed(4);
+    document.getElementById('res-correction').textContent = data.correction_term.toFixed(4);
+
+    renderResultBar(data.composition);
+
+    // Pair table
+    const tbody = document.getElementById('pair-tbody');
+    tbody.innerHTML = '';
+    (data.pair_contributions || []).forEach(p => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${p.pair}</td><td>${p.omega_sf.toFixed(4)}</td><td>${p.contribution.toFixed(6)}</td>`;
+      tbody.appendChild(tr);
+    });
+
+    // Missing pairs
+    const mp = document.getElementById('missing-pairs');
+    if (data.missing_pairs && data.missing_pairs.length > 0) {
+      mp.innerHTML = `<div class="warning-box">
+        Ω<sub>sf</sub>データ欠損ペア（Vegard縮退）: ${data.missing_pairs.join(', ')}
+      </div>`;
+    } else {
+      mp.innerHTML = '';
+    }
+
+    // Warning
+    const wa = document.getElementById('warning-area');
+    if (data.warning) {
+      wa.innerHTML = `<div class="warning-box">${data.warning}</div>`;
+    } else if (data.vegard_fallback) {
+      wa.innerHTML = `<div class="warning-box">
+        一部の元素対でΩ<sub>sf</sub>データが欠損しているため、
+        該当ペアはVegard則に縮退しています（補正なし）。
+      </div>`;
+    } else {
+      wa.innerHTML = '';
+    }
+
+    document.getElementById('results').scrollIntoView({behavior: 'smooth'});
+
+  } catch (e) {
+    alert('エラー: ' + e.message);
+  }
+}
+
+// Presets
+const PRESETS = {
+  cantor:     {comp: {Co:20,Cr:20,Fe:20,Mn:20,Ni:20}, struct: 'FCC'},
+  refractory: {comp: {Nb:25,Mo:25,Ta:25,W:25}, struct: 'BCC'},
+  cocrfeni:   {comp: {Co:25,Cr:25,Fe:25,Ni:25}, struct: 'FCC'},
+  senkov:     {comp: {Nb:20,Ti:20,V:20,Zr:20,Hf:20}, struct: 'BCC'},
+  alcrfev:    {comp: {Al:20,Cr:20,Fe:20,Mo:20,V:20}, struct: 'BCC'},
+};
+
+function loadPreset(name) {
+  const p = PRESETS[name];
+  composition = {...p.comp};
+  document.getElementById('struct-' + p.struct.toLowerCase()).checked = true;
+  renderElements();
+  populateSelect();
+}
+
+// Init
+init();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

PR #213のFlask+HTML分離版Webアプリを、配布しやすい単一HTMLファイルに統合。

**変更内容:**
- `webapp/HEA_Lattice_Predictor.html` を新規作成（901行、約30KB）
- `model_data.json`のデータ（41元素King原子体積、152 B2ペア、95 L1₂ペア）をJavaScript内に埋め込み
- 予測ロジック（Alonso DFT-SSモデル）をPythonからJavaScriptに移植
- サーバー不要でブラウザのみで動作（オフライン対応）
- Flask版と同一の予測値を出力

**検証済みテストケース:**
| 合金 | 構造 | 予測値 | Vegard | 一致 |
|------|------|--------|--------|------|
| CoCrFeNi | FCC | 3.5761 Å | 3.5778 Å | ✓ |
| NbMoTaW | BCC | 3.2305 Å | 3.2305 Å | ✓ |
| CoCrFeNiMn | FCC | 3.5918 Å | 3.5936 Å | ✓ |

**使い方:** `HEA_Lattice_Predictor.html`をダブルクリックするだけ。Flask/Python/npmは不要。

## Review & Testing Checklist for Human
- [ ] `webapp/HEA_Lattice_Predictor.html` をブラウザで開き、5つのプリセット全てが動作することを確認
- [ ] CoCrFeNi FCC → 3.5761 Å が表示されることを確認
- [ ] 手動で元素を追加・削除し、正規化ボタンが正しく動作することを確認

### Notes
- 既存のFlask版（`app.py`, `index.html`, `model_data.json`）はそのまま残しています。不要であれば別PRで削除可能です。

Link to Devin session: https://app.devin.ai/sessions/aa336d0f2b374126a139328ec9469942
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->