### PR TITLE
fix: HTML参考文献[1]をGalindo-Nava(2017)からCoreño Alonso(2021)に修正

### DIFF
--- a/webapp/HEA_Lattice_Predictor.html
+++ b/webapp/HEA_Lattice_Predictor.html
@@ -614,12 +614,13 @@
 
       <div class="ref-item">
         <span class="ref-id">[1]</span>
-        E. Galindo-Nava, P.E.J. Rivera-D&iacute;az-del-Castillo,
-        &ldquo;Understanding the factors controlling the hardness in martensitic steels,&rdquo;
-        <em>Scripta Materialia</em>, Vol. 134, pp. 39&ndash;42, 2017.
+        J. Core&ntilde;o Alonso, O. Core&ntilde;o Alonso,
+        &ldquo;Derivation of unit cell volume, and lattice parameter of cubic high entropy alloys from volume size factors,&rdquo;
+        <em>Intermetallics</em>, Vol. 137, 107299, 2021.
+        (<a href="https://doi.org/10.1016/j.intermet.2021.107299" target="_blank">doi:10.1016/j.intermet.2021.107299</a>)
         <br>
         <span style="color:var(--text-light);">
-          Alonsoモデルの元となる体積サイズ因子（Ω<sub>sf</sub>）によるHEA格子定数予測式を提案。
+          体積サイズ因子（Ω<sub>sf</sub>）を用いたHEA格子定数予測式を提案。
           本ツールの予測式の基礎。
         </span>
       </div>


### PR DESCRIPTION
## Summary

HTML（HEA_Lattice_Predictor.html）の参考文献[1]が誤っていたため修正。

**修正前（誤）：**
> E. Galindo-Nava, P.E.J. Rivera-Díaz-del-Castillo, "Understanding the factors controlling the hardness in martensitic steels," Scripta Materialia, Vol. 134, pp. 39–42, 2017.

→ マルテンサイト鋼の硬度に関する論文であり、Alonsoモデル（HEA格子定数予測）の出典として不正確。

**修正後（正）：**
> J. Coreño Alonso, O. Coreño Alonso, "Derivation of unit cell volume, and lattice parameter of cubic high entropy alloys from volume size factors," Intermetallics, Vol. 137, 107299, 2021.

`minamoto.bib`のAlonso2021エントリに基づき修正。DOIリンクも追加。

## Review & Testing Checklist for Human
- [ ] HTML参考文献タブを開き、[1]がCoreño Alonso(2021)になっていること確認
- [ ] DOIリンク(https://doi.org/10.1016/j.intermet.2021.107299)が正しいページに遷移すること確認

### Notes
- LaTeX側の`\bibitem{Alonso2021}`は `J.A. Alonso, J. Phase Equilib. Diffus. 43 (2022) 555`（DOI: 10.1007/s11669-022-00988-z）で、`minamoto.bib`の Coreño Alonso(2021, Intermetallics)とは**別の論文**です。LaTeX側の参考文献も確認が必要かもしれません。

Link to Devin session: https://app.devin.ai/sessions/aa336d0f2b374126a139328ec9469942
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->