### PR TITLE
fix: 記号・用語の初出時説明を追加し、記述の明瞭性を向上

### DIFF
--- a/paper/hea_lattice_prediction.tex
+++ b/paper/hea_lattice_prediction.tex
@@ -41,13 +41,16 @@
 DFT計算から構造特異的に導出（B2→BCC、L1$_2$→FCC）し、
 元素対247パラメータ（152 B2 + 95 L1$_2$）を元素別加法分解
 $\Omega_\text{sf}^{(s)}(i\text{-}j) \approx \delta_i^{(s)} + \delta_j^{(s)}$に
-圧縮する（39元素パラメータ）。この分解により、各元素の
+圧縮する（DFTデータが利用可能な39元素のパラメータ$\delta$に集約。
+元素数は周期表の主要金属41元素から$4f$電子系のGd・Ceを除外した結果）。
+この分解により、各元素の
 \emph{組成依存有効原子体積}$V_\text{eff}(i;\, \{c_j\})$を
 定義でき、等モル・非等モルを問わず任意組成のHEA格子定数を
 $a = (n_\text{auc}\sum c_i V_\text{eff})^{1/3}$で予測可能となる。
 64個の訓練HEAに対しRMSE = 0.0197~\AA{}（Vegard比13\%改善）を達成する。
-さらに、B2秩序構造（$\alpha = -1$）に代わり
-Special Quasi-random Structure（SQS, $\alpha \approx 0$）から
+さらに、B2秩序構造（Warren--Cowley短距離秩序パラメータ$\alpha = -1$、
+すなわち最近接が全て異種原子）に代わり
+Special Quasi-random Structure（SQS, $\alpha \approx 0$、ランダム配列）から
 $\Omega_\text{sf}$を導出することで、BCC HEA予測を
 0.0293 → 0.0273~\AA{}（6.9\%改善）に向上させた。
 20個の独立HEAでRMSE = 0.020~\AA{}が確認された。
@@ -135,7 +138,7 @@ Alonsoら~\cite{Alonso2021}は、Kingの体積サイズ因子を
     \Omega_{\text{sf},\, j/i},
   \label{eq:alonso}
 \end{equation}
-ここで$V_\text{uc}$は単位胞体積、$Z$は単位胞中の原子数
+ここで$V_\text{uc}$は単位胞体積、$Z$（$= n_\text{auc}$）は単位胞中の原子数
 （BCC: 2、FCC: 4）、$c_i$は成分$i$の濃度、
 $V_i$は純元素$i$の原子体積、
 $\Omega_{\text{sf},\, j/i}$は元素$j$を元素$i$の母相に
@@ -144,7 +147,8 @@ $\Omega_{\text{sf},\, j/i}$は元素$j$を元素$i$の母相に
 第2項は混合に伴う体積変化を表す補正項である。
 
 Alonsoモデルは$\Omega_{\text{sf},\, j/i}$にKingの実験値を用い、
-スケーリングなし（$q = 1$）で64個のHEAに対しRMSE $\approx 0.023$~\AA{}を
+スケーリング因子なし（校正定数$q = 1$、すなわち$\Omega_\text{sf}$を
+無補正で適用）で64個のHEAに対しRMSE $\approx 0.023$~\AA{}を
 達成した。この精度はVegard則（RMSE $\approx 0.028$~\AA）から
 18\%の改善に相当する。
 
@@ -185,7 +189,8 @@ Core\~{n}o-Alonso \& Core\~{n}o-Alonso~\cite{CorenoAlonso2004}は
 Miedemaの「Macroscopic Atom」モデル~\cite{deBoer1988}から
 $\Omega_\text{sf}$を半経験的に導出し、17個のB2および22個のL1$_2$
 金属間化合物の格子定数を予測した。しかしMiedemaパラメータ
-（$\phi^*$, $n_{\text{ws}}$）から計算された$\Omega_\text{sf}$は
+（化学ポテンシャルに関連する電気陰性度$\phi^*$および
+Wigner--Seitz境界における電子密度$n_{\text{ws}}$）から計算された$\Omega_\text{sf}$は
 Kingの実験値との相関が$r = 0.711$に留まり、格子定数の平均誤差は
 B2で1.73\%、L1$_2$で1.15\%であった。この精度限界は、Miedemaモデルが
 合金形成エンタルピーの符号再現に最適化されたパラメータを流用しており、
@@ -220,7 +225,8 @@ $\delta r$が構造情報を数学的・原理的に含み得ないことを初�
   \item \textbf{DFTデータへの置換}:
     Kingの実験$\Omega_\text{sf}$に替えて、Materials Project・OQMDの
     3,297二元系化合物のDFT計算から構造特異的$\Omega_\text{sf}$を導出
