### PR TITLE
fix: HTML図パスをDevin添付URL→html_figures/相対パスに修正

### DIFF
--- a/report_for_students.html
+++ b/report_for_students.html
@@ -476,12 +476,12 @@ B2参照: $q_\text{BCC}=0.49$, $q_\text{FCC}=0.13$。</p>
 </div>
 
 <figure>
-<img src="https://app.devin.ai/attachments/a553733a-fd3a-4e99-b768-3dc80d329dfb/fig_parity.png" alt="パリティプロット">
+<img src="html_figures/fig_parity.png" alt="パリティプロット">
 <figcaption>図1: パリティプロット。横軸=実験格子定数、縦軸=予測格子定数。完全一致なら対角線上に乗る。</figcaption>
 </figure>
 
 <figure>
-<img src="https://app.devin.ai/attachments/85eedf61-e965-413b-ac94-4916d76e55a4/fig_rmse_bar.png" alt="RMSE比較棒グラフ">
+<img src="html_figures/fig_rmse_bar.png" alt="RMSE比較棒グラフ">
 <figcaption>図2: 各手法のRMSE比較。DFT-$\Omega_\text{sf}$ が最小。</figcaption>
 </figure>
 
@@ -530,7 +530,7 @@ B2参照: $q_\text{BCC}=0.49$, $q_\text{FCC}=0.13$。</p>
 </div>
 
 <figure>
-<img src="https://app.devin.ai/attachments/e04729b0-0604-47a4-a08d-acb6aad11e09/fig_bcc_fcc.png" alt="BCC/FCC別誤差分布">
+<img src="html_figures/fig_bcc_fcc.png" alt="BCC/FCC別誤差分布">
 <figcaption>図3: BCC/FCC別の誤差分布。FCCの誤差がBCCより顕著に小さい。</figcaption>
 </figure>
 
@@ -575,7 +575,7 @@ Alonso体積ズレ補正（King実験値）はBCC/FCC双方で最も悪い。</p
 </div>
 
 <figure>
-<img src="https://app.devin.ai/attachments/96861be4-63f9-40d0-a53f-147f56e1945a/fig_indep_test.png" alt="独立テスト結果">
+<img src="html_figures/fig_indep_test.png" alt="独立テスト結果">
 <figcaption>図4: 独立テスト20 HEAの予測 vs 実験。色分けはBCC/FCC。赤枠の2点（Nb-Ti-V-Zr, Cr-Mo-Nb-Ta-V-W）が外れ値。</figcaption>
 </figure>
 
@@ -651,12 +651,12 @@ $\Omega_\text{sf}(i\text{-}j) \approx \delta_i + \delta_j$
 </div>
 
 <figure>
-<img src="https://app.devin.ai/attachments/17bfdd93-bbec-41ce-baa7-3f75e2493961/fig_element_delta.png" alt="元素別δパラメータ">
+<img src="html_figures/fig_element_delta.png" alt="元素別δパラメータ">
 <figcaption>図5: 38元素の $\delta$ パラメータ。正の値=その元素は合金を膨張させる、負の値=収縮させる。</figcaption>
 </figure>
 
 <figure>
-<img src="https://app.devin.ai/attachments/9d2e10ac-5405-4ba6-b8cc-edf8fb400949/fig_additive_fit.png" alt="加法フィット品質">
+<img src="html_figures/fig_additive_fit.png" alt="加法フィット品質">
 <figcaption>図6: 加法近似の品質。横軸=DFT計算の $\Omega_\text{sf}$、縦軸=$\delta_i+\delta_j$ による予測値。R²≈0.65。</figcaption>
 </figure>
 
@@ -702,7 +702,7 @@ B2参照で $q_\text{BCC}=0.49$ は「DFTの $\Omega_\text{sf}$ を約半分に�
 </div>
 
 <figure>
-<img src="https://app.devin.ai/attachments/08990d7c-c743-459c-babc-14acff184104/fig_dft_selfconsistent.png" alt="DFT自己整合q≈1">
+<img src="html_figures/fig_dft_selfconsistent.png" alt="DFT自己整合q≈1">
 <figcaption>図10: 参照体積の選択がqと精度に与える影響。VASP参照でq≈1が達成され、パラメータフリー予測が可能になった。</figcaption>
 </figure>
 
@@ -736,7 +736,7 @@ B2参照で $q_\text{BCC}=0.49$ は「DFTの $\Omega_\text{sf}$ を約半分に�
 </div>
 
 <figure>
-<img src="https://app.devin.ai/attachments/9446f17d-087f-4a63-b7b7-b8d391ee401b/fig_sqs_issues.png" alt="SQS収束率">
+<img src="html_figures/fig_sqs_issues.png" alt="SQS収束率">
 <figcaption>図11: 構造タイプ別のVASP収束率。SQS（16原子/セル）は32.6%と極めて低い。</figcaption>
 </figure>
 
@@ -762,7 +762,7 @@ B2参照で $q_\text{BCC}=0.49$ は「DFTの $\Omega_\text{sf}$ を約半分に�
 </div>
 
 <figure>
