### PR TITLE
fix: gpt-5-codexコードレビュー指摘修正（致命的バグ2件 + 高バグ2件）

### DIFF
--- a/l12-schema-graph-text2sql/verification_package/scripts/03_verify_schema_graph.py
+++ b/l12-schema-graph-text2sql/verification_package/scripts/03_verify_schema_graph.py
@@ -111,8 +111,11 @@ def main():
     if isolated:
         print(f"    → FK接続なしテーブル（グラフ外）: {isolated}")
 
-    check("テーブルグラフは連結", nx.is_connected(table_graph),
-          "非連結 — FK関係が不足している可能性")
+    if n_nodes == 0:
+        check("テーブルグラフは連結", False, "グラフが空です")
+    else:
+        check("テーブルグラフは連結", nx.is_connected(table_graph),
+              "非連結 — FK関係が不足している可能性")
 
     # --- 3. 最短経路探索 ---
     print("\n■ 3. 最短JOINパス探索")
@@ -333,10 +336,11 @@ def main():
                     "",
                 )
             else:
+                # 非連結テーブルにパスが見つかった場合は警告（FK接続ありの可能性）
                 check(
-                    f"非連結テーブル{iso_tbl}への走査 → パスが見つかる（FK接続あり）",
-                    True,
-                    f"パス: {path}",
+                    f"非連結テーブル{iso_tbl}への走査 → 空パスを期待",
+                    False,
+                    f"パスが見つかりました: {path}（FK接続がある可能性）",
                 )
         except Exception as e:
             # エラーが発生する場合、例外型を記録

--- a/l12-schema-graph-text2sql/verification_package/scripts/07_verify_results.py
+++ b/l12-schema-graph-text2sql/verification_package/scripts/07_verify_results.py
@@ -65,6 +65,17 @@ def skip(name: str, reason: str):
     skipped += 1
 
 
+def safe_rows(result_dict, default=0):
+    """rows値を安全に取得（None/欠落 → default）"""
+    v = result_dict.get("rows")
+    return v if v is not None else default
+
+
+def safe_latency(result_dict):
+    """latency_ms値を安全に取得（None → None, 0 → 0）"""
+    return result_dict.get("latency_ms")
+
+
 def pN(vals, n):
     """percentile (0-100)"""
     s = sorted(vals)
@@ -114,6 +125,10 @@ def main():
 
     N = len(detail)
     print(f"\n  データソース: {source_name}  ({N}件)")
+
+    if N == 0:
+        print("\n  エラー: 実験結果が0件です。データファイルが空の可能性があります。")
+        return 1
 
     # ------------------------------------------------------------------
     # ■ 1. 基本成功率（生データから再計算）
@@ -480,7 +495,7 @@ def main():
             if not r.get("success"):
                 continue
             total_success_cond += 1
-            if r.get("rows", -1) == 0:
+            if safe_rows(r, -1) == 0:
                 zero_rows.append(d.get("query", {}).get("id", "?"))
             else:
                 positive_rows += 1
@@ -497,10 +512,10 @@ def main():
     print("\n    === 実効成功率サマリ ===")
     full_def = sum(1 for d in detail
                    if d.get("llm_full_schema", {}).get("success")
-                   and d.get("llm_full_schema", {}).get("rows", 0) > 0) / N * 100
+                   and safe_rows(d.get("llm_full_schema", {})) > 0) / N * 100
     trav_def = sum(1 for d in detail
                    if d.get("llm_traversed", {}).get("success")
-                   and d.get("llm_traversed", {}).get("rows", 0) > 0) / N * 100
+                   and safe_rows(d.get("llm_traversed", {})) > 0) / N * 100
     full_nom = sum(1 for d in detail
                    if d.get("llm_full_schema", {}).get("success")) / N * 100
     trav_nom = sum(1 for d in detail
@@ -533,8 +548,8 @@ def main():
         qid = d.get("query", {}).get("id", "")
         f = d.get("llm_full_schema", {})
         t = d.get("llm_traversed", {})
-        f_limit = f.get("rows", 0) == 100
-        t_limit = t.get("rows", 0) == 100
+        f_limit = safe_rows(f) == 100
+        t_limit = safe_rows(t) == 100
         if f_limit or t_limit:
             limit_total += 1
             if f.get("success") != t.get("success"):
@@ -561,7 +576,7 @@ def main():
         qid = d.get("query", {}).get("id", "?")
         for key in ["llm_full_schema", "llm_traversed"]:
             r = d.get(key, {})
-            if r.get("success") and r.get("rows", 0) == 100:
+            if r.get("success") and safe_rows(r) == 100:
                 sql = r.get("sql", "")
                 if "GROUP BY" in sql.upper():
                     agg_limit_hit.append({"id": qid, "cond": key})
@@ -578,8 +593,8 @@ def main():
     print("\n■ 9. Latency分布【提案7】")
 
     for label, key in [("Full Schema", "llm_full_schema"), ("Traversed", "llm_traversed")]:
-        lats = [d.get(key, {}).get("latency_ms", 0) for d in detail
-                if d.get(key, {}).get("latency_ms")]
+        lats = [safe_latency(d.get(key, {})) for d in detail
+                if safe_latency(d.get(key, {})) is not None]
         if lats:
             p50 = pN(lats, 50)
             p95 = pN(lats, 95)
@@ -593,10 +608,10 @@ def main():
         else:
             print(f"    {label}: latencyデータなし")
 
-    full_lats = [d.get("llm_full_schema", {}).get("latency_ms", 0) for d in detail
-                 if d.get("llm_full_schema", {}).get("latency_ms")]
-    trav_lats = [d.get("llm_traversed", {}).get("latency_ms", 0) for d in detail
-                 if d.get("llm_traversed", {}).get("latency_ms")]
+    full_lats = [safe_latency(d.get("llm_full_schema", {})) for d in detail
+                 if safe_latency(d.get("llm_full_schema", {})) is not None]
+    trav_lats = [safe_latency(d.get("llm_traversed", {})) for d in detail
+                 if safe_latency(d.get("llm_traversed", {})) is not None]
     if full_lats and trav_lats:
         full_avg = statistics.mean(full_lats)
         trav_avg = statistics.mean(trav_lats)
@@ -698,7 +713,7 @@ def main():
                 sg_no_where = sum(1 for d in sg_success
                                   if "WHERE" not in d.get("sql", "").upper())
                 sg_limit_hit = sum(1 for d in sg_success
-                                   if d.get("rows", 0) == 100)
+                                   if safe_rows(d) == 100)
                 n_sg = len(sg_success)
                 if n_sg > 0:
                     print(f"\n    SG+RB品質分析 (成功{n_sg}件):")