-    （B2→BCC、L1$_2$→FCC、Gd・Ce除外）。
+    （B2→BCC、L1$_2$→FCC。Gd・Ceは$4f$電子の強い局在性により
+    DFT-GGA計算が不安定なため除外、\ref{sec:appendix_gdce}節参照）。
   \item \textbf{元素別加法分解}:
     $\Omega_\text{sf}^{(s)}(i\text{-}j) \approx \delta_i^{(s)} + \delta_j^{(s)}$により、
     247個の元素対パラメータを39元素パラメータに圧縮。
@@ -232,7 +238,7 @@ $\delta r$が構造情報を数学的・原理的に含み得ないことを初�
     任意組成のHEA格子定数を
     $a = (n_\text{auc}\sum c_i V_\text{eff})^{1/3}$で予測可能に。
   \item \textbf{SQS構造による改善}:
-    B2（秩序構造、$\alpha = -1$）由来の$\Omega_\text{sf}$は
+    B2（秩序構造、Warren--Cowley短距離秩序パラメータ$\alpha = -1$）由来の$\Omega_\text{sf}$は
     Ni-Zr等の二元系では再現性があるが、多成分ランダム固溶体である
     HEAの体積偏差を系統的に過大評価する。
     SQS（$\alpha \approx 0$）からの$\Omega_\text{sf}$導出により
@@ -794,8 +800,12 @@ DFT-SSモデルはVegardに対してRMSE 12\%の改善を達成する。
 BCC独立テスト8合金中7合金でVegard則への縮退（改善率0\%）が
 観察される。これはMP/OQMDデータベースにこれらの高融点元素ペアの
 B2構造データが存在しないためであり、$\Omega_\text{sf} = 0$に退行する。
+なお、VASP B2計算による直接補完も試みたが、B2秩序構造（$\alpha = -1$）の
+$\Omega_\text{sf}$がランダム固溶体の体積偏差を系統的に過大評価し、
+$q_\text{BCC}$が0.50に崩壊する問題が生じた
+（\ref{sec:appendix_vasp}節参照）。
 この問題はSQS（$\alpha \approx 0$）構造を用いた
-$\Omega_\text{sf}$の補完により解消される
+$\Omega_\text{sf}$の導出により解消される
 （\ref{sec:sqs_improvement}節参照）。
 
 特に注目すべきは、Alonsoモデルが独立テストでRMSE = 0.0261~\AA{}と
@@ -2399,6 +2409,7 @@ $r \approx 0.28$と低く、B2の$r > 0.9$に比べて一貫性が劣る。
 将来的には統一計算条件での再計算が望ましい。
 
 \subsection{Gd・Ce除外の理由}
+\label{sec:appendix_gdce}
 
 GdおよびCeは$4f$電子の強い局在性のため
 DFT-GGA計算での構造最適化が不安定であり、


### PR DESCRIPTION
## Summary

論文中で説明なく登場していた記号・用語に初出時の定義を追加し、読者の理解を助ける修正。

### 修正内容（7点）

| # | 問題 | 修正 |
|---|------|------|
| 1 | `q = 1` がいきなり出てくる | 「校正定数$q$、すなわち$\Omega_\text{sf}$を無補正で適用」と定義 |
| 2 | `φ*`, `n_ws` が何の記号か不明 | 「電気陰性度$\phi^*$」「Wigner--Seitz境界における電子密度$n_\text{ws}$」と説明 |
| 3 | Gd・Ce除外の理由が不明 | 初出箇所で「$4f$電子の強い局在性によりDFT-GGA計算が不安定」と明記、付録節参照を追加 |
| 4 | `α = -1` が何かわからない | 「Warren--Cowley短距離秩序パラメータ$\alpha$」と定義、$\alpha = -1$は全異種近接、$\alpha \approx 0$はランダム配列と説明 |
| 5 | `Z` と `n_auc` が同じ量か不明 | `$Z$（$= n_\text{auc}$）` と明記 |
| 6 | 「39元素」が唐突 | 「主要金属41元素から$4f$電子系のGd・Ceを除外した結果」と経緯を追加 |
| 7 | B2 DFTデータがないのにVASPで補完したのでは？ | VASP B2直接補完を試みたが$q$崩壊が生じたこと、SQSにより解消されることを追記（付録節参照も追加） |

## Review & Testing Checklist for Human
- [ ] アブストラクトの「41元素から39元素」の説明が正確か確認（実際の元素リストと照合）
- [ ] φ*, n_ws の日本語説明が物理的に正しいか確認（de Boer 1988原典と照合推奨）
- [ ] VASP B2補完→q崩壊の説明が§5.2/付録の記述と整合しているか確認

### Notes
- `lualatex` → `bibtex` → `lualatex` × 2 でコンパイル確認済み（citation warning/undefined reference なし）
- 23ページ、既存の構成に変更なし（追記のみ）

Link to Devin session: https://app.devin.ai/sessions/2138d5f8fb634a37a9c10087f81b8f63
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->