-<img src="https://app.devin.ai/attachments/db68ac4d-8605-4325-8b2f-ee64d961c771/fig_delta_r_proof.png" alt="δr構造不変性の証明">
+<img src="html_figures/fig_delta_r_proof.png" alt="δr構造不変性の証明">
 <figcaption>図7: δrが構造情報を含み得ないことの実証。(a)(b) B2/L1$_2$の格子定数 vs $\delta r$、(c) B2-L1$_2$間の格子定数差 vs $\delta r$（ほぼ無相関）。</figcaption>
 </figure>
 
@@ -788,12 +788,12 @@ B2参照で $q_\text{BCC}=0.49$ は「DFTの $\Omega_\text{sf}$ を約半分に�
 </div>
 
 <figure>
-<img src="https://app.devin.ai/attachments/9bc34c2e-4e0e-4951-af0f-20a2eb5be57b/fig_roc.png" alt="ROC曲線">
+<img src="html_figures/fig_roc.png" alt="ROC曲線">
 <figcaption>図8: ROC曲線。固溶体 vs 金属間化合物含有の二値分類。$\delta r$ のAUC=0.869が最良。</figcaption>
 </figure>
 
 <figure>
-<img src="https://app.devin.ai/attachments/69022afb-d6d2-4c54-9c15-67d2cb98a9ae/fig_phase_map.png" alt="相安定性マップ">
+<img src="html_figures/fig_phase_map.png" alt="相安定性マップ">
 <figcaption>図9: 相安定性マップ。各HEAの $\delta r$ vs $\Omega$ パラメータ。色=相の種類。</figcaption>
 </figure>
 
@@ -826,7 +826,7 @@ DFT自己整合モデル (0.0203 Å) はかなりノイズフロアに肉薄し�
 </div>
 
 <figure>
-<img src="https://app.devin.ai/attachments/31a42cb6-9316-4f31-927c-b7c25806422b/fig_noise_floor.png" alt="ノイズフロア">
+<img src="html_figures/fig_noise_floor.png" alt="ノイズフロア">
 <figcaption>図14: 各手法のRMSEとノイズフロア（赤点線）。ノイズフロア以下の改善は原理的に困難。</figcaption>
 </figure>
 
@@ -883,27 +883,27 @@ DFT自己整合モデル (0.0203 Å) はかなりノイズフロアに肉薄し�
 <!-- ================================================================== -->
 
 <figure>
-<img src="https://app.devin.ai/attachments/6f3c25a9-0df6-4112-9881-a895a7cf7aa0/fig_composition_examples.png" alt="組成依存プロット">
+<img src="html_figures/fig_composition_examples.png" alt="組成依存プロット">
 <figcaption>図A1: 代表的な元素ペアの組成依存 $V_\text{eff}$ プロット。Vegard（直線）からのDFT偏差を可視化。</figcaption>
 </figure>
 
 <figure>
-<img src="https://app.devin.ai/attachments/72956666-1207-4f7c-ba08-97e426a52e51/fig_packing.png" alt="剛体球モデル">
+<img src="html_figures/fig_packing.png" alt="剛体球モデル">
 <figcaption>図A2: 剛体球接触モデルの限界。実際の原子は「柔らかい球」であり、接触モデルでは体積偏差を再現できない。</figcaption>
 </figure>
 
 <figure>
-<img src="https://app.devin.ai/attachments/87420df7-8ffa-4675-9538-48f3198776c2/fig_l12_asymmetry.png" alt="L12非対称性">
+<img src="html_figures/fig_l12_asymmetry.png" alt="L12非対称性">
 <figcaption>図A3: L1$_2$構造の非対称性。A$_3$BとB$_3$Aで格子定数が大きく異なる（平均差0.33Å）。半径だけでは予測不可能。</figcaption>
 </figure>
 
 <figure>
-<img src="https://app.devin.ai/attachments/45eee88f-0f4b-4250-9ccd-52f75ef468ca/fig_volume_radius.png" alt="体積 vs 半径">
+<img src="html_figures/fig_volume_radius.png" alt="体積 vs 半径">
 <figcaption>図A4: DFT原子体積と各種半径定義の関係。体積由来の「有効半径」が構造効果を最もよく反映する。</figcaption>
 </figure>
 
 <figure>
-<img src="https://app.devin.ai/attachments/f9508d40-5fb8-4481-bb11-87398baef33c/fig_vegard_structure_absorbed.png" alt="Vegard構造効果">
+<img src="html_figures/fig_vegard_structure_absorbed.png" alt="Vegard構造効果">
 <figcaption>図A5: Vegard偏差に構造効果がどの程度吸収されるかの可視化。</figcaption>
 </figure>
 


### PR DESCRIPTION
## Summary

`report_for_students.html` の全17画像の `src` 属性が認証必要な Devin添付URL（`https://app.devin.ai/attachments/...`）のままだったため、リポジトリからHTMLを直接開いた場合に図が表示されなかった。

`html_figures/fig_*.png` の相対パスに置換し、リポジトリ内の `html_figures/` ディレクトリと対応させた。デプロイサイト（`hea-report-deploy-jjdhtuci.devinapps.com`）側は既に相対パスで動作済み。

Link to Devin session: https://app.devin.ai/sessions/2138d5f8fb634a37a9c10087f81b8f63
Requested by: @minimumtone