### PR TITLE
fix: gpt-5-codex指摘の全バグ修正（4ファイル、Critical×4 + High/Medium）

### DIFF
--- a/hea_lattice_xgboost.py
+++ b/hea_lattice_xgboost.py
@@ -45,7 +45,9 @@ from scipy.optimize import minimize
 from xgboost import XGBRegressor
 from cubist import Cubist
 
-warnings.filterwarnings("ignore")
+warnings.filterwarnings("ignore", category=FutureWarning)
+warnings.filterwarnings("ignore", category=UserWarning, module="xgboost")
+_WARNED_UNKNOWN_ELEMENTS = set()
 
 # Japanese font setup
 for fp in fm.findSystemFonts():
@@ -709,6 +711,10 @@ def build_omega_sf_ml_model(omega_sf_dict, structure_label=""):
 
     print(f"      Ω_sf ML ({structure_label}): {N} known pairs, 14 features")
 
+    if N < 2:
+        print(f"        Skipping ML model: insufficient data (N={N}, need ≥2 for LOO-CV)")
+        return None, None, float('inf'), 0.0, {}
+
     # LOO-CV for Ridge (baseline)
     best_ridge_rmse = 999
     best_alpha = 1.0
@@ -803,6 +809,17 @@ def fill_missing_omega_sf(omega_dft, omega_ml_predictions):
     return omega_filled, filled_pairs, fill_stats
 
 
+def _warn_unknown_element(elem, context=""):
+    """Emit a one-time warning for elements not in KING_ATOMIC_VOLUMES."""
+    key = (elem, context)
+    if key not in _WARNED_UNKNOWN_ELEMENTS:
+        _WARNED_UNKNOWN_ELEMENTS.add(key)
+        warnings.warn(
+            f"Unknown element '{elem}' not in KING_ATOMIC_VOLUMES"
+            f"{' (' + context + ')' if context else ''}, using default value",
+            stacklevel=3)
+
+
 def compute_delta_r(comp):
     """
     Traditional atomic size mismatch δr (%) using King atomic volumes.
@@ -811,6 +828,9 @@ def compute_delta_r(comp):
     elements = list(comp.keys())
     fracs = np.array([comp[e] for e in elements])
     fracs = fracs / fracs.sum()
+    for e in elements:
+        if e not in KING_ATOMIC_VOLUMES:
+            _warn_unknown_element(e, "compute_delta_r")
     vols = np.array([KING_ATOMIC_VOLUMES.get(e, 15.0) for e in elements])
     r_vals = vols ** (1/3)
     r_avg = np.sum(fracs * r_vals)
@@ -1195,6 +1215,10 @@ def build_hea_features(omega_sf):
 
 def loo_cv_xgboost(X, y, **xgb_params):
     """Leave-One-Out cross-validation for XGBoost."""
+    if len(y) < 2:
+        print(f"    loo_cv_xgboost: insufficient data (N={len(y)}), skipping")
+        return np.full(len(y), np.nan)
+
     loo = LeaveOneOut()
     y_pred = np.zeros(len(y))
 
@@ -1233,6 +1257,11 @@ def two_stage_model(X_binary, y_binary, X_hea, y_hea, omega_sf, xgb_params):
     Stage 1: Pre-train on DFT binary data
     Stage 2: Fine-tune residual on HEA data with LOO-CV
     """
+    if len(y_binary) == 0 or len(y_hea) < 2:
+        print("    two_stage_model: insufficient data "
+              f"(binary={len(y_binary)}, HEA={len(y_hea)}), skipping")
+        return np.full(len(y_hea), np.nan), np.full(len(y_hea), np.nan)
+
     # Stage 1: Train base model on binary data
     base_model = XGBRegressor(**xgb_params)
     base_model.fit(X_binary, y_binary, verbose=False)

--- a/paper/generate_all_figures.py
+++ b/paper/generate_all_figures.py
@@ -92,6 +92,9 @@ def load_compounds():
                 df["stype"] = struct
                 dfs.append(df)
                 break
+    if not dfs:
+        raise FileNotFoundError(
+            "No compound CSV files found. Check four_case_output/figures/ and data/ directories.")
     all_df = pd.concat(dfs, ignore_index=True)
     # Exclude Gd/Ce
     mask = ~(all_df["element_A"].isin(EXCLUDE_ELEMENTS) |
@@ -148,15 +151,19 @@ def optimize_gamma(heas, ob2, ol12):
         ])
 
     def rmse_bcc(gb):
+        if not bcc_i:
+            return 0.0
         p = pred_all(gb, 1.0)
         return np.sqrt(np.mean((p[bcc_i] - y[bcc_i]) ** 2))
 
     def rmse_fcc(gf):
+        if not fcc_i:
+            return 0.0
         p = pred_all(1.0, gf)
         return np.sqrt(np.mean((p[fcc_i] - y[fcc_i]) ** 2))
 
-    gb = minimize_scalar(rmse_bcc, bounds=(-5, 5), method="bounded").x
-    gf = minimize_scalar(rmse_fcc, bounds=(-5, 5), method="bounded").x
+    gb = minimize_scalar(rmse_bcc, bounds=(-5, 5), method="bounded").x if bcc_i else 1.0
+    gf = minimize_scalar(rmse_fcc, bounds=(-5, 5), method="bounded").x if fcc_i else 1.0
     return gb, gf
 
 
@@ -491,6 +498,15 @@ def fig07_composition_examples(all_df):
     print("  fig_composition_examples.png")
 
 
+def _l12_bucket(elA, elB, cA, cB):
+    """Determine L1₂ bucket for sorted pair key.
+    'A3B' = sorted_pair[0] is majority; 'AB3' = sorted_pair[1] is majority.
+    """
+    pair = tuple(sorted([elA, elB]))
+    maj_elem = elA if cA >= cB else elB
+    return "A3B" if maj_elem == pair[0] else "AB3"
+
+
 def fig08_delta_r_proof(all_df):
     """Fig 8: 6-panel proof that delta_r cannot absorb structure info."""
     # Compute delta_r and Omega_sf for each pair×structure
