### PR TITLE
fix: .gitignore *.lock → few_shot_examples.lock に限定

### DIFF
--- a/l12-schema-graph-text2sql/.gitignore
+++ b/l12-schema-graph-text2sql/.gitignore
@@ -15,7 +15,7 @@ venv/
 # Generated artifacts
 *.pdf
 *.html
-*.lock
+few_shot_examples.lock
 
 # LaTeX build artifacts
 *.aux


### PR DESCRIPTION
## Summary

Devin Review指摘 (#298) への対応。`*.lock`パターンが広すぎて`poetry.lock`/`uv.lock`等の依存ロックファイルを誤除外するリスクがあったため、`few_shot_examples.lock`に限定。

Link to Devin session: https://app.devin.ai/sessions/5c4cf372d3d54d638f06fe4ed622b85b
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->