### PR TITLE
fix: バグ監査修正 — 未使用import + k-meansスケーラー + R²負値注釈

### DIFF
--- a/install_guide.html
+++ b/install_guide.html
@@ -408,11 +408,15 @@
     <p>以下のコマンドを<strong>コピー＆ペースト</strong>して Enter を押してください：</p>
     <p><strong>Windows の場合：</strong></p>
     <div class="code-block">
-<span class="prompt">C:\...\machine-learning-main&gt;</span> pip install streamlit pandas numpy matplotlib seaborn plotly scikit-learn
+<span class="prompt">C:\...\machine-learning-main&gt;</span> pip install -r requirements.txt
     </div>
     <p><strong>macOS の場合：</strong></p>
     <div class="code-block">
-<span class="prompt">$</span> pip3 install streamlit pandas numpy matplotlib seaborn plotly scikit-learn
+<span class="prompt">$</span> pip3 install -r requirements.txt
+    </div>
+    <div class="info">
+        <code>requirements.txt</code> はアプリに必要な全パッケージが記載されたファイルです。
+        このコマンドで一括インストールされます。
     </div>
     <div class="warning">
         インストールには数分かかることがあります。画面にたくさんの文字が流れますが、
@@ -530,7 +534,7 @@ Ctrl + C
     <dd>
         <strong>対処法（Windows）</strong>：<code>pip</code> の代わりに <code>python -m pip</code> を使ってみてください：
         <div class="code-block">
-<span class="prompt">&gt;</span> python -m pip install streamlit pandas numpy matplotlib seaborn plotly scikit-learn
+<span class="prompt">&gt;</span> python -m pip install -r requirements.txt
         </div>
         <strong>対処法（macOS）</strong>：<code>pip3</code> を使ってください。
     </dd>
@@ -547,7 +551,7 @@ Ctrl + C
         スタートメニューで「cmd」と検索し、右クリック → 「管理者として実行」。<br>
         <strong>対処法（macOS）</strong>：コマンドの先頭に <code>sudo</code> を付けてください：
         <div class="code-block">
-<span class="prompt">$</span> sudo pip3 install streamlit pandas numpy matplotlib seaborn plotly scikit-learn
+<span class="prompt">$</span> sudo pip3 install -r requirements.txt
         </div>
         パスワードを求められたら、Mac のログインパスワードを入力してください（入力中は画面に何も表示されません）。
     </dd>

--- a/mi_textbook_app.py
+++ b/mi_textbook_app.py
@@ -45,7 +45,7 @@ from sklearn.cluster import KMeans
 from sklearn.decomposition import PCA
 from sklearn.metrics import (
     mean_squared_error, r2_score, mean_absolute_error,
-    classification_report, confusion_matrix, silhouette_score,
+    confusion_matrix, silhouette_score,
     accuracy_score
 )
 from sklearn.pipeline import Pipeline
@@ -672,6 +672,14 @@ elif section_key == "regression":
     col2.metric("RMSE", f"{rmse_lr:.2f}")
     col3.metric("MAE", f"{mae_lr:.2f}")
 
+    if r2_lr < 0:
+        st.warning(r"""
+        **R² が負値** — 線形回帰モデルが平均値予測よりも悪い結果です。
+        これは組成情報だけでは降伏強度の予測が困難であることを意味します
+        （降伏強度は熱処理・加工履歴にも強く依存するため）。
+        非線形モデル（SVR, Random Forest）との比較で改善を確認してください。
+        """)
+
     fig_lr = px.scatter(x=y_test, y=y_pred_lr,
                         labels={"x": f"実測値 ({target_col})", "y": "予測値"},
                         title=f"線形回帰: 予測 vs 実測 (R² = {r2_lr:.4f})")
@@ -1032,7 +1040,8 @@ elif section_key == "classification":
     """)
 
     n_clusters_km = st.slider("クラスタ数 k", 2, 8, 4, key="km_cls")
-    X_cls_scaled = scaler_cls.fit_transform(X_cls)
+    scaler_km = StandardScaler()
+    X_cls_scaled = scaler_km.fit_transform(X_cls)
     km = KMeans(n_clusters=n_clusters_km, random_state=42, n_init=10)
     km_labels = km.fit_predict(X_cls_scaled)
     sil = silhouette_score(X_cls_scaled, km_labels)

--- a/mi_textbook_app.py
+++ b/mi_textbook_app.py
@@ -673,10 +673,9 @@ elif section_key == "regression":
     col3.metric("MAE", f"{mae_lr:.2f}")
 
     if r2_lr < 0:
-        st.warning(r"""
+        st.warning(f"""
         **R² が負値** — 線形回帰モデルが平均値予測よりも悪い結果です。
-        これは組成情報だけでは降伏強度の予測が困難であることを意味します
-        （降伏強度は熱処理・加工履歴にも強く依存するため）。
+        これは現在の特徴量だけでは {target_col} の予測が困難であることを意味します。
         非線形モデル（SVR, Random Forest）との比較で改善を確認してください。
         """)
 

--- a/mi_textbook_requirements.txt
+++ b/mi_textbook_requirements.txt
@@ -1,0 +1,9 @@
+# MI講義アプリ 必要パッケージ
+# インストール: pip install -r requirements.txt
+
+streamlit>=1.30.0
+pandas>=2.0.0
+numpy>=1.24.0
+scikit-learn>=1.3.0
+matplotlib>=3.7.0
+plotly>=5.15.0


### PR DESCRIPTION
## Summary

静的コード解析で検出した3件を修正 + 配布用ファイル追加。

1. **未使用import削除**: `classification_report` — importされていたが全セクションで未使用
2. **k-meansスケーラー分離**: Section 5で `scaler_cls.fit_transform(X_cls)` が全データに再fitし、SVM用スケーラーを汚染していた → 独立した `scaler_km = StandardScaler()` に変更
3. **R²負値の注釈**: 線形回帰でR²<0の場合 `st.warning` で学生向け解説を表示（`target_col` を使いデータセット汎用）
4. **`mi_textbook_requirements.txt`追加**: MI講義アプリ専用の依存パッケージ一覧
5. **`install_guide.html`更新**: `pip install -r requirements.txt` を使う形に統一

Link to Devin session: https://app.devin.ai/sessions/aea4d2995eae49449461fdc157823817
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->