@@ -514,10 +530,8 @@ def fig08_delta_r_proof(all_df):
             total = cA + cB
             v_veg = (cA * vA + cB * vB) / total
             osf = (a**3 / 4 - v_veg) / v_veg
-            if cA == 3:
-                pair_data[pair]["L12_A3B"].append(osf)
-            else:
-                pair_data[pair]["L12_AB3"].append(osf)
+            bucket = "L12_" + _l12_bucket(elA, elB, cA, cB)
+            pair_data[pair][bucket].append(osf)
 
     # Pairs with all 3 structures
     complete = {}
@@ -528,6 +542,10 @@ def fig08_delta_r_proof(all_df):
                 "L12_A3B": np.median(data["L12_A3B"]),
                 "L12_AB3": np.median(data["L12_AB3"]),
             }
+
+    if not complete:
+        print("  fig_delta_r_proof.png — skipped (no pairs with all 3 structures)")
+        return
 
     fig, axes = plt.subplots(2, 3, figsize=(18, 11))
 
@@ -598,15 +616,16 @@ def fig08_delta_r_proof(all_df):
             continue
         pair = tuple(sorted([elA, elB]))
         cA = row.get("count_A", 3)
-        if cA == 3:
-            pair_a[pair]["A3B"].append(a)
-        else:
-            pair_a[pair]["AB3"].append(a)
+        cB = row.get("count_B", 1)
+        bucket = _l12_bucket(elA, elB, cA, cB)
+        pair_a[pair][bucket].append(a)
     diffs = []
     for pair in pair_a:
         if pair_a[pair]["A3B"] and pair_a[pair]["AB3"]:
             diffs.append(abs(np.median(pair_a[pair]["A3B"]) -
                             np.median(pair_a[pair]["AB3"])))
+    if not diffs:
+        diffs = [0.0]
     ax.hist(diffs, bins=40, color="C0", edgecolor="black", linewidth=0.3)
     ax.axvline(np.mean(diffs), color="C3", linestyle="--", lw=2,
                label=f"mean = {np.mean(diffs):.3f} \u00c5")
@@ -662,10 +681,9 @@ def fig09_packing(all_df):
             pair_a[pair]["B2"].append(a)
         elif stype == "L12":
             cA = row.get("count_A", 3)
-            if cA == 3:
-                pair_a[pair]["A3B"].append(a)
-            else:
-                pair_a[pair]["AB3"].append(a)
+            cB = row.get("count_B", 1)
+            bucket = _l12_bucket(elA, elB, cA, cB)
+            pair_a[pair][bucket].append(a)
 
     # For pairs with both A3B and AB3, compute packing nearest-neighbor distance
     dnn_a3b, dnn_ab3 = [], []
@@ -675,6 +693,10 @@ def fig09_packing(all_df):
             a2 = np.median(pair_a[pair]["AB3"])
             dnn_a3b.append(a1 / np.sqrt(2))  # FCC nearest neighbor
             dnn_ab3.append(a2 / np.sqrt(2))
+
+    if not dnn_a3b:
+        print("  fig_packing.png — skipped (no pairs with both A3B and AB3)")
+        return
 
     fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 6))
 
@@ -713,16 +735,19 @@ def fig10_l12_asymmetry(all_df):
             continue
         pair = tuple(sorted([elA, elB]))
         cA = row.get("count_A", 3)
-        if cA == 3:
-            pair_a[pair]["A3B"].append(a)
-        else:
-            pair_a[pair]["AB3"].append(a)
+        cB = row.get("count_B", 1)
+        bucket = _l12_bucket(elA, elB, cA, cB)
+        pair_a[pair][bucket].append(a)
 
     a3b_vals, ab3_vals = [], []
     for pair in pair_a:
         if pair_a[pair]["A3B"] and pair_a[pair]["AB3"]:
             a3b_vals.append(np.median(pair_a[pair]["A3B"]))
             ab3_vals.append(np.median(pair_a[pair]["AB3"]))
+
+    if not a3b_vals:
+        print("  fig_l12_asymmetry.png — skipped (no pairs with both A3B and AB3)")
+        return
 
     fig, ax = plt.subplots(figsize=(7, 7))
     ax.scatter(a3b_vals, ab3_vals, c="C3", alpha=0.4, s=20)
@@ -745,6 +770,9 @@ def fig10_l12_asymmetry(all_df):
 def fig11_volume_radius(radii):
     """Fig 11: Structure-dependent effective radii from volume."""
     elements = sorted([e for e in radii if "r_b2" in radii[e] and "r_l12_maj" in radii[e]])
+    if not elements:
+        print("  fig_volume_radius.png — skipped (no elements with both B2 and L12 radii)")
+        return
     r_pure = [radii[e]["r_pure"] for e in elements]
     r_b2 = [radii[e]["r_b2"] for e in elements]
     r_l12 = [radii[e]["r_l12_maj"] for e in elements]
@@ -860,10 +888,9 @@ def fig14_vegard_absorbed(all_df, radii):
             pair_a[pair]["B2"].append(a)
         elif stype == "L12":
             cA = row.get("count_A", 3)
-            if cA == 3:
-                pair_a[pair]["A3B"].append(a)
-            else:
-                pair_a[pair]["AB3"].append(a)
+            cB = row.get("count_B", 1)
+            bucket = _l12_bucket(elA, elB, cA, cB)
+            pair_a[pair][bucket].append(a)
 
     a_dft = []
     a_veg_pure = []
@@ -942,6 +969,8 @@ def fig15_roc(heas_mp, ob2, ol12):
         phase = h.get("phase", "SS")
         dr = compute_delta_r(comp)
         dsf = compute_delta_sf(comp, ob2)
+        if np.isnan(dr) or np.isnan(dsf):
+            continue
         dr_vals.append(dr)
         dsf_vals.append(dsf)
         labels.append(1 if phase == "IM" else 0)  # IM=1, SS=0
@@ -950,8 +979,8 @@ def fig15_roc(heas_mp, ob2, ol12):
     dsf_vals = np.array(dsf_vals)
     labels = np.array(labels)
 
