### PR TITLE
fix: データリーク修正(Pipeline化) + 学生向けインストールガイド追加

### DIFF
--- a/install_guide.html
+++ b/install_guide.html
@@ -1,0 +1,599 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MI講義アプリ インストールガイド</title>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: "Hiragino Kaku Gothic ProN", "Yu Gothic", "Meiryo", sans-serif;
+            line-height: 1.8;
+            color: #333;
+            background: #f8f9fa;
+            padding: 20px;
+        }
+        .container {
+            max-width: 900px;
+            margin: 0 auto;
+            background: #fff;
+            padding: 40px;
+            border-radius: 12px;
+            box-shadow: 0 2px 12px rgba(0,0,0,0.08);
+        }
+        h1 {
+            text-align: center;
+            color: #1a73e8;
+            margin-bottom: 10px;
+            font-size: 1.8em;
+        }
+        .subtitle {
+            text-align: center;
+            color: #666;
+            margin-bottom: 40px;
+            font-size: 0.95em;
+        }
+        h2 {
+            color: #1a73e8;
+            border-left: 4px solid #1a73e8;
+            padding-left: 12px;
+            margin-top: 40px;
+            margin-bottom: 16px;
+            font-size: 1.3em;
+        }
+        h3 {
+            color: #444;
+            margin-top: 24px;
+            margin-bottom: 8px;
+            font-size: 1.1em;
+        }
+        p { margin-bottom: 12px; }
+        .step {
+            background: #f0f7ff;
+            border: 1px solid #d0e3f7;
+            border-radius: 8px;
+            padding: 20px;
+            margin: 16px 0;
+        }
+        .step-number {
+            display: inline-block;
+            background: #1a73e8;
+            color: #fff;
+            width: 28px;
+            height: 28px;
+            border-radius: 50%;
+            text-align: center;
+            line-height: 28px;
+            font-weight: bold;
+            font-size: 0.9em;
+            margin-right: 8px;
+        }
+        .step-title {
+            font-weight: bold;
+            font-size: 1.05em;
+            color: #1a73e8;
+        }
+        .code-block {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 16px 20px;
+            border-radius: 6px;
+            font-family: "Consolas", "Monaco", "Courier New", monospace;
+            font-size: 0.9em;
+            overflow-x: auto;
+            margin: 12px 0;
+            position: relative;
+        }
+        .code-block .comment {
+            color: #6a9955;
+        }
+        .code-block .prompt {
+            color: #569cd6;
+            user-select: none;
+        }
+        .warning {
+            background: #fff3cd;
+            border: 1px solid #ffc107;
+            border-radius: 8px;
+            padding: 16px;
+            margin: 16px 0;
+        }
+        .warning::before {
+            content: "⚠️ 注意: ";
+            font-weight: bold;
+        }
+        .success {
+            background: #d4edda;
+            border: 1px solid #28a745;
+            border-radius: 8px;
+            padding: 16px;
+            margin: 16px 0;
+        }
+        .success::before {
+            content: "✅ ";
+        }
+        .info {
+            background: #e8f4fd;
+            border: 1px solid #bee5eb;
+            border-radius: 8px;
+            padding: 16px;
+            margin: 16px 0;
+        }
+        .info::before {
+            content: "💡 ヒント: ";
+            font-weight: bold;
+        }
+        .os-tabs {
+            display: flex;
+            gap: 0;
+            margin-top: 16px;
+            margin-bottom: 0;
+        }
+        .os-tab {
+            padding: 10px 20px;
+            border: 1px solid #ddd;
+            border-bottom: none;
+            border-radius: 8px 8px 0 0;
+            cursor: pointer;
+            background: #f5f5f5;
+            font-weight: bold;
+            font-size: 0.9em;
+        }
+        .os-tab.active {
+            background: #fff;
+            border-bottom: 2px solid #fff;
+            color: #1a73e8;
+        }
+        .os-content {
+            border: 1px solid #ddd;
+            border-radius: 0 8px 8px 8px;
+            padding: 20px;
+            background: #fff;
+        }
+        .os-panel { display: none; }
+        .os-panel.active { display: block; }
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 16px 0;
+        }
+        th, td {
+            border: 1px solid #ddd;
+            padding: 10px 14px;
+            text-align: left;
+        }
+        th { background: #f0f7ff; color: #1a73e8; }
+        .screenshot-placeholder {
+            background: #eee;
+            border: 2px dashed #ccc;
+            border-radius: 8px;
+            padding: 30px;
+            text-align: center;
+            color: #888;
+            margin: 12px 0;
+        }
+        a { color: #1a73e8; }
+        ul, ol { margin: 8px 0 12px 24px; }
+        li { margin-bottom: 6px; }
+        .toc {
+            background: #f8f9fa;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 20px 30px;
+            margin: 20px 0 40px;
+        }
+        .toc h3 { margin-top: 0; color: #1a73e8; }
+        .toc ol { margin-left: 20px; }
+        .toc li { margin-bottom: 4px; }
+        .toc a { text-decoration: none; }
+        .toc a:hover { text-decoration: underline; }
+        .faq dt {
+            font-weight: bold;
+            color: #d32f2f;
+            margin-top: 16px;
+        }
+        .faq dd {
+            margin-left: 20px;
+            margin-bottom: 12px;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+
+<h1>MI講義アプリ インストールガイド</h1>
+<p class="subtitle">マテリアルズ・インフォマティクス講義用 Streamlit アプリケーション</p>
+
+<div class="toc">
+    <h3>目次</h3>
+    <ol>
+        <li><a href="#overview">はじめに（このアプリについて）</a></li>
+        <li><a href="#requirements">必要なもの</a></li>
+        <li><a href="#install-python">Step 1: Python のインストール</a></li>
+        <li><a href="#download-app">Step 2: アプリのダウンロード</a></li>
+        <li><a href="#install-packages">Step 3: 必要なパッケージのインストール</a></li>
+        <li><a href="#run-app">Step 4: アプリの起動</a></li>
+        <li><a href="#usage">Step 5: アプリの使い方</a></li>
+        <li><a href="#shutdown">Step 6: アプリの終了</a></li>
+        <li><a href="#troubleshooting">トラブルシューティング（困ったとき）</a></li>
+    </ol>
+</div>
+
+<!-- ===== Section 1: Overview ===== -->
+<h2 id="overview">1. はじめに（このアプリについて）</h2>
+<p>
+    このアプリは、<strong>ブラウザ上で動く対話的な教材</strong>です。
+    自分の PC にインストールして使います。インターネット接続はインストール時のみ必要で、
+    一度インストールすればオフラインでも動作します。
+</p>
+<p>アプリでは以下のことが学べます：</p>
+<ul>
+    <li>材料データの探索・可視化</li>
+    <li>主成分分析（PCA）による次元削減</li>
+    <li>回帰分析（線形回帰、SVR、ランダムフォレスト）</li>
+    <li>分類（SVM、k-means）</li>
+    <li>交差検証による汎化性能評価</li>
+</ul>
+
+<!-- ===== Section 2: Requirements ===== -->
+<h2 id="requirements">2. 必要なもの</h2>
+<table>
+    <tr><th>項目</th><th>内容</th></tr>
+    <tr><td>パソコン</td><td>Windows 10/11、macOS、または Linux</td></tr>
+    <tr><td>インターネット</td><td>インストール時に必要（アプリ実行時は不要）</td></tr>
+    <tr><td>ディスク容量</td><td>約 1 GB の空き</td></tr>
+    <tr><td>ブラウザ</td><td>Chrome, Edge, Firefox など（既にインストール済みのものでOK）</td></tr>
+</table>
+
+<div class="info">
+    プログラミングの経験は不要です。このガイドの手順をそのまま実行すれば動きます。
+</div>
+
+<!-- ===== Section 3: Install Python ===== -->
+<h2 id="install-python">3. Step 1: Python のインストール</h2>
+<p>
+    このアプリは <strong>Python</strong>（パイソン）というプログラミング言語で書かれています。
+    まず Python をインストールします。
+</p>
+
+<div class="os-tabs">
+    <div class="os-tab active" onclick="showOS('windows')">Windows</div>
+    <div class="os-tab" onclick="showOS('mac')">macOS</div>
+</div>
+<div class="os-content">
+    <div id="os-windows" class="os-panel active">
+        <div class="step">
+            <span class="step-number">1</span>
+            <span class="step-title">Python 公式サイトを開く</span>
+            <p>ブラウザで以下の URL にアクセスしてください：</p>
+            <p><a href="https://www.python.org/downloads/" target="_blank">https://www.python.org/downloads/</a></p>
+        </div>
+
+        <div class="step">
+            <span class="step-number">2</span>
+            <span class="step-title">「Download Python 3.xx.x」ボタンをクリック</span>
+            <p>ページ上部にある黄色い「Download Python 3.xx.x」ボタンをクリックします。</p>
+            <p>（数字はバージョン番号です。最新のものをダウンロードしてください）</p>
+        </div>
+
+        <div class="step">
+            <span class="step-number">3</span>
+            <span class="step-title">インストーラーを実行する</span>
+            <p>ダウンロードしたファイル（<code>python-3.xx.x-amd64.exe</code>）をダブルクリックして実行します。</p>
+            <div class="warning">
+                <strong>最も重要な操作：</strong>インストール画面の一番下にある
+                <strong>「Add python.exe to PATH」にチェックを入れてください</strong>。
+                これを忘れるとアプリが動きません。
+            </div>
+            <p>チェックを入れたら「Install Now」をクリックしてください。</p>
+        </div>
+
+        <div class="step">
+            <span class="step-number">4</span>
+            <span class="step-title">インストール確認</span>
+            <p>インストールが完了したら、以下の方法で確認します：</p>
+            <ol>
+                <li>キーボードで <code>Windows キー</code> を押す</li>
+                <li>「<code>cmd</code>」と入力して Enter（コマンドプロンプトが開きます）</li>
+                <li>黒い画面が開いたら、以下を入力して Enter：</li>
+            </ol>
+            <div class="code-block">
+<span class="prompt">C:\Users\あなたの名前&gt;</span> python --version
+            </div>
+            <div class="success">
+                <code>Python 3.xx.x</code> と表示されればインストール成功です。
+            </div>
+        </div>
+    </div>
+
+    <div id="os-mac" class="os-panel">
+        <div class="step">
+            <span class="step-number">1</span>
+            <span class="step-title">Python 公式サイトを開く</span>
+            <p>ブラウザで以下の URL にアクセスしてください：</p>
+            <p><a href="https://www.python.org/downloads/" target="_blank">https://www.python.org/downloads/</a></p>
+        </div>
+
+        <div class="step">
+            <span class="step-number">2</span>
+            <span class="step-title">「Download Python 3.xx.x」ボタンをクリック</span>
+            <p>ページ上部にある黄色い「Download Python 3.xx.x」ボタンをクリックします。</p>
+        </div>
+
+        <div class="step">
+            <span class="step-number">3</span>
+            <span class="step-title">インストーラーを実行する</span>
+            <p>ダウンロードした <code>.pkg</code> ファイルをダブルクリックして、画面の指示に従ってインストールします。</p>
+        </div>
+
+        <div class="step">
+            <span class="step-number">4</span>
+            <span class="step-title">インストール確認</span>
+            <p>インストールが完了したら、以下の方法で確認します：</p>
+            <ol>
+                <li>Spotlight 検索（<code>Command + Space</code>）で「ターミナル」と検索して開く</li>
+                <li>以下を入力して Enter：</li>
+            </ol>
+            <div class="code-block">
+<span class="prompt">$</span> python3 --version
+            </div>
+            <div class="success">
+                <code>Python 3.xx.x</code> と表示されればインストール成功です。
+            </div>
+            <div class="info">
+                macOS では <code>python3</code> と入力します（<code>python</code> だけだと古いバージョンが起動する場合があります）。
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- ===== Section 4: Download App ===== -->
+<h2 id="download-app">4. Step 2: アプリのダウンロード</h2>
+
+<div class="step">
+    <span class="step-number">1</span>
+    <span class="step-title">アプリファイルをダウンロード</span>
+    <p>以下の GitHub ページからアプリをダウンロードします：</p>
+    <p><a href="https://github.com/minimumtone/machine-learning" target="_blank">https://github.com/minimumtone/machine-learning</a></p>
+    <ol>
+        <li>緑色の「<strong>Code</strong>」ボタンをクリック</li>
+        <li>「<strong>Download ZIP</strong>」をクリック</li>
+        <li>ダウンロードされた ZIP ファイルを好きな場所に展開（解凍）する</li>
+    </ol>
+    <div class="info">
+        展開先は「デスクトップ」や「ドキュメント」など、わかりやすい場所がおすすめです。
+    </div>
+</div>
+
+<!-- ===== Section 5: Install Packages ===== -->
+<h2 id="install-packages">5. Step 3: 必要なパッケージのインストール</h2>
+<p>
+    アプリの動作に必要な追加ソフトウェア（ライブラリ）をインストールします。
+    「パッケージ」とは、Python に追加機能を提供するプログラムの集まりです。
+</p>
+
+<div class="step">
+    <span class="step-number">1</span>
+    <span class="step-title">コマンドプロンプト（ターミナル）を開く</span>
+    <p><strong>Windows の場合：</strong></p>
+    <ol>
+        <li><code>Windows キー</code> を押して「<code>cmd</code>」と入力 → Enter</li>
+    </ol>
+    <p><strong>macOS の場合：</strong></p>
+    <ol>
+        <li><code>Command + Space</code> で「ターミナル」と検索 → Enter</li>
+    </ol>
+</div>
+
+<div class="step">
+    <span class="step-number">2</span>
+    <span class="step-title">アプリのフォルダに移動する</span>
+    <p>ダウンロードして展開したフォルダに移動します。</p>
+    <p><strong>Windows の場合（デスクトップに展開した例）：</strong></p>
+    <div class="code-block">
+<span class="prompt">C:\Users\あなたの名前&gt;</span> cd Desktop\machine-learning-main
+    </div>
+    <p><strong>macOS の場合（デスクトップに展開した例）：</strong></p>
+    <div class="code-block">
+<span class="prompt">$</span> cd ~/Desktop/machine-learning-main
+    </div>
+    <div class="info">
+        「<code>cd</code>」は「change directory（ディレクトリを変更）」の略で、フォルダを移動するコマンドです。
+    </div>
+</div>
+
+<div class="step">
+    <span class="step-number">3</span>
+    <span class="step-title">パッケージを一括インストール</span>
+    <p>以下のコマンドを<strong>コピー＆ペースト</strong>して Enter を押してください：</p>
+    <p><strong>Windows の場合：</strong></p>
+    <div class="code-block">
+<span class="prompt">C:\...\machine-learning-main&gt;</span> pip install streamlit pandas numpy matplotlib seaborn plotly scikit-learn
+    </div>
+    <p><strong>macOS の場合：</strong></p>
+    <div class="code-block">
+<span class="prompt">$</span> pip3 install streamlit pandas numpy matplotlib seaborn plotly scikit-learn
+    </div>
+    <div class="warning">
+        インストールには数分かかることがあります。画面にたくさんの文字が流れますが、
+        エラーが出なければ正常です。最後に「Successfully installed ...」と表示されれば成功です。
+    </div>
+</div>
+
+<div class="step">
+    <span class="step-number">4</span>
+    <span class="step-title">インストール確認</span>
+    <p>以下を入力して、エラーが出ないことを確認します：</p>
+    <p><strong>Windows：</strong></p>
+    <div class="code-block">
+<span class="prompt">C:\...\machine-learning-main&gt;</span> python -c "import streamlit; print(streamlit.__version__)"
+    </div>
+    <p><strong>macOS：</strong></p>
+    <div class="code-block">
+<span class="prompt">$</span> python3 -c "import streamlit; print(streamlit.__version__)"
+    </div>
+    <div class="success">
+        バージョン番号（例: <code>1.38.0</code>）が表示されれば成功です。
+    </div>
+</div>
+
+<!-- ===== Section 6: Run App ===== -->
+<h2 id="run-app">6. Step 4: アプリの起動</h2>
+
+<div class="step">
+    <span class="step-number">1</span>
+    <span class="step-title">アプリを起動するコマンドを実行</span>
+    <p>アプリのフォルダ内で、以下のコマンドを実行します：</p>
+    <p><strong>Windows：</strong></p>
+    <div class="code-block">
+<span class="prompt">C:\...\machine-learning-main&gt;</span> streamlit run mi_textbook_app.py
+    </div>
+    <p><strong>macOS：</strong></p>
+    <div class="code-block">
+<span class="prompt">$</span> streamlit run mi_textbook_app.py
+    </div>
+</div>
+
+<div class="step">
+    <span class="step-number">2</span>
+    <span class="step-title">ブラウザが自動で開く</span>
+    <p>コマンド実行後、自動的にブラウザが開き、アプリが表示されます。</p>
+    <p>もし自動で開かない場合は、ブラウザのアドレスバーに以下を入力してください：</p>
+    <div class="code-block">
+http://localhost:8501
+    </div>
+    <div class="success">
+        ブラウザに「マテリアルズ・インフォマティクス (MI) とは」という画面が表示されれば成功です。
+    </div>
+</div>
+
+<div class="info">
+    コマンドプロンプト（ターミナル）の画面は<strong>閉じないでください</strong>。
+    閉じるとアプリも停止します。アプリを使っている間は、その画面はそのまま放置してください。
+</div>
+
+<!-- ===== Section 7: Usage ===== -->
+<h2 id="usage">7. Step 5: アプリの使い方</h2>
+<p>アプリの操作はすべてブラウザ上で行います。</p>
+
+<h3>画面の構成</h3>
+<table>
+    <tr><th>場所</th><th>機能</th></tr>
+    <tr><td><strong>左側サイドバー</strong></td><td>セクション（章）の切り替え、データセットの選択</td></tr>
+    <tr><td><strong>メイン画面</strong></td><td>理論の説明、数式、グラフ、操作パネル</td></tr>
+</table>
+
+<h3>基本操作</h3>
+<ul>
+    <li><strong>セクションの移動</strong>：左のサイドバーでセクション名をクリック</li>
+    <li><strong>データセットの変更</strong>：サイドバーの「材料データ」ドロップダウンで選択</li>
+    <li><strong>スライダー</strong>：パラメータ（正則化の強さ、次数など）を変更して結果の変化を観察</li>
+    <li><strong>グラフの操作</strong>：マウスホバーで数値表示、ドラッグでズーム、ダブルクリックでリセット</li>
+</ul>
+
+<h3>推奨する学習順序</h3>
+<p>サイドバーの番号順（1 → 2 → ... → 8）に進めてください。各セクションは前のセクションの知識を前提としています。</p>
+
+<!-- ===== Section 8: Shutdown ===== -->
+<h2 id="shutdown">8. Step 6: アプリの終了</h2>
+
+<div class="step">
+    <span class="step-number">1</span>
+    <span class="step-title">コマンドプロンプト（ターミナル）で停止</span>
+    <p>アプリを起動したコマンドプロンプト（ターミナル）の画面で：</p>
+    <div class="code-block">
+<span class="comment"># キーボードで Ctrl キーを押しながら C を押す</span>
+Ctrl + C
+    </div>
+    <p>これでアプリが停止します。ブラウザの画面を閉じても OK です。</p>
+</div>
+
+<div class="step">
+    <span class="step-number">2</span>
+    <span class="step-title">次回の起動方法</span>
+    <p>次にアプリを使いたいときは、Step 4 のコマンド（<code>streamlit run mi_textbook_app.py</code>）を
+    再度実行するだけで起動できます。パッケージの再インストールは不要です。</p>
+</div>
+
+<!-- ===== Section 9: Troubleshooting ===== -->
+<h2 id="troubleshooting">9. トラブルシューティング（困ったとき）</h2>
+
+<dl class="faq">
+    <dt>Q: 「python が見つかりません」「'python' is not recognized」と表示される</dt>
+    <dd>
+        <strong>原因</strong>：Python インストール時に「Add python.exe to PATH」にチェックを入れなかった可能性があります。<br>
+        <strong>対処法</strong>：Python を一度アンインストールし、再インストールしてください。
+        インストール時に必ず「Add python.exe to PATH」にチェックを入れてください。
+    </dd>
+
+    <dt>Q: 「pip が見つかりません」と表示される</dt>
+    <dd>
+        <strong>対処法（Windows）</strong>：<code>pip</code> の代わりに <code>python -m pip</code> を使ってみてください：
+        <div class="code-block">
+<span class="prompt">&gt;</span> python -m pip install streamlit pandas numpy matplotlib seaborn plotly scikit-learn
+        </div>
+        <strong>対処法（macOS）</strong>：<code>pip3</code> を使ってください。
+    </dd>
+
+    <dt>Q: 「ModuleNotFoundError: No module named 'streamlit'」と表示される</dt>
+    <dd>
+        <strong>原因</strong>：パッケージのインストールが完了していません。<br>
+        <strong>対処法</strong>：Step 3 のインストールコマンドを再度実行してください。
+    </dd>
+
+    <dt>Q: 「Permission denied」「アクセスが拒否されました」と表示される</dt>
+    <dd>
+        <strong>対処法（Windows）</strong>：コマンドプロンプトを「管理者として実行」してください。
+        スタートメニューで「cmd」と検索し、右クリック → 「管理者として実行」。<br>
+        <strong>対処法（macOS）</strong>：コマンドの先頭に <code>sudo</code> を付けてください：
+        <div class="code-block">
+<span class="prompt">$</span> sudo pip3 install streamlit pandas numpy matplotlib seaborn plotly scikit-learn
+        </div>
+        パスワードを求められたら、Mac のログインパスワードを入力してください（入力中は画面に何も表示されません）。
+    </dd>
+
+    <dt>Q: ブラウザに何も表示されない / 「このサイトにアクセスできません」と出る</dt>
+    <dd>
+        <strong>対処法</strong>：
+        <ol>
+            <li>コマンドプロンプト（ターミナル）が開いたままか確認する</li>
+            <li>画面に「You can now view your Streamlit app in your browser」と表示されているか確認する</li>
+            <li>ブラウザのアドレスバーに <code>http://localhost:8501</code> を直接入力する</li>
+        </ol>
+    </dd>
+
+    <dt>Q: 「Address already in use（ポートが使用中）」と表示される</dt>
+    <dd>
+        <strong>原因</strong>：前回のアプリが完全に終了していない可能性があります。<br>
+        <strong>対処法</strong>：別のポート番号で起動できます：
+        <div class="code-block">
+<span class="prompt">&gt;</span> streamlit run mi_textbook_app.py --server.port 8502
+        </div>
+        ブラウザでは <code>http://localhost:8502</code> にアクセスしてください。
+    </dd>
+
+    <dt>Q: グラフが表示されない / 画面が白いまま</dt>
+    <dd>
+        <strong>対処法</strong>：ブラウザのキャッシュをクリアしてページを再読み込みしてください
+        （<code>Ctrl + Shift + R</code> または <code>Command + Shift + R</code>）。
+    </dd>
+
+    <dt>Q: 上記で解決しない</dt>
+    <dd>
+        エラーメッセージのスクリーンショットを撮って、担当教員に連絡してください。
+    </dd>
+</dl>
+
+</div>
+
+<script>
+function showOS(os) {
+    document.querySelectorAll('.os-panel').forEach(p => p.classList.remove('active'));
+    document.querySelectorAll('.os-tab').forEach(t => t.classList.remove('active'));
+    document.getElementById('os-' + os).classList.add('active');
+    event.target.classList.add('active');
+}
+</script>
+
+</body>
+</html>

--- a/mi_textbook_app.py
+++ b/mi_textbook_app.py
@@ -20,19 +20,18 @@ import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib
-import seaborn as sns
 import plotly.express as px
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
 from sklearn.model_selection import (
-    train_test_split, cross_val_score, KFold, LeaveOneOut, learning_curve,
-    validation_curve
+    train_test_split, cross_val_score, cross_val_predict, KFold, LeaveOneOut,
+    learning_curve, validation_curve
 )
 from sklearn.preprocessing import StandardScaler, PolynomialFeatures
 from sklearn.linear_model import LinearRegression, Ridge, Lasso
 from sklearn.svm import SVR, SVC
-from sklearn.ensemble import RandomForestRegressor, RandomForestClassifier, IsolationForest
+from sklearn.ensemble import RandomForestRegressor, IsolationForest
 from sklearn.neighbors import LocalOutlierFactor
 from sklearn.cluster import KMeans
 from sklearn.decomposition import PCA
@@ -603,11 +602,12 @@ elif section_key == "regression":
 
     X = df_main[feature_cols].values
     y = df_main[target_col].values
-    scaler = StandardScaler()
-    X_scaled = scaler.fit_transform(X)
-    X_train, X_test, y_train, y_test = train_test_split(
-        X_scaled, y, test_size=0.2, random_state=42
+    X_train_raw, X_test_raw, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
     )
+    scaler = StandardScaler()
+    X_train = scaler.fit_transform(X_train_raw)
+    X_test = scaler.transform(X_test_raw)
 
     # 4.1 線形回帰
     st.header("4.1 線形回帰 (Linear Regression)")
@@ -921,11 +921,12 @@ elif section_key == "regularization":
 
     X = df_main[feature_cols].values
     y = df_main[target_col].values
-    scaler = StandardScaler()
-    X_scaled = scaler.fit_transform(X)
-    X_train, X_test, y_train, y_test = train_test_split(
-        X_scaled, y, test_size=0.2, random_state=42
+    X_train_raw, X_test_raw, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
     )
+    scaler = StandardScaler()
+    X_train = scaler.fit_transform(X_train_raw)
+    X_test = scaler.transform(X_test_raw)
 
     st.header("5.1 正則化の理論")
     st.markdown(r"""
@@ -1268,8 +1269,6 @@ elif section_key == "cv_generalization":
 
     X = df_main[feature_cols].values
     y = df_main[target_col].values
-    scaler = StandardScaler()
-    X_scaled = scaler.fit_transform(X)
 
     st.header("7.1 交差検証の理論")
     st.markdown(r"""
@@ -1328,16 +1327,16 @@ elif section_key == "cv_generalization":
     cv_method = st.selectbox("CV 方法", ["k-fold CV", "LOOCV"])
 
     if cv_model_name == "線形回帰":
-        model_cv = LinearRegression()
+        model_cv = Pipeline([("scaler", StandardScaler()), ("model", LinearRegression())])
     elif cv_model_name == "Ridge":
-        model_cv = Ridge(alpha=1.0)
+        model_cv = Pipeline([("scaler", StandardScaler()), ("model", Ridge(alpha=1.0))])
     elif cv_model_name == "Lasso":
-        model_cv = Lasso(alpha=0.1, max_iter=10000)
+        model_cv = Pipeline([("scaler", StandardScaler()), ("model", Lasso(alpha=0.1, max_iter=10000))])
     elif cv_model_name == "SVR":
-        model_cv = SVR(kernel="rbf", C=10)
+        model_cv = Pipeline([("scaler", StandardScaler()), ("model", SVR(kernel="rbf", C=10))])
     else:
-        model_cv = RandomForestRegressor(n_estimators=100, max_depth=10,
-                                          random_state=42, n_jobs=-1)
+        model_cv = Pipeline([("scaler", StandardScaler()), ("model", RandomForestRegressor(n_estimators=100, max_depth=10,
+                                          random_state=42, n_jobs=-1))])
 
     if cv_method == "k-fold CV":
         k = st.slider("フォールド数 k", 2, 20, 5)
@@ -1348,17 +1347,16 @@ elif section_key == "cv_generalization":
         cv = LeaveOneOut()
         scoring = "neg_mean_squared_error"
         score_label = "負MSE"
-        st.warning(f"LOOCV: データ数 {len(X_scaled)} 回の学習を行います。少し時間がかかります。")
+        st.warning(f"LOOCV: データ数 {len(X)} 回の学習を行います。少し時間がかかります。")
         st.info("LOOCV では各フォールドが1サンプルのため R² は定義できません。代わりに MSE を使用し、全予測値から総合 R² を算出します。")
 
     with st.spinner("交差検証を実行中..."):
-        scores = cross_val_score(model_cv, X_scaled, y, cv=cv, scoring=scoring)
+        scores = cross_val_score(model_cv, X, y, cv=cv, scoring=scoring)
 
     st.markdown(f"### 結果 ({cv_method})")
     if cv_method == "LOOCV":
         mse_scores = -scores  # neg_mean_squared_error → positive MSE
-        from sklearn.model_selection import cross_val_predict
-        y_pred_loocv = cross_val_predict(model_cv, X_scaled, y, cv=LeaveOneOut())
+        y_pred_loocv = cross_val_predict(model_cv, X, y, cv=LeaveOneOut())
         overall_r2 = r2_score(y, y_pred_loocv)
         overall_rmse = np.sqrt(mse_scores.mean())
         col1, col2, col3 = st.columns(3)
@@ -1401,7 +1399,7 @@ elif section_key == "cv_generalization":
 
     with st.spinner("学習曲線を計算中..."):
         train_sizes_abs, train_scores, test_scores = learning_curve(
-            model_cv, X_scaled, y, cv=5,
+            model_cv, X, y, cv=5,
             train_sizes=np.linspace(0.1, 1.0, 10),
             scoring="r2", n_jobs=-1
         )
@@ -1433,7 +1431,8 @@ elif section_key == "cv_generalization":
         if val_model == "Ridge":
             param_range = np.logspace(-3, 3, 20)
             train_s, test_s = validation_curve(
-                Ridge(), X_scaled, y, param_name="alpha",
+                Pipeline([("scaler", StandardScaler()), ("model", Ridge())]),
+                X, y, param_name="model__alpha",
                 param_range=param_range, cv=5, scoring="r2", n_jobs=-1
             )
             param_label = "α (log scale)"
@@ -1441,7 +1440,8 @@ elif section_key == "cv_generalization":
         elif val_model == "Lasso":
             param_range = np.logspace(-4, 1, 20)
             train_s, test_s = validation_curve(
-                Lasso(max_iter=10000), X_scaled, y, param_name="alpha",
+                Pipeline([("scaler", StandardScaler()), ("model", Lasso(max_iter=10000))]),
+                X, y, param_name="model__alpha",
                 param_range=param_range, cv=5, scoring="r2", n_jobs=-1
             )
             param_label = "α (log scale)"
@@ -1449,8 +1449,8 @@ elif section_key == "cv_generalization":
         else:
             param_range = np.arange(2, 25)
             train_s, test_s = validation_curve(
-                RandomForestRegressor(n_estimators=50, random_state=42, n_jobs=-1),
-                X_scaled, y, param_name="max_depth",
+                Pipeline([("scaler", StandardScaler()), ("model", RandomForestRegressor(n_estimators=50, random_state=42, n_jobs=-1))]),
+                X, y, param_name="model__max_depth",
                 param_range=param_range, cv=5, scoring="r2", n_jobs=-1
             )
             param_label = "max_depth"

--- a/mi_textbook_app.py
+++ b/mi_textbook_app.py
@@ -22,6 +22,7 @@ import matplotlib.pyplot as plt
 import matplotlib
 import plotly.express as px
 import plotly.graph_objects as go
+import plotly.io as pio
 from plotly.subplots import make_subplots
 
 from sklearn.model_selection import (
@@ -61,6 +62,20 @@ try:
 except Exception:
     pass
 plt.rcParams["axes.unicode_minus"] = False
+
+# Plotly 日本語フォント設定（中国語フォントへのフォールバックを防止）
+_JP_FONT = "Yu Gothic, YuGothic, Meiryo, Hiragino Sans, Hiragino Kaku Gothic ProN, Noto Sans JP, sans-serif"
+_plotly_template = pio.templates["plotly"]
+_plotly_template.layout.font = dict(family=_JP_FONT)
+pio.templates.default = "plotly"
+
+# Streamlit の Plotly テーマが上書きするため CSS でも強制指定
+st.markdown(f"""<style>
+.js-plotly-plot text, .js-plotly-plot .gtitle, .js-plotly-plot .xtitle,
+.js-plotly-plot .ytitle, .js-plotly-plot .legendtext {{
+    font-family: {_JP_FONT} !important;
+}}
+</style>""", unsafe_allow_html=True)
 
 # ---------------------------------------------------------------------------
 # 材料データセット生成
@@ -214,14 +229,48 @@ if dataset_choice == "鉄鋼（構造材料）":
     df_main = generate_steel_data()
     target_col = "降伏強度 (MPa)"
     dataset_desc = "鉄鋼合金の組成・プロセス条件から降伏強度を予測（OQMD参照）"
+    dataset_detail = """
+| 特徴量 | 説明 | 単位 | 範囲 |
+|:---|:---|:---|:---|
+| C (wt%) | 炭素含有量 — 強度に最も影響する元素 | wt% | 0.05–0.8 |
+| Mn (wt%) | マンガン — 固溶強化・靭性向上 | wt% | 0.3–2.0 |
+| Si (wt%) | ケイ素 — 脱酸・固溶強化 | wt% | 0.1–1.0 |
+| Cr (wt%) | クロム — 耐食性・焼入性向上 | wt% | 0–18 |
+| Ni (wt%) | ニッケル — 靭性・耐食性向上 | wt% | 0–10 |
+| 焼入温度 (°C) | オーステナイト化温度 | °C | 800–1200 |
+
+**目的変数**: 降伏強度 (MPa) — 材料が塑性変形を開始する応力値
+"""
 elif dataset_choice == "熱電材料（機能材料）":
     df_main = generate_thermoelectric_data()
     target_col = "性能指数 ZT"
     dataset_desc = "熱電材料の電子構造特徴から性能指数ZTを予測（Materials Project参照）"
+    dataset_detail = """
+| 特徴量 | 説明 | 単位 | 範囲 |
+|:---|:---|:---|:---|
+| キャリア濃度 log(cm⁻³) | 電荷キャリア密度の対数値 | log(cm⁻³) | 18–21 |
+| バンドギャップ (eV) | 電子の禁制帯幅 — 熱電性能の最適値が存在 | eV | 0.05–2.0 |
+| 有効質量 (m_e) | キャリアの有効質量 — ゼーベック係数に寄与 | m_e | 0.5–5.0 |
+| 格子熱伝導率 (W/mK) | フォノン輸送による熱伝導 — 低いほど高性能 | W/mK | 0.5–10 |
+| 測定温度 (K) | 熱電性能評価温度 | K | 300–900 |
+
+**目的変数**: 性能指数 ZT — 熱電変換効率を表す無次元数（ZT = S²σT/κ）
+"""
 else:
     df_main = generate_polymer_data()
     target_col = "ガラス転移温度 Tg (°C)"
     dataset_desc = "高分子の分子特徴からガラス転移温度を予測（PolyInfo参照）"
+    dataset_detail = """
+| 特徴量 | 説明 | 単位 | 範囲 |
+|:---|:---|:---|:---|
+| 分子量 log(g/mol) | 重量平均分子量の対数値 | log(g/mol) | 3–6 |
+| 主鎖柔軟性 | 高分子主鎖の回転しやすさ指標 | — | 0–10 |
+| 極性指標 | 側鎖の極性の強さ — 分子間力に影響 | — | 0–5 |
+| 架橋密度 | 架橋点の密度 — Tg上昇要因 | — | 0–3 |
+| 結晶化度 (%) | 結晶領域の割合 | % | 0–80 |
+
+**目的変数**: ガラス転移温度 Tg (°C) — 非晶質領域がガラス状態からゴム状態に転移する温度
+"""
 
 feature_cols = [c for c in df_main.columns if c != target_col]
 df_cls = generate_classification_data()
@@ -352,6 +401,8 @@ elif section_key == "data_exploration":
 
     # 2.1 データの確認
     st.header("2.1 データの概要")
+    st.markdown("#### データセットの説明")
+    st.markdown(dataset_detail)
     st.dataframe(df_main.head(20), use_container_width=True)
     st.markdown(f"データ数: **{len(df_main)}** 件、特徴量数: **{len(feature_cols)}** 個、目的変数: **{target_col}**")
 


### PR DESCRIPTION
## Summary

データリーク修正・フォント修正・データ説明追加の3点を含むPR。

### 1. データリーク修正（Pipeline化）
- Section 4/5: `train_test_split` → `scaler.fit(train_only)` → `scaler.transform(test)` に修正
- Section 7: 全モデルを `Pipeline([("scaler", StandardScaler()), ("model", ...)])` で包み、`cross_val_score` / `learning_curve` / `validation_curve` に raw data を渡す
- `validation_curve` の `param_name` を `"model__alpha"` (nested) に対応

### 2. Plotly 日本語フォント明示指定
- `pio.templates["plotly"].layout.font` に Yu Gothic/Meiryo/Hiragino Sans/Noto Sans JP を設定
- Streamlit テーマ上書き対策として CSS `!important` でも強制指定
- 中国語フォントへのフォールバックを防止

### 3. データセット説明追加
- Section 2（データ探索）に各データセットの特徴量テーブルを表示
- 鉄鋼: 6特徴量（組成5 + プロセス1）→ 降伏強度
- 熱電: 5特徴量（電子構造）→ ZT
- 高分子: 5特徴量（分子特徴）→ Tg

### 4. その他
- 未使用 import 削除（`seaborn`, `RandomForestClassifier`）
- `cross_val_predict` を top-level import に移動
- `install_guide.html` — 学生向け環境構築ガイド（Windows/macOS対応）

Link to Devin session: https://app.devin.ai/sessions/aea4d2995eae49449461fdc157823817
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->