@@ -811,8 +826,8 @@ def main():
         qid = d.get("query", {}).get("id", "?")
         f = d.get("llm_full_schema", {})
         t = d.get("llm_traversed", {})
-        f_rows = f.get("rows", -1)
-        t_rows = t.get("rows", -1)
+        f_rows = safe_rows(f, -1)
+        t_rows = safe_rows(t, -1)
 
         # 条件: 両方success、かつ Trav rows が Full rows より大幅に多い
         if f.get("success") and t.get("success"):
@@ -997,8 +1012,8 @@ def main():
         t = d.get("llm_traversed", {})
         if not (f.get("success") and t.get("success")):
             continue
-        f_rows = f.get("rows", -1)
-        t_rows = t.get("rows", -1)
+        f_rows = safe_rows(f, -1)
+        t_rows = safe_rows(t, -1)
         qid = d.get("query", {}).get("id", "?")
 
         # パターン: 片方rows>10, 他方rows=0

--- a/l12-schema-graph-text2sql/verification_package/scripts/07_verify_results.py
+++ b/l12-schema-graph-text2sql/verification_package/scripts/07_verify_results.py
@@ -617,7 +617,7 @@ def main():
         trav_avg = statistics.mean(trav_lats)
         full_sd = statistics.stdev(full_lats) if len(full_lats) > 1 else 0
         trav_sd = statistics.stdev(trav_lats) if len(trav_lats) > 1 else 0
-        savings = (1 - trav_avg / full_avg) * 100
+        savings = (1 - trav_avg / full_avg) * 100 if full_avg > 0 else 0
         stdev_ratio = trav_sd / full_sd if full_sd > 0 else 0
         print(f"    Traversalによる平均レイテンシ削減: {savings:.1f}%")
         print(f"    stdev比: {stdev_ratio:.2f} (Full={full_sd:.0f}ms → Trav={trav_sd:.0f}ms)")


### PR DESCRIPTION
## Summary

`gpt-5-codex`によるコードレビューで検出されたバグ4件を修正。

### 【致命的】2件

1. **`07_verify_results.py`: `N=0`ゼロ除算** — `detail`が空リストの場合、`full_ok / N * 100`等で`ZeroDivisionError`。`N == 0`の早期リターンを追加。

2. **`03_verify_schema_graph.py`: `nx.is_connected()`空グラフ例外** — `table_graph`が空の場合`NetworkXPointlessConcept`でクラッシュ。`n_nodes == 0`の事前チェックを追加。

### 【高】2件

3. **`07_verify_results.py`: `rows=None`時の`TypeError`** — `.get("rows", 0)`は`rows`キーが存在しvalue=Noneの場合にNoneを返す。`safe_rows()`ヘルパー関数で全箇所（7箇所）をNone-safe化。

4. **`03_verify_schema_graph.py`: 非連結テーブル検査が常にTrue** — path長に関わらず`check(..., True, ...)`で常にパス扱い。非連結テーブルにパスが見つかった場合はFalseを返すよう修正。

### 【低】1件

5. **`07_verify_results.py`: latency 0ms除外** — `if d.get("latency_ms")`で0msを除外。`safe_latency()` + `is not None`判定に変更。

Link to Devin session: https://app.devin.ai/sessions/b8f167b6073c457e9680a6ad2800c836
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->