-    if len(np.unique(labels)) < 2:
-        print("  fig_roc.png — skipped (single class)")
+    if len(labels) == 0 or len(np.unique(labels)) < 2:
+        print("  fig_roc.png — skipped (insufficient data or single class)")
         return
 
     fig, ax = plt.subplots(figsize=(7, 7))

--- a/vasp_inputs/detect_rerun_needed.py
+++ b/vasp_inputs/detect_rerun_needed.py
@@ -1,0 +1,725 @@
+#!/usr/bin/env python3
+"""
+ISIF=7 SQS計算の未収束ケースを検出し、自動再計算するスクリプト。
+
+Phase 1 (--detect): vasp.log / OUTCARをスキャンして再計算が必要なケースを検出
+Phase 2 (--rerun):  CONTCAR→POSCAR、INCAR修正、mpirun で再計算実行
+
+検出する問題:
+  1. ZBRENT エラー (can not reach accuracy / fatal error in bracketing)
+  2. NSW上限到達（イオンステップ = NSW、まだ収束していない）
+  3. OUTCARに "reached required accuracy" がない（未収束）
+  4. CONTCAR が空 or 存在しない（計算未完了）
+  5. Ω_sfアウトライア（|Ω_sf| > threshold）
+
+使い方:
+    # 検出のみ（ドライラン）
+    python detect_rerun_needed.py /path/to/BCC_SQS_ISIF7
+
+    # 検出 + 再計算実行（8コア×4ジョブ並列）
+    python detect_rerun_needed.py /path/to/BCC_SQS_ISIF7 --rerun
+
+    # オプション
+    --ncore 8           MPI並列コア数 (default: 8)
+    --max-jobs 4        同時実行ジョブ数 (default: 4)
+    --nsw 300           再計算のNSW (default: 300)
+    --potim VALUE       再計算のPOTIM (default: auto — ZBRENTエラー時に調整)
+    --ibrion {1,2}      再計算のIBRION (default: auto — ZBRENT時に1へ切替)
+    --omega-threshold 0.5  |Ω_sf|アウトライア閾値 (default: 0.5)
+
+環境変数:
+    VASPBIN  VASPバイナリのパス (必須、--rerun時)
+"""
+
+import os
+import re
+import sys
+import glob
+import time
+import shutil
+import signal
+import argparse
+import subprocess
+from collections import defaultdict
+from concurrent.futures import ProcessPoolExecutor, as_completed
+
+
+# =====================================================================
+# Directory parsing
+# =====================================================================
+def parse_dirname(dirname):
+    """Parse directory name like 'Ag8Al8' or 'Fe4Co4Ni4Cr4' into element list.
+
+    Returns list of (element, count) tuples, or None if unparseable.
+    For 2-element dirs: [(elA, cA), (elB, cB)]
+    For N-element dirs: [(el1, c1), (el2, c2), ...]
+    """
+    pairs = re.findall(r'([A-Z][a-z]?)(\d+)', dirname)
+    if not pairs:
+        return None
+    # Verify the pattern accounts for the entire dirname
+    reconstructed = ''.join(el + cnt for el, cnt in pairs)
+    if reconstructed != dirname:
+        return None
+    return [(el, int(cnt)) for el, cnt in pairs]
+
+
+# =====================================================================
+# Convergence checks
+# =====================================================================
+def check_vasp_log(calc_dir):
+    """Check vasp.log for convergence issues. Returns list of issue strings."""
+    issues = []
+
+    # Find log file
+    vasp_log = None
+    for name in ['vasp.log', 'stdout']:
+        p = os.path.join(calc_dir, name)
+        if os.path.isfile(p):
+            vasp_log = p
+            break
+    if vasp_log is None:
+        for p in glob.glob(os.path.join(calc_dir, 'slurm-*.out')):
+            vasp_log = p
+            break
+    if vasp_log is None:
+        issues.append("NO_VASP_LOG")
+        return issues
+
+    try:
+        with open(vasp_log, 'r', errors='replace') as f:
+            content = f.read()
+    except Exception as e:
+        issues.append(f"READ_ERROR: {e}")
+        return issues
+
+    if 'ZBRENT: can not reach accuracy' in content:
+        issues.append("ZBRENT_ACCURACY")
+    if 'ZBRENT: fatal error in bracketing' in content:
+        issues.append("ZBRENT_FATAL")
+    if 'please rerun with smaller EDIFF' in content:
+        issues.append("EDIFF_RERUN")
+    if 'VERY BAD NEWS!' in content:
+        issues.append("VERY_BAD_NEWS")
+    if 'SGRCON: ERROR' in content:
+        issues.append("SGRCON_ERROR")
+    if 'internal error in subroutine PRICEL' in content:
+        issues.append("PRICEL_ERROR")
+
+    # Count ionic steps
+    ionic_steps = re.findall(r'^\s+(\d+)\s+F=', content, re.MULTILINE)
+    if ionic_steps:
+        max_step = max(int(s) for s in ionic_steps)
+        nsw = read_nsw(calc_dir)
+        if nsw and max_step >= nsw:
+            issues.append(f"NSW_REACHED({max_step}/{nsw})")
+
+    return issues
+
+
+def check_outcar(calc_dir):
+    """Check OUTCAR for convergence. Returns (converged, issues)."""
+    issues = []
+    outcar = os.path.join(calc_dir, 'OUTCAR')
+    if not os.path.isfile(outcar):
+        return False, ["NO_OUTCAR"]
+    try:
+        with open(outcar, 'r', errors='replace') as f:
+            content = f.read()
+    except Exception:
+        return False, ["OUTCAR_READ_ERROR"]
+    converged = 'reached required accuracy' in content
+    if not converged:
+        issues.append("NOT_CONVERGED")
+    return converged, issues
+
+
+def check_contcar(calc_dir):
+    """Check if CONTCAR exists and is valid."""
+    contcar = os.path.join(calc_dir, 'CONTCAR')
+    if not os.path.isfile(contcar):
+        return ["NO_CONTCAR"]
+    if os.path.getsize(contcar) == 0:
+        return ["EMPTY_CONTCAR"]
+    try:
+        with open(contcar) as f:
+            lines = f.readlines()
+        if len(lines) < 6:
+            return ["INCOMPLETE_CONTCAR"]
+    except Exception:
+        return ["CONTCAR_READ_ERROR"]
+    return []
+
+
+def read_nsw(calc_dir):
+    """Read NSW from INCAR."""
+    incar = os.path.join(calc_dir, 'INCAR')
+    if not os.path.isfile(incar):
+        return None
+    try:
+        with open(incar) as f:
+            for line in f:
+                m = re.match(r'\s*NSW\s*=\s*(\d+)', line)
+                if m:
+                    return int(m.group(1))
+    except Exception:
+        pass
+    return None
+
+
+def read_incar_param(calc_dir, param):
+    """Read a numeric parameter from INCAR (e.g. POTIM, IBRION)."""
+    incar = os.path.join(calc_dir, 'INCAR')
+    if not os.path.isfile(incar):
+        return None
+    try:
+        with open(incar) as f:
+            for line in f:
+                m = re.match(rf'\s*{param}\s*=\s*([\d.Ee+-]+)', line)
+                if m:
+                    return float(m.group(1))
+    except Exception:
+        pass
+    return None
+
+
+def read_lattice_constant(calc_dir):
+    """Read equivalent cubic lattice constant from CONTCAR via cell volume.
+
+    Uses vol**(1/3) instead of first-vector magnitude, which correctly
+    handles non-orthogonal cells (FCC primitive, rotated, etc.).
+    """
+    contcar = os.path.join(calc_dir, 'CONTCAR')
+    if not os.path.isfile(contcar) or os.path.getsize(contcar) == 0:
+        return None
+    try:
+        with open(contcar) as f:
+            lines = f.readlines()
+        if len(lines) < 5:
+            return None
+        scale = float(lines[1].strip())
+        a_vec = [float(x) for x in lines[2].split()]
+        b_vec = [float(x) for x in lines[3].split()]
+        c_vec = [float(x) for x in lines[4].split()]
+        vol = abs(
+            a_vec[0] * (b_vec[1]*c_vec[2] - b_vec[2]*c_vec[1]) -
+            a_vec[1] * (b_vec[0]*c_vec[2] - b_vec[2]*c_vec[0]) +
+            a_vec[2] * (b_vec[0]*c_vec[1] - b_vec[1]*c_vec[0])
+        ) * abs(scale)**3
+        return vol ** (1.0 / 3.0)
+    except Exception:
+        return None
+
+
+# =====================================================================
+# Ω_sf computation
+# =====================================================================
+VASP_ATOMIC_VOLUMES = {
+    "Ag": 17.840, "Al": 16.602, "Au": 17.798, "Be": 8.105,
+    "Ca": 42.025, "Co": 10.994, "Cr": 11.415, "Cu": 12.024,
+    "Dy": 31.744, "Er": 31.063, "Fe": 11.312, "Ge": 19.243,
+    "Hf": 22.068, "Ir": 14.334, "La": 37.591, "Mg": 22.909,
+    "Mn": 10.855, "Mo": 15.629, "Nb": 18.370, "Ni": 10.941,
+    "Os": 13.776, "Pb": 30.596, "Pd": 15.466, "Pt": 15.219,
+    "Re": 14.875, "Rh": 13.761, "Ru": 14.136, "Sc": 24.869,
+    "Si": 14.822, "Sn": 27.611, "Ta": 18.159, "Tb": 32.503,
+    "Ti": 17.022, "V":  13.275, "W":  15.960, "Y":  33.017,
+    "Zn": 15.741, "Zr": 22.721,
+}
+
+
+def compute_omega_sf(elA, countA, elB, countB, lattice_const):
+    """Compute Ω_sf for a given pair."""
+    if elA not in VASP_ATOMIC_VOLUMES or elB not in VASP_ATOMIC_VOLUMES:
+        return None
+    if elA == elB:
+        return None
+    vA = VASP_ATOMIC_VOLUMES[elA]
+    vB = VASP_ATOMIC_VOLUMES[elB]
+    total = countA + countB
+    v_actual = lattice_const**3 / total
+    v_vegard = (countA * vA + countB * vB) / total
+    if v_vegard == 0:
+        return None
+    return (v_actual - v_vegard) / v_vegard
+
+
+# =====================================================================
+# Phase 1: Scan & detect
+# =====================================================================
+def scan_directory(sqs_dir, omega_threshold=0.5):
+    """Scan all SQS directories and detect rerun cases."""
+    results = []
+
+    if not os.path.isdir(sqs_dir):
+        print(f"ERROR: {sqs_dir} is not a directory", file=sys.stderr)
+        sys.exit(1)
+
+    dirs = sorted(os.listdir(sqs_dir))
+    total = 0
+    converged = 0
+    rerun_needed = 0
+
+    for dirname in dirs:
+        calc_dir = os.path.join(sqs_dir, dirname)
+        if not os.path.isdir(calc_dir):
+            continue
+        parsed = parse_dirname(dirname)
+        if parsed is None:
+            continue
+
+        elements = parsed  # list of (element, count)
+        total += 1
+        all_issues = []
+
+        log_issues = check_vasp_log(calc_dir)
+        all_issues.extend(log_issues)
+
+        conv, outcar_issues = check_outcar(calc_dir)
+        all_issues.extend(outcar_issues)
+        if conv:
+            converged += 1
+
+        contcar_issues = check_contcar(calc_dir)
+        all_issues.extend(contcar_issues)
+
+        omega_sf = None
+        # Ω_sf check only for binary compounds
+        if len(elements) == 2:
+            elA, countA = elements[0]
+            elB, countB = elements[1]
+            if elA != elB:
+                a = read_lattice_constant(calc_dir)
+                if a is not None:
+                    omega_sf = compute_omega_sf(elA, countA, elB, countB, a)
+                    if omega_sf is not None and abs(omega_sf) > omega_threshold:
+                        all_issues.append(f"OMEGA_OUTLIER({omega_sf:+.3f})")
+
+        # Read current POTIM and IBRION for diagnostics
+        cur_potim = read_incar_param(calc_dir, 'POTIM')
+        cur_ibrion = read_incar_param(calc_dir, 'IBRION')
+
+        needs_rerun = len(all_issues) > 0
+        if needs_rerun:
+            rerun_needed += 1
+
+        results.append({
+            'dirname': dirname,
+            'calc_dir': calc_dir,
+            'elA': elA, 'countA': countA,
+            'elB': elB, 'countB': countB,
+            'converged': conv,
+            'omega_sf': omega_sf,
+            'issues': all_issues,
+            'needs_rerun': needs_rerun,
+            'potim': cur_potim,
+            'ibrion': cur_ibrion,
+        })
+
+    return results, total, converged, rerun_needed
+
+
+# =====================================================================
+# Phase 2: Prepare & run
+# =====================================================================
+def backup_and_prepare(calc_dir, new_nsw=300, new_potim=None, new_ibrion=None):
+    """
+    Prepare directory for rerun:
+    1. Backup old outputs to .bak/
+    2. Copy CONTCAR → POSCAR (restart from last geometry)
+    3. Update INCAR: NSW, ISIF=7, POTIM, IBRION
+    Returns True if preparation succeeded.
+    """
+    # Create backup
+    bak_dir = os.path.join(calc_dir, '.bak')
+    os.makedirs(bak_dir, exist_ok=True)
+    for fname in ['POSCAR', 'OUTCAR', 'OSZICAR', 'vasp.log',
+                  'WAVECAR', 'CHGCAR', 'CHG', 'vasprun.xml']:
+        src = os.path.join(calc_dir, fname)
+        if os.path.isfile(src):
+            dst = os.path.join(bak_dir, fname)
+            shutil.copy2(src, dst)
+
+    # CONTCAR → POSCAR (restart from last geometry)
+    contcar = os.path.join(calc_dir, 'CONTCAR')
+    poscar = os.path.join(calc_dir, 'POSCAR')
+    if os.path.isfile(contcar) and os.path.getsize(contcar) > 100:
+        shutil.copy2(contcar, poscar)
+    else:
+        # No valid CONTCAR — keep original POSCAR
+        if not os.path.isfile(poscar):
+            return False
+
+    # Update INCAR
+    incar_path = os.path.join(calc_dir, 'INCAR')
+    if not os.path.isfile(incar_path):
+        return False
+
+    with open(incar_path, 'r') as f:
+        lines = f.readlines()
+
+    new_lines = []
+    nsw_set = False
+    isif_set = False
+    ibrion_set = False
+    potim_set = False
+    for line in lines:
+        # Update NSW
+        if re.match(r'\s*NSW\s*=', line):
+            new_lines.append(f' NSW = {new_nsw}\n')
+            nsw_set = True
+        # Ensure ISIF=7
+        elif re.match(r'\s*ISIF\s*=', line):
+            new_lines.append(' ISIF = 7\n')
+            isif_set = True
+        # IBRION
+        elif re.match(r'\s*IBRION\s*=', line):
+            if new_ibrion is not None:
+                new_lines.append(f' IBRION = {new_ibrion}\n')
+            else:
+                new_lines.append(line)
+            ibrion_set = True
+        # POTIM
+        elif re.match(r'\s*POTIM\s*=', line):
+            if new_potim is not None:
+                new_lines.append(f' POTIM = {new_potim:.6f}\n')
+            else:
+                new_lines.append(line)
+            potim_set = True
+        else:
+            new_lines.append(line)
+
+    if not nsw_set:
+        new_lines.append(f' NSW = {new_nsw}\n')
+    if not isif_set:
+        new_lines.append(' ISIF = 7\n')
+    if new_potim is not None and not potim_set:
+        new_lines.append(f' POTIM = {new_potim:.6f}\n')
+    if new_ibrion is not None and not ibrion_set:
+        new_lines.append(f' IBRION = {new_ibrion}\n')
+
+    with open(incar_path, 'w') as f:
+        f.writelines(new_lines)
+
+    # Remove WAVECAR/CHGCAR to start clean (avoid incompatible restart)
+    for fname in ['WAVECAR', 'CHGCAR', 'CHG']:
+        fpath = os.path.join(calc_dir, fname)
+        if os.path.isfile(fpath):
+            os.remove(fpath)
+
+    return True
+
+
+def run_vasp_job(calc_dir, vaspbin, ncore):
+    """
+    Run a single VASP job. Returns (dirname, success, elapsed_sec, message).
+
+    Uses process groups to ensure MPI child processes are cleaned up on
+    timeout, preventing zombie processes.
+    """
+    dirname = os.path.basename(calc_dir)
+    log_path = os.path.join(calc_dir, 'vasp.log')
+
+    cmd = f"mpirun -np {ncore} {vaspbin}"
+
+    t0 = time.time()
+    proc = None
+    try:
+        log_f = open(log_path, 'w')
+        proc = subprocess.Popen(
+            cmd, shell=True, cwd=calc_dir,
+            stdout=log_f, stderr=subprocess.STDOUT,
+            preexec_fn=os.setsid,  # new process group for clean kill
+        )
+        proc.wait(timeout=7200)  # 2 hour timeout per job
+        log_f.close()
+
+        elapsed = time.time() - t0
+        # Quick convergence check
+        outcar = os.path.join(calc_dir, 'OUTCAR')
+        converged = False
+        if os.path.isfile(outcar):
+            with open(outcar, 'r', errors='replace') as f:
+                converged = 'reached required accuracy' in f.read()
+        status = "CONVERGED" if converged else "NOT_CONVERGED"
+        return dirname, converged, elapsed, status
+    except subprocess.TimeoutExpired:
+        elapsed = time.time() - t0
+        # Kill the entire process group (mpirun + all MPI children)
+        if proc is not None:
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+                proc.wait(timeout=10)
+            except (ProcessLookupError, subprocess.TimeoutExpired):
+                try:
+                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+        return dirname, False, elapsed, "TIMEOUT"
+    except Exception as e:
+        elapsed = time.time() - t0
+        if proc is not None:
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+            except (ProcessLookupError, OSError):
+                pass
+        return dirname, False, elapsed, f"ERROR: {e}"
+
+
+def run_all_jobs(rerun_dirs, vaspbin, ncore, max_jobs):
+    """Run all rerun jobs with max_jobs parallel workers."""
+    total = len(rerun_dirs)
+    print(f"\n{'='*70}")
+    print(f"RUNNING {total} VASP JOBS  ({max_jobs} parallel × {ncore} cores each)")
+    print(f"VASPBIN: {vaspbin}")
+    print(f"{'='*70}\n")
+
+    completed = 0
+    succeeded = 0
+    failed_dirs = []
+
+    with ProcessPoolExecutor(max_workers=max_jobs) as executor:
+        futures = {}
+        for calc_dir in rerun_dirs:
+            future = executor.submit(run_vasp_job, calc_dir, vaspbin, ncore)
+            futures[future] = calc_dir
+
+        for future in as_completed(futures):
+            dirname, converged, elapsed, status = future.result()
+            completed += 1
+            if converged:
+                succeeded += 1
+                mark = "OK"
+            else:
+                failed_dirs.append(dirname)
+                mark = "NG"
+            print(f"  [{completed}/{total}] {mark}  {dirname:20s}  "
+                  f"{elapsed:7.1f}s  {status}")
+
+    print(f"\n{'='*70}")
+    print(f"RESULTS: {succeeded}/{total} converged, "
+          f"{total - succeeded} still unconverged")
+    if failed_dirs:
+        print(f"\nStill unconverged:")
+        for d in failed_dirs:
+            print(f"  {d}")
+    print(f"{'='*70}")
+
+    return succeeded, failed_dirs
+
+
+# =====================================================================
+# Main
+# =====================================================================
+def main():
+    parser = argparse.ArgumentParser(
+        description='Detect & rerun unconverged SQS ISIF=7 calculations',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Detect only (dry run)
+  python detect_rerun_needed.py /path/to/BCC_SQS_ISIF7
+
+  # Detect + rerun (8 cores × 4 jobs)
+  python detect_rerun_needed.py /path/to/BCC_SQS_ISIF7 --rerun
+
+  # Custom settings
+  python detect_rerun_needed.py /path/to/BCC_SQS_ISIF7 --rerun \\
+      --ncore 8 --max-jobs 4 --nsw 300 --potim 0.2
+
+  # ZBRENT対策: POTIM調整 + IBRION=1 (quasi-Newton)
+  python detect_rerun_needed.py /path/to/BCC_SQS_ISIF7 --rerun \\
+      --potim 0.2 --ibrion 1
+""")
+    parser.add_argument('sqs_dir',
+                        help='Path to BCC_SQS_ISIF7 directory')
+    parser.add_argument('--rerun', action='store_true',
+                        help='Actually run VASP recalculations (default: detect only)')
+    parser.add_argument('--ncore', type=int, default=8,
+                        help='MPI cores per VASP job (default: 8)')
+    parser.add_argument('--max-jobs', type=int, default=4,
+                        help='Max parallel VASP jobs (default: 4)')
+    parser.add_argument('--nsw', type=int, default=300,
+                        help='NSW for rerun INCAR (default: 300)')
+    parser.add_argument('--potim', type=float, default=None,
+                        help='POTIM for rerun INCAR (default: auto-adjust '
+                             'for ZBRENT cases). '
+                             'Typical: 0.1-0.3 for ISIF=7')
+    parser.add_argument('--ibrion', type=int, default=None, choices=[1, 2],
+                        help='IBRION for rerun (1=RMM-DIIS quasi-Newton, '
+                             '2=CG). Default: auto (ZBRENT→1, others→keep)')
+    parser.add_argument('--omega-threshold', type=float, default=0.5,
+                        help='|Ω_sf| outlier threshold (default: 0.5)')
+    parser.add_argument('-o', '--output', default='rerun_list.txt',
+                        help='Output file for rerun list (default: rerun_list.txt)')
+    parser.add_argument('--all', action='store_true',
+                        help='Show all directories including converged')
+    args = parser.parse_args()
+
+    # ---- Phase 1: Detect ----
+    print(f"Scanning: {args.sqs_dir}")
+    print(f"Ω_sf outlier threshold: |Ω_sf| > {args.omega_threshold}")
+    print()
+
+    results, total, converged, rerun_needed = scan_directory(
+        args.sqs_dir, args.omega_threshold)
+
+    # Summary
+    print("=" * 70)
+    print(f"SUMMARY")
+    print(f"  Total directories:  {total}")
+    print(f"  Converged (OUTCAR): {converged} ({100*converged/max(total,1):.1f}%)")
+    print(f"  Rerun needed:       {rerun_needed} ({100*rerun_needed/max(total,1):.1f}%)")
+    print("=" * 70)
+    print()
+
+    # Issue breakdown
+    issue_counts = defaultdict(int)
+    for r in results:
+        for iss in r['issues']:
+            key = re.sub(r'\(.*\)', '', iss)
+            issue_counts[key] += 1
+
+    if issue_counts:
+        print("Issue breakdown:")
+        for key, count in sorted(issue_counts.items(), key=lambda x: -x[1]):
+            print(f"  {key:30s} {count:5d}")
+        print()
+
+    # POTIM distribution for problem cases
+    zbrent_cases = [r for r in results
+                    if any('ZBRENT' in i for i in r['issues'])]
+    if zbrent_cases:
+        potim_vals = [r['potim'] for r in zbrent_cases if r['potim'] is not None]
+        if potim_vals:
+            print(f"ZBRENT error cases ({len(zbrent_cases)}) — current POTIM:")
+            from collections import Counter
+            pcounts = Counter(potim_vals)
+            for pval, cnt in sorted(pcounts.items()):
+                print(f"  POTIM={pval:.6f}  ({cnt} cases)")
+            print()
+
+    # Detailed list
+    print("RERUN NEEDED:")
+    print("-" * 90)
+    rerun_entries = []
+    for r in results:
+        if r['needs_rerun'] or args.all:
+            flag = "RERUN" if r['needs_rerun'] else "OK"
+            issues_str = ", ".join(r['issues']) if r['issues'] else "OK"
+            omega_str = (f"Ω={r['omega_sf']:+.4f}"
+                         if r['omega_sf'] is not None else "Ω=N/A")
+            potim_str = (f"POTIM={r['potim']:.4f}"
+                         if r['potim'] is not None else "POTIM=N/A")
+            print(f"  {flag:5s}  {r['dirname']:20s}  {omega_str:14s}  "
+                  f"{potim_str:14s}  {issues_str}")
+            if r['needs_rerun']:
+                rerun_entries.append(r)
+
+    # Write rerun list
+    output_path = os.path.join(
+        os.path.dirname(os.path.abspath(args.sqs_dir)), args.output)
+    with open(output_path, 'w') as f:
+        for r in rerun_entries:
+            f.write(r['dirname'] + '\n')
+    print(f"\nRerun list: {output_path} ({len(rerun_entries)} directories)")
+
+    if not args.rerun:
+        print("\n(Dry run — add --rerun to execute VASP recalculations)")
+        return
+
+    # ---- Phase 2: Rerun ----
+    if not rerun_entries:
+        print("\nNo directories need rerun. Done.")
+        return
+
+    # Check VASPBIN
+    vaspbin = os.environ.get('VASPBIN')
+    if not vaspbin:
+        print("\nERROR: $VASPBIN is not set.", file=sys.stderr)
+        print("  export VASPBIN=/path/to/vasp_std", file=sys.stderr)
+        sys.exit(1)
+    if not os.path.isfile(vaspbin):
+        print(f"\nERROR: VASPBIN={vaspbin} not found.", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"\n{'='*70}")
+    print(f"PREPARING {len(rerun_entries)} directories for rerun...")
+    potim_desc = (f"POTIM → {args.potim}" if args.potim
+                  else "POTIM → auto (ZBRENT: 0.2, others: keep)")
+    ibrion_desc = (f"IBRION → {args.ibrion}" if args.ibrion
+                   else "IBRION → auto (ZBRENT: 1, others: keep)")
+    print(f"  CONTCAR → POSCAR, NSW → {args.nsw}, ISIF = 7")
+    print(f"  {potim_desc}")
+    print(f"  {ibrion_desc}")
+    print(f"{'='*70}")
+
+    # Determine POTIM/IBRION strategy per directory
+    prepared_dirs = []
+    for r in rerun_entries:
+        calc_dir = r['calc_dir']
+        has_zbrent = any('ZBRENT' in i for i in r['issues'])
+
+        # POTIM: user-specified > auto-adjust for ZBRENT > keep original
+        if args.potim is not None:
+            potim = args.potim
+        elif has_zbrent:
+            cur = r.get('potim')
+            if cur is not None and cur < 0.1:
+                potim = 0.2  # too small → increase
+            elif cur is not None and cur > 0.5:
+                potim = 0.2  # too large → decrease
+            else:
+                potim = 0.2  # default ZBRENT fix
+        else:
+            potim = None  # keep original
+
+        # IBRION: user-specified > auto (ZBRENT→1) > keep original
+        if args.ibrion is not None:
+            ibrion = args.ibrion
+        elif has_zbrent:
+            ibrion = 1  # RMM-DIIS quasi-Newton: more robust near minimum
+        else:
+            ibrion = None  # keep original
+
+        ok = backup_and_prepare(calc_dir, new_nsw=args.nsw,
+                                new_potim=potim, new_ibrion=ibrion)
+        if ok:
+            prepared_dirs.append(calc_dir)
+            potim_msg = f"POTIM={potim}" if potim else "POTIM=keep"
+            ibrion_msg = f"IBRION={ibrion}" if ibrion else "IBRION=keep"
+            print(f"  OK  {r['dirname']:20s}  {potim_msg}  {ibrion_msg}")
+        else:
+            print(f"  NG  {r['dirname']}  (preparation failed, skipping)")
+
+    if not prepared_dirs:
+        print("\nNo directories could be prepared. Aborting.")
+        return
+
+    # Confirm before running
+    print(f"\nReady to run {len(prepared_dirs)} VASP jobs")
+    print(f"  {args.max_jobs} parallel × {args.ncore} cores = "
+          f"{args.max_jobs * args.ncore} total cores")
+    print(f"  VASPBIN: {vaspbin}")
+    resp = input("Proceed? [y/N] ").strip().lower()
+    if resp != 'y':
+        print("Aborted.")
+        return
+
+    # Run
+    succeeded, failed = run_all_jobs(
+        prepared_dirs, vaspbin, args.ncore, args.max_jobs)
+
+    # Write remaining failures
+    if failed:
+        fail_path = os.path.join(
+            os.path.dirname(os.path.abspath(args.sqs_dir)),
+            'still_unconverged.txt')
+        with open(fail_path, 'w') as f:
+            for d in failed:
+                f.write(d + '\n')
+        print(f"\nStill-unconverged list: {fail_path}")
+
+
+if __name__ == '__main__':
+    main()

--- a/vasp_inputs/reanalyze_all.py
+++ b/vasp_inputs/reanalyze_all.py
@@ -25,8 +25,9 @@ BCC_B2/A1B1、FCC_L12/A3B1、BCC_SQS/A8B8の全結果を抽出して
 
     オプション:
       -o, --output-dir   出力ディレクトリ (default: ./reanalysis_output)
-      --hea-csv          HEAデータCSV (default: data/hea_dataset.csv)
-      --skip-hea         HEA予測を省略
+      --b2-dir           B2サブディレクトリ名 (default: BCC_B2)
+      --l12-dir          L12サブディレクトリ名 (default: FCC_L12)
+      --sqs-dir          SQSサブディレクトリ名 (default: BCC_SQS)
 
 出力:
     reanalysis_output/
@@ -61,8 +62,9 @@ ALL_ELEMENTS = sorted([
     'Ta', 'Tb', 'Ti', 'V',  'W',  'Y',  'Zn', 'Zr',
 ])
 
-# King atomic volumes (Å³) — pure-element BCC/FCC DFT volumes
-KING_ATOMIC_VOLUMES = {
+# VASP DFT atomic volumes (Å³) — pure-element BCC/FCC volumes from VASP GGA-PBE
+# (historically named KING_ATOMIC_VOLUMES; kept as alias for backward compatibility)
+VASP_ATOMIC_VOLUMES = {
     "Ag": 17.840, "Al": 16.602, "Au": 17.798, "Be": 8.105,
     "Ca": 42.025, "Co": 10.994, "Cr": 11.415, "Cu": 12.024,
     "Dy": 31.744, "Er": 31.063, "Fe": 11.312, "Ge": 19.243,
@@ -74,6 +76,7 @@ KING_ATOMIC_VOLUMES = {
     "Ti": 17.022, "V":  13.275, "W":  15.960, "Y":  33.017,
     "Zn": 15.741, "Zr": 22.721,
 }
+KING_ATOMIC_VOLUMES = VASP_ATOMIC_VOLUMES  # backward compatibility alias
 
 
 # =====================================================================
@@ -124,9 +127,11 @@ def read_lattice_constant(calc_dir):
             a_vec[2] * (b_vec[0]*c_vec[1] - b_vec[1]*c_vec[0])
         ) * abs(scale)**3
 
-        # For cubic: a = scale * |a_vec|
-        a_mag = (a_vec[0]**2 + a_vec[1]**2 + a_vec[2]**2)**0.5
-        lattice_const = abs(scale) * a_mag
+        # Equivalent cubic lattice constant from cell volume.
+        # Works for any cell shape (conventional, primitive, rotated).
+        # Downstream code uses a**3/Z to get per-atom volume, so
+        # a = vol**(1/3) ensures a**3/Z = vol/Z regardless of cell type.
+        lattice_const = vol ** (1.0 / 3.0)
 
         if lattice_const < 1.5 or lattice_const > 15.0:
             return None, False, source
@@ -283,6 +288,8 @@ def compute_omega_sf_b2(results):
     """Compute Ω_sf from B2 data (A1B1 pairs, Z=2)."""
     pair_data = defaultdict(list)
     for r in results:
+        if not r.get('converged', False):
+            continue
         elA, elB = r['element_A'], r['element_B']
         a = r['lattice_constant']
         if elA not in KING_ATOMIC_VOLUMES or elB not in KING_ATOMIC_VOLUMES:
@@ -307,6 +314,8 @@ def compute_omega_sf_l12(results):
     """Compute Ω_sf from L12 data (A3B1 pairs, Z=4)."""
     pair_data = defaultdict(list)
     for r in results:
+        if not r.get('converged', False):
+            continue
         elA, elB = r['element_A'], r['element_B']
         cA, cB = int(r['count_A']), int(r['count_B'])
         a = r['lattice_constant']
@@ -333,6 +342,8 @@ def compute_omega_sf_sqs(results):
     """Compute Ω_sf from SQS data (A8B8 pairs, Z=16)."""
     pair_data = defaultdict(list)
     for r in results:
+        if not r.get('converged', False):
+            continue
         elA, elB = r['element_A'], r['element_B']
         a = r['lattice_constant']
         if elA not in KING_ATOMIC_VOLUMES or elB not in KING_ATOMIC_VOLUMES:
@@ -390,6 +401,8 @@ def predict_hea_lattice(comp, struct, omega_sf, q=1.0):
         v_eff_i = vi * (1.0 + q * correction)
         v_eff_total += ci * v_eff_i
 
+    if v_eff_total <= 0:
+        return None
     a_pred = (n_auc * v_eff_total) ** (1.0 / 3.0)
     return a_pred
 


### PR DESCRIPTION
## Summary

gpt-5-codexが特定した4ファイルの全バグ（Critical 4件、High/Medium複数件）を修正。

### Critical fixes

1. **`generate_all_figures.py` — L1₂向き情報消失**: `tuple(sorted([elA, elB]))` が A₃B/B₃A の多数/少数サイト情報を破壊。`_l12_bucket(elA, elB, cA, cB)` ヘルパーで多数元素のsorted-pair内位置を追跡し、fig08/09/10/14すべてに適用。

2. **`reanalyze_all.py` — 格子定数の立方体仮定**: `lattice_const = abs(scale) * a_mag`（第一ベクトル長）→ `vol ** (1/3)`（体積ベース等価立方格子定数）。FCC primitive cell（`0 0.5 0.5`形式）で13-41%過小評価していた問題を解消。

3. **`hea_lattice_xgboost.py` — 空データでLOO/XGBoost停止**: `build_omega_sf_ml_model` / `loo_cv_xgboost` / `two_stage_model` に `N < 2` ガードを追加。

4. **`detect_rerun_needed.py` — 二元系限定parse_dirname**: `r'^([A-Z][a-z]?)(\d+)([A-Z][a-z]?)(\d+)$'` → `re.findall(r'([A-Z][a-z]?)(\d+)', dirname)` で3+元素ディレクトリ名（`Fe4Co4Ni4Cr4`等）に対応。

### High/Medium fixes

- **空配列ガード**: fig08/09/10/11/14で `min()`/`max()` on empty list防御
- **未収束フィルタ**: Ω_sf計算（B2/L12/SQS）に `converged` チェック追加
- **ROC NaN**: `compute_delta_r`/`compute_delta_sf` の NaN をフィルタ
- **v_eff負値**: `predict_hea_lattice` で `v_eff_total <= 0` → `None`
- **未知元素警告**: `_warn_unknown_element()` で一回限り警告（以前はサイレントにデフォルト値使用）
- **warnings制御**: `warnings.filterwarnings("ignore")` → FutureWarning + xgboost UserWarningのみ抑制
- **MPIゾンビ**: `subprocess.run` → `Popen` + `os.setsid` + `killpg` でタイムアウト時のMPI子プロセス確実終了
- **変数名**: `KING_ATOMIC_VOLUMES` → `VASP_ATOMIC_VOLUMES`（エイリアス保持）
- **ドキュメント**: 存在しないCLIオプション記述を修正

Link to Devin session: https://app.devin.ai/sessions/2138d5f8fb634a37a9c10087f81b8f63
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->