### PR TITLE
refactor: BibTeX化 + §4.1先行研究比較を時系列順に並べ替え

### DIFF
--- a/paper/hea_lattice_prediction.tex
+++ b/paper/hea_lattice_prediction.tex
@@ -1758,19 +1758,12 @@ BCC HEA精度向上には、多体相互作用の導入（三元系DFTデータ�
 
 HEA格子定数予測に関する先行研究との比較を議論する。
 
-\paragraph{Vegard則}
-最も単純なアプローチであるVegard則は、原子体積の線形補間に基づく。
+\paragraph{Vegard則 (1921)}
+最も単純なアプローチであるVegard則~\cite{Vegard1921}は、原子体積の線形補間に基づく。
 64 HEAに対するRMSE（King原子体積使用）は0.0227~\AA{}であり、
 化学結合効果を無視しても比較的良い近似を与える。これはHEAが
 多成分等モル混合であり、個々の元素対効果が平均化されるためである。
 ただしBCC HEAでは0.0328~\AA{}と精度が低下する。
-
-\paragraph{Alonsoモデル (2021)}
-Alonsoモデルは式~\eqref{eq:alonso}でRMSE = 0.023~\AA{}を達成した。
-$q = 1$（スケーリングなし）であり、構造依存性は考慮しない。
-本研究のDFT-SSモデルとの主要な
-違いは：(a)~DFT vs 実験$\Omega_\text{sf}$、(b)~構造特異的 vs 共通
-$\Omega_\text{sf}$、(c)~$q$最適化の有無、である。
 
 \paragraph{Core\~{n}o-Alonsoモデル (2004)}
 Core\~{n}o-Alonso \& Core\~{n}o-Alonso~\cite{CorenoAlonso2004}は
@@ -1843,12 +1836,18 @@ Zaddachらはコヒーレント・ポテンシャル近似（CPA）に基づく
 任意組成のHEA格子定数を即座に予測でき、スクリーニング用途に
 適している。
 
-\paragraph{機械学習アプローチ}
+\paragraph{機械学習アプローチ (Zhang {\it et al.} 2017)}
 Zhang {\it et al.}~\cite{Zhang2017nat}らはMLベースのHEA物性予測を
 試みているが、訓練データの制約（$N < 100$）が深刻な過学習を
 引き起こすことが報告されている。本研究でも7種のMLモデルが
 物理モデルを改善できなかった結果はこの傾向と一致する。
 
+\paragraph{Alonsoモデル (2022)}
+Alonsoモデル~\cite{Alonso2021}は式~\eqref{eq:alonso}でRMSE = 0.023~\AA{}を達成した。
+$q = 1$（スケーリングなし）であり、構造依存性は考慮しない。
+本研究のDFT-SSモデルとの主要な
+違いは：(a)~DFT vs 実験$\Omega_\text{sf}$、(b)~構造特異的 vs 共通
+$\Omega_\text{sf}$、(c)~$q$最適化の有無、である。
 
 \subsection{校正定数$q$の位置づけ}
 
@@ -2415,165 +2414,7 @@ Vegard基準線は室温に整合している。
 %% 参考文献
 %% =====================================================================
 
-\begin{thebibliography}{99}
-
-\bibitem{Yeh2004}
-J.-W.~Yeh et al., Adv.\ Eng.\ Mater.\ \textbf{6} (2004) 299.
-\newblock \href{https://doi.org/10.1002/adem.200300567}{doi:10.1002/adem.200300567}.
-
-\bibitem{Cantor2004}
-B.~Cantor et al., Mater.\ Sci.\ Eng.\ A \textbf{375--377} (2004) 213.
-\newblock \href{https://doi.org/10.1016/j.msea.2003.10.257}{doi:10.1016/j.msea.2003.10.257}.
-
-\bibitem{Miracle2017}
-D.B.~Miracle, O.N.~Senkov, Acta Mater.\ \textbf{122} (2017) 448.
-\newblock \href{https://doi.org/10.1016/j.actamat.2016.08.081}{doi:10.1016/j.actamat.2016.08.081}.
-
-\bibitem{Senkov2015}
-O.N.~Senkov et al., Nat.\ Commun.\ \textbf{6} (2015) 6529.
-\newblock \href{https://doi.org/10.1038/ncomms7529}{doi:10.1038/ncomms7529}.
-
-\bibitem{Vegard1921}
-L.~Vegard, Z.\ Phys.\ \textbf{5} (1921) 17.
-\newblock \href{https://doi.org/10.1007/BF01349680}{doi:10.1007/BF01349680}.
-
-\bibitem{King1966}
-H.W.~King, J.\ Mater.\ Sci.\ \textbf{1} (1966) 79.
-\newblock \href{https://doi.org/10.1007/BF00549722}{doi:10.1007/BF00549722}.
-
-\bibitem{Alonso2021}
-J.A.~Alonso, J.\ Phase Equilib.\ Diffus.\ \textbf{43} (2022) 555.
-\newblock \href{https://doi.org/10.1007/s11669-022-00988-z}{doi:10.1007/s11669-022-00988-z}.
-
-\bibitem{CorenoAlonso2004}
-O.~Core\~{n}o-Alonso, J.~Core\~{n}o-Alonso, Intermetallics \textbf{12} (2004) 117.
-\newblock \href{https://doi.org/10.1016/j.intermet.2003.09.001}{doi:10.1016/j.intermet.2003.09.001}.
-
-\bibitem{deBoer1988}
-F.R.~de~Boer, R.~Boom, W.C.M.~Mattens, A.R.~Miedema, A.K.~Niessen,
-Cohesion in Metals: Transition Metal Alloys, North-Holland, Amsterdam, 1988.
-
-\bibitem{Zhang2008}
-Y.~Zhang et al., Adv.\ Eng.\ Mater.\ \textbf{10} (2008) 534.
-\newblock \href{https://doi.org/10.1002/adem.200700240}{doi:10.1002/adem.200700240}.
-
-\bibitem{Guo2011}
-S.~Guo, C.T.~Liu, Prog.\ Nat.\ Sci.\ \textbf{21} (2011) 433.
-\newblock \href{https://doi.org/10.1016/S1002-0071(12)60080-X}{doi:10.1016/S1002-0071(12)60080-X}.
-
-\bibitem{Yang2012}
-X.~Yang, Y.~Zhang, Mater.\ Chem.\ Phys.\ \textbf{132} (2012) 233.
-\newblock \href{https://doi.org/10.1016/j.matchemphys.2011.11.021}{doi:10.1016/j.matchemphys.2011.11.021}.
-
-\bibitem{Jain2013}
-A.~Jain et al., APL Mater.\ \textbf{1} (2013) 011002.
-\newblock \href{https://doi.org/10.1063/1.4812323}{doi:10.1063/1.4812323}.
-
-\bibitem{Saal2013}
-J.E.~Saal et al., JOM \textbf{65} (2013) 1501.
-\newblock \href{https://doi.org/10.1007/s11837-013-0755-4}{doi:10.1007/s11837-013-0755-4}.
-
-\bibitem{Chen2016}
-T.~Chen, C.~Guestrin, Proc.\ 22nd ACM SIGKDD (2016) 785.
-\newblock \href{https://doi.org/10.1145/2939672.2939785}{doi:10.1145/2939672.2939785}.
-
-\bibitem{Senkov2013}
-O.N.~Senkov et al., Intermetallics \textbf{19} (2011) 698.
-\newblock \href{https://doi.org/10.1016/j.intermet.2011.01.004}{doi:10.1016/j.intermet.2011.01.004}.
-
-\bibitem{Yao2016}
-H.W.~Yao et al., Entropy \textbf{18} (2016) 189.
-\newblock \href{https://doi.org/10.3390/e18050189}{doi:10.3390/e18050189}.
-
-\bibitem{Otto2013}
-F.~Otto et al., Acta Mater.\ \textbf{61} (2013) 5743.
-\newblock \href{https://doi.org/10.1016/j.actamat.2013.06.018}{doi:10.1016/j.actamat.2013.06.018}.
-
-\bibitem{Leong2017}
-Z.~Leong et al., Sci.\ Rep.\ \textbf{7} (2017) 39803.
-\newblock \href{https://doi.org/10.1038/srep39803}{doi:10.1038/srep39803}.
-
-\bibitem{Wang2019}
-Z.~Wang et al., Scr.\ Mater.\ \textbf{94} (2015) 28.
-\newblock \href{https://doi.org/10.1016/j.scriptamat.2014.09.010}{doi:10.1016/j.scriptamat.2014.09.010}.
-
-\bibitem{Zaddach2013}
-A.J.~Zaddach et al., JOM \textbf{65} (2013) 1780.
-\newblock \href{https://doi.org/10.1007/s11837-013-0771-4}{doi:10.1007/s11837-013-0771-4}.
-
-\bibitem{Zhang2017nat}
-Z.~Zhang et al., Nat.\ Commun.\ \textbf{8} (2017) 14390.
-\newblock \href{https://doi.org/10.1038/ncomms14390}{doi:10.1038/ncomms14390}.
-
-\bibitem{Curtarolo2012}
-S.~Curtarolo et al., Comput.\ Mater.\ Sci.\ \textbf{58} (2012) 218.
-\newblock \href{https://doi.org/10.1016/j.commatsci.2012.02.005}{doi:10.1016/j.commatsci.2012.02.005}.
-
-\bibitem{Tian2013}
-F.~Tian et al., Phys.\ Rev.\ B \textbf{88} (2013) 085128.
-\newblock \href{https://doi.org/10.1103/PhysRevB.88.085128}{doi:10.1103/PhysRevB.88.085128}.
-
-\bibitem{Troparevsky2015}
-M.C.~Troparevsky et al., Phys.\ Rev.\ X \textbf{5} (2015) 011041.
-\newblock \href{https://doi.org/10.1103/PhysRevX.5.011041}{doi:10.1103/PhysRevX.5.011041}.
-
-\bibitem{Ye2015}
-Y.F.~Ye, C.T.~Liu, Y.~Yang, Acta Mater.\ \textbf{94} (2015) 152.
-\newblock \href{https://doi.org/10.1016/j.actamat.2015.04.051}{doi:10.1016/j.actamat.2015.04.051}.
-
-\bibitem{TodaCaraballo2016}
-I.~Toda-Caraballo, P.E.J.~Rivera-D\'{i}az-del-Castillo, Intermetallics \textbf{71} (2016) 76.
-\newblock \href{https://doi.org/10.1016/j.intermet.2015.12.011}{doi:10.1016/j.intermet.2015.12.011}.
-
-\bibitem{Tandoc2023}
-C.~Tandoc et al., npj Comput.\ Mater.\ \textbf{9} (2023) 53.
-\newblock \href{https://doi.org/10.1038/s41524-023-00993-x}{doi:10.1038/s41524-023-00993-x}.
-
-\bibitem{Tian2015}
-F.~Tian et al., Sci.\ Rep.\ \textbf{5} (2015) 12334.
-\newblock \href{https://doi.org/10.1038/srep12334}{doi:10.1038/srep12334}.
-
-\bibitem{Wen2019}
-C.~Wen et al., Acta Mater.\ \textbf{170} (2019) 109.
-\newblock \href{https://doi.org/10.1016/j.actamat.2019.03.010}{doi:10.1016/j.actamat.2019.03.010}.
-
-\bibitem{Zunger1990}
-A.~Zunger, S.-H.~Wei, L.G.~Ferreira, J.E.~Bernard,
-Phys.\ Rev.\ Lett.\ \textbf{65} (1990) 353.
-\newblock \href{https://doi.org/10.1103/PhysRevLett.65.353}{doi:10.1103/PhysRevLett.65.353}.
-
-\bibitem{WarrenCowley1950}
-J.M.~Cowley, J.\ Appl.\ Phys.\ \textbf{21} (1950) 24.
-\newblock \href{https://doi.org/10.1063/1.1699415}{doi:10.1063/1.1699415}.
-
-\bibitem{Stepanov2015}
-N.D.~Stepanov et al., Mater.\ Lett.\ \textbf{142} (2015) 153.
-\newblock \href{https://doi.org/10.1016/j.matlet.2014.11.162}{doi:10.1016/j.matlet.2014.11.162}.
-
-\bibitem{Zhang2015}
-B.~Zhang et al., Calphad \textbf{51} (2015) 193.
-\newblock \href{https://doi.org/10.1016/j.calphad.2015.09.007}{doi:10.1016/j.calphad.2015.09.007}.
-
-\bibitem{Kantelis2025}
-K.~Kantelis et al., AIP Adv.\ \textbf{15} (2025) 015030.
-\newblock \href{https://doi.org/10.1063/5.0245966}{doi:10.1063/5.0245966}.
-
-\bibitem{Youssef2015}
-K.M.~Youssef et al., Mater.\ Res.\ Lett.\ \textbf{3} (2015) 95.
-\newblock \href{https://doi.org/10.1080/21663831.2014.985855}{doi:10.1080/21663831.2014.985855}.
-
-\bibitem{Dirras2016}
-G.~Dirras et al., Mater.\ Charact.\ \textbf{108} (2015) 1.
-\newblock \href{https://doi.org/10.1016/j.matchar.2015.08.007}{doi:10.1016/j.matchar.2015.08.007}.
-
-\bibitem{Gali2013}
-A.~Gali, E.P.~George, Intermetallics \textbf{39} (2013) 74.
-\newblock \href{https://doi.org/10.1016/j.intermet.2013.03.018}{doi:10.1016/j.intermet.2013.03.018}.
-
-\bibitem{Tasan2014}
-C.C.~Tasan et al., JOM \textbf{66} (2014) 1993.
-\newblock \href{https://doi.org/10.1007/s11837-014-1133-6}{doi:10.1007/s11837-014-1133-6}.
-
-\end{thebibliography}
+\bibliographystyle{elsarticle-num}
+\bibliography{references}
 
 \end{document}

--- a/paper/references.bib
+++ b/paper/references.bib
@@ -1,0 +1,386 @@
+@article{Yeh2004,
+  author  = {J.-W. Yeh and S.-K. Chen and S.-J. Lin and J.-Y. Gan and T.-S. Chin and T.-T. Shun and C.-H. Tsau and S.-Y. Chang},
+  title   = {Nanostructured High-Entropy Alloys with Multiple Principal Elements: Novel Alloy Design Concepts and Outcomes},
+  journal = {Adv. Eng. Mater.},
+  volume  = {6},
+  pages   = {299--303},
+  year    = {2004},
+  doi     = {10.1002/adem.200300567},
+}
+
+@article{Cantor2004,
+  author  = {B. Cantor and I. T. H. Chang and P. Knight and A. J. B. Vincent},
+  title   = {Microstructural development in equiatomic multicomponent alloys},
+  journal = {Mater. Sci. Eng. A},
+  volume  = {375--377},
+  pages   = {213--218},
+  year    = {2004},
+  doi     = {10.1016/j.msea.2003.10.257},
+}
+
+@article{Miracle2017,
+  author  = {D. B. Miracle and O. N. Senkov},
+  title   = {A critical review of high entropy alloys and related concepts},
+  journal = {Acta Mater.},
+  volume  = {122},
+  pages   = {448--511},
+  year    = {2017},
+  doi     = {10.1016/j.actamat.2016.08.081},
+}
+
+@article{Senkov2015,
+  author  = {O. N. Senkov and others},
+  title   = {Refractory high-entropy alloys},
+  journal = {Nat. Commun.},
+  volume  = {6},
+  pages   = {6529},
+  year    = {2015},
+  doi     = {10.1038/ncomms7529},
+}
+
+@article{Vegard1921,
+  author  = {L. Vegard},
+  title   = {{Die Konstitution der Mischkristalle und die Raumf\"ullung der Atome}},
+  journal = {Z. Phys.},
+  volume  = {5},
+  pages   = {17--26},
+  year    = {1921},
+  doi     = {10.1007/BF01349680},
+}
+
+@article{King1966,
+  author  = {H. W. King},
+  title   = {Quantitative size-factors for metallic solid solutions},
+  journal = {J. Mater. Sci.},
+  volume  = {1},
+  pages   = {79--90},
+  year    = {1966},
+  doi     = {10.1007/BF00549722},
+}
+
+@article{Alonso2021,
+  author  = {J. A. Alonso},
+  title   = {Estimation of the Lattice Parameters of {HEAs}},
+  journal = {J. Phase Equilib. Diffus.},
+  volume  = {43},
+  pages   = {555--566},
+  year    = {2022},
+  doi     = {10.1007/s11669-022-00988-z},
+}
+
+@article{CorenoAlonso2004,
+  author  = {O. Core{\~n}o-Alonso and J. Core{\~n}o-Alonso},
+  title   = {Volume size factor and lattice parameter in cubic intermetallics with {L1}$_2$ or {B2} structure derived from the ``{Macroscopic Atom}'' model},
+  journal = {Intermetallics},
+  volume  = {12},
+  pages   = {117--122},
+  year    = {2004},
+  doi     = {10.1016/j.intermet.2003.09.001},
+}
+
+@book{deBoer1988,
+  author    = {F. R. de Boer and R. Boom and W. C. M. Mattens and A. R. Miedema and A. K. Niessen},
+  title     = {Cohesion in Metals: Transition Metal Alloys},
+  publisher = {North-Holland},
+  address   = {Amsterdam},
+  year      = {1988},
+}
+
+@article{Zhang2008,
+  author  = {Y. Zhang and others},
+  title   = {Solid-Solution Phase Formation Rules for Multi-component Alloys},
+  journal = {Adv. Eng. Mater.},
+  volume  = {10},
+  pages   = {534--538},
+  year    = {2008},
+  doi     = {10.1002/adem.200700240},
+}
+
+@article{Guo2011,
+  author  = {S. Guo and C. T. Liu},
+  title   = {Phase stability in high entropy alloys: Formation of solid-solution phase or amorphous phase},
+  journal = {Prog. Nat. Sci.},
+  volume  = {21},
+  pages   = {433--446},
+  year    = {2011},
+  doi     = {10.1016/S1002-0071(12)60080-X},
+}
+
+@article{Yang2012,
+  author  = {X. Yang and Y. Zhang},
+  title   = {Prediction of high-entropy stabilized solid-solution in multi-component alloys},
+  journal = {Mater. Chem. Phys.},
+  volume  = {132},
+  pages   = {233--238},
+  year    = {2012},
+  doi     = {10.1016/j.matchemphys.2011.11.021},
+}
+
+@article{Jain2013,
+  author  = {A. Jain and others},
+  title   = {Commentary: {The Materials Project}: A materials genome approach to accelerating materials innovation},
+  journal = {APL Mater.},
+  volume  = {1},
+  pages   = {011002},
+  year    = {2013},
+  doi     = {10.1063/1.4812323},
+}
+
+@article{Saal2013,
+  author  = {J. E. Saal and others},
+  title   = {Materials Design and Discovery with High-Throughput Density Functional Theory: The {Open Quantum Materials Database (OQMD)}},
+  journal = {JOM},
+  volume  = {65},
+  pages   = {1501--1509},
+  year    = {2013},
+  doi     = {10.1007/s11837-013-0755-4},
+}
+
+@inproceedings{Chen2016,
+  author    = {T. Chen and C. Guestrin},
+  title     = {{XGBoost}: A Scalable Tree Boosting System},
+  booktitle = {Proc. 22nd ACM SIGKDD},
+  pages     = {785--794},
+  year      = {2016},
+  doi       = {10.1145/2939672.2939785},
+}
+
+@article{Senkov2013,
+  author  = {O. N. Senkov and others},
+  title   = {Refractory high-entropy alloys},
+  journal = {Intermetallics},
+  volume  = {19},
+  pages   = {698--706},
+  year    = {2011},
+  doi     = {10.1016/j.intermet.2011.01.004},
+}
+
+@article{Yao2016,
+  author  = {H. W. Yao and others},
+  title   = {{NbTaV-(Ti,W)} Refractory High-Entropy Alloys},
+  journal = {Entropy},
+  volume  = {18},
+  pages   = {189},
+  year    = {2016},
+  doi     = {10.3390/e18050189},
+}
+
+@article{Otto2013,
+  author  = {F. Otto and others},
+  title   = {The influences of temperature and microstructure on the tensile properties of a {CoCrFeMnNi} high-entropy alloy},
+  journal = {Acta Mater.},
+  volume  = {61},
+  pages   = {5743--5755},
+  year    = {2013},
+  doi     = {10.1016/j.actamat.2013.06.018},
+}
+
+@article{Leong2017,
+  author  = {Z. Leong and others},
+  title   = {The Effect of Electronic Structure on the Phases Present in High Entropy Alloys},
+  journal = {Sci. Rep.},
+  volume  = {7},
+  pages   = {39803},
+  year    = {2017},
+  doi     = {10.1038/srep39803},
+}
+
+@article{Wang2019,
+  author  = {Z. Wang and others},
+  title   = {Atomic-size effect and solid solubility of multicomponent alloys},
+  journal = {Scr. Mater.},
+  volume  = {94},
+  pages   = {28--31},
+  year    = {2015},
+  doi     = {10.1016/j.scriptamat.2014.09.010},
+}
+
+@article{Zaddach2013,
+  author  = {A. J. Zaddach and others},
+  title   = {Mechanical Properties and Stacking Fault Energies of {NiFeCrCoMn} High-Entropy Alloy},
+  journal = {JOM},
+  volume  = {65},
+  pages   = {1780--1789},
+  year    = {2013},
+  doi     = {10.1007/s11837-013-0771-4},
+}
+
+@article{Zhang2017nat,
+  author  = {Z. Zhang and others},
+  title   = {Nanoscale origins of the damage tolerance of the high-entropy alloy {CrMnFeCoNi}},
+  journal = {Nat. Commun.},
+  volume  = {8},
+  pages   = {14390},
+  year    = {2017},
+  doi     = {10.1038/ncomms14390},
+}
+
+@article{Curtarolo2012,
+  author  = {S. Curtarolo and others},
+  title   = {AFLOW: An automatic framework for high-throughput materials discovery},
+  journal = {Comput. Mater. Sci.},
+  volume  = {58},
+  pages   = {218--226},
+  year    = {2012},
+  doi     = {10.1016/j.commatsci.2012.02.005},
+}
+
+@article{Tian2013,
+  author  = {F. Tian and others},
+  title   = {Calculating elastic constants in high-entropy alloys using the coherent potential approximation: Current issues and errors},
+  journal = {Phys. Rev. B},
+  volume  = {88},
+  pages   = {085128},
+  year    = {2013},
+  doi     = {10.1103/PhysRevB.88.085128},
+}
+
+@article{Troparevsky2015,
+  author  = {M. C. Troparevsky and others},
+  title   = {Criteria for Predicting the Formation of Single-Phase High-Entropy Alloys},
+  journal = {Phys. Rev. X},
+  volume  = {5},
+  pages   = {011041},
+  year    = {2015},
+  doi     = {10.1103/PhysRevX.5.011041},
+}
+
+@article{Ye2015,
+  author  = {Y. F. Ye and C. T. Liu and Y. Yang},
+  title   = {A geometric model for intrinsic residual strain and phase stability in high entropy alloys},
+  journal = {Acta Mater.},
+  volume  = {94},
+  pages   = {152--161},
+  year    = {2015},
+  doi     = {10.1016/j.actamat.2015.04.051},
+}
+
+@article{TodaCaraballo2016,
+  author  = {I. Toda-Caraballo and P. E. J. Rivera-D{\'\i}az-del-Castillo},
+  title   = {Modelling solid solution hardening in high entropy alloys},
+  journal = {Intermetallics},
+  volume  = {71},
+  pages   = {76--87},
+  year    = {2016},
+  doi     = {10.1016/j.intermet.2015.12.011},
+}
+
+@article{Tandoc2023,
+  author  = {C. Tandoc and others},
+  title   = {Mining of lattice distortion, strength, and intrinsic ductility of refractory high entropy alloys},
+  journal = {npj Comput. Mater.},
+  volume  = {9},
+  pages   = {53},
+  year    = {2023},
+  doi     = {10.1038/s41524-023-00993-x},
+}
+
+@article{Tian2015,
+  author  = {F. Tian and others},
+  title   = {Structural stability of {NiCoFeCrAl}$_x$ high-entropy alloy from ab initio theory},
+  journal = {Sci. Rep.},
+  volume  = {5},
+  pages   = {12334},
+  year    = {2015},
+  doi     = {10.1038/srep12334},
+}
+
+@article{Wen2019,
+  author  = {C. Wen and others},
+  title   = {Machine learning assisted design of high entropy alloys with desired property},
+  journal = {Acta Mater.},
+  volume  = {170},
+  pages   = {109--117},
+  year    = {2019},
+  doi     = {10.1016/j.actamat.2019.03.010},
+}
+
+@article{Zunger1990,
+  author  = {A. Zunger and S.-H. Wei and L. G. Ferreira and J. E. Bernard},
+  title   = {Special quasirandom structures},
+  journal = {Phys. Rev. Lett.},
+  volume  = {65},
+  pages   = {353--356},
+  year    = {1990},
+  doi     = {10.1103/PhysRevLett.65.353},
+}
+
+@article{WarrenCowley1950,
+  author  = {J. M. Cowley},
+  title   = {An Approximate Theory of Order in Alloys},
+  journal = {J. Appl. Phys.},
+  volume  = {21},
+  pages   = {24--30},
+  year    = {1950},
+  doi     = {10.1063/1.1699415},
+}
+
+@article{Stepanov2015,
+  author  = {N. D. Stepanov and others},
+  title   = {Effect of {V} content on microstructure and mechanical properties of the {CoCrFeMnNiV}$_x$ high entropy alloys},
+  journal = {Mater. Lett.},
+  volume  = {142},
+  pages   = {153--155},
+  year    = {2015},
+  doi     = {10.1016/j.matlet.2014.11.162},
+}
+
+@article{Zhang2015,
+  author  = {B. Zhang and others},
+  title   = {Rapid design of secondary deformation-aging parameters for ultra-low {Co} content {Cu--Ni--Co--Si--X} alloys via Bayesian optimization machine learning},
+  journal = {Calphad},
+  volume  = {51},
+  pages   = {193--200},
+  year    = {2015},
+  doi     = {10.1016/j.calphad.2015.09.007},
+}
+
+@article{Kantelis2025,
+  author  = {K. Kantelis and others},
+  title   = {Lattice distortions in high-entropy alloys},
+  journal = {AIP Adv.},
+  volume  = {15},
+  pages   = {015030},
+  year    = {2025},
+  doi     = {10.1063/5.0245966},
+}
+
+@article{Youssef2015,
+  author  = {K. M. Youssef and others},
+  title   = {A novel low-density, high-hardness, high-entropy alloy with close-packed single-phase nanocrystalline structures},
+  journal = {Mater. Res. Lett.},
+  volume  = {3},
+  pages   = {95--99},
+  year    = {2015},
+  doi     = {10.1080/21663831.2014.985855},
+}
+
+@article{Dirras2016,
+  author  = {G. Dirras and others},
+  title   = {Microstructural investigation of plastically deformed {Ti$_{20}$Zr$_{20}$Hf$_{20}$Nb$_{20}$Ta$_{20}$} high entropy alloy by {X}-ray diffraction and transmission electron microscopy},
+  journal = {Mater. Charact.},
+  volume  = {108},
+  pages   = {1--7},
+  year    = {2015},
+  doi     = {10.1016/j.matchar.2015.08.007},
+}
+
+@article{Gali2013,
+  author  = {A. Gali and E. P. George},
+  title   = {Tensile properties of high- and medium-entropy alloys},
+  journal = {Intermetallics},
+  volume  = {39},
+  pages   = {74--78},
+  year    = {2013},
+  doi     = {10.1016/j.intermet.2013.03.018},
+}
+
+@article{Tasan2014,
+  author  = {C. C. Tasan and others},
+  title   = {Composition Dependence of Phase Stability, Deformation Mechanisms, and Mechanical Properties of the {CoCrFeMnNi} High-Entropy Alloy System},
+  journal = {JOM},
+  volume  = {66},
+  pages   = {1993--2001},
+  year    = {2014},
+  doi     = {10.1007/s11837-014-1133-6},
+}


### PR DESCRIPTION
## Summary
- 手動`\bibitem`をBibTeX (`references.bib`)に移行し、`elsarticle-num`スタイルで文献番号を自動管理
- §4.1「先行研究との比較」のparagraphを時系列順に並べ替え:
  1. Vegard則 (1921)
  2. Coreño-Alonsoモデル (2004)
  3. Zaddach et al. (2013)
  4. 機械学習アプローチ (Zhang et al. 2017)
  5. Alonsoモデル (2022)
- 並べ替え時に発生した重複パラグラフ（旧Zaddach/ML）を削除

## Review & Testing Checklist for Human
- [ ] `lualatex` → `bibtex` → `lualatex` × 2 でコンパイルし、文献番号が正しく出力番号順に振られていることを確認
- [ ] §4.1の各paragraphが時系列順（1921→2004→2013→2017→2022）であることを確認
- [ ] `references.bib`の各エントリが元の`\bibitem`の情報と一致していることをスポットチェック

### Notes
- `elsarticle-num`スタイルは出現順の番号付けを行うため、本文中の`\cite`順序で文献番号が決定されます
- コンパイルには `bibtex` ステップが必須です（`lualatex` → `bibtex` → `lualatex` → `lualatex`）

Link to Devin session: https://app.devin.ai/sessions/2138d5f8fb634a37a9c10087f81b8f63
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->