### PR TITLE
fix: repair_loop リテラル後処理追加 + site_label bool crash修正

### DIFF
--- a/l12-schema-graph-text2sql/llm/entity_extractor.py
+++ b/l12-schema-graph-text2sql/llm/entity_extractor.py
@@ -652,6 +652,10 @@ def extract_conditions(query: str) -> dict[str, Any]:
         if _site_b:
             sites.append('B-site')
         result['site_label'] = sites if len(sites) > 1 else sites[0]
+    elif result.get('site_label') is True:
+        # Generic 'サイト' keyword matched but no A/B prefix found;
+        # remove the boolean to avoid downstream crash in condition_mapper
+        del result['site_label']
 
     # Coverage score
     coverage = compute_coverage(query, result, terms)

--- a/l12-schema-graph-text2sql/llm/entity_extractor.py
+++ b/l12-schema-graph-text2sql/llm/entity_extractor.py
@@ -643,8 +643,8 @@ def extract_conditions(query: str) -> dict[str, Any]:
                     break
 
     # Site label extraction (A-site / B-site)
-    _site_a = re.search(r'[Aa]サイト|A[\-\s]?site', query)
-    _site_b = re.search(r'[Bb]サイト|B[\-\s]?site', query)
+    _site_a = re.search(r'[Aa]サイト|A[\-\s]?site', query, re.IGNORECASE)
+    _site_b = re.search(r'[Bb]サイト|B[\-\s]?site', query, re.IGNORECASE)
     if _site_a or _site_b:
         sites = []
         if _site_a:

--- a/l12-schema-graph-text2sql/llm/repair_loop.py
+++ b/l12-schema-graph-text2sql/llm/repair_loop.py
@@ -14,6 +14,8 @@ import time
 from pathlib import Path
 from typing import Any, Callable
 
+from llm.sql_generator import _fix_known_literals
+
 
 def _load_repair_template() -> str:
     path = Path(__file__).parent / "prompt_templates" / "sql_repair_prompt.md"
@@ -88,6 +90,8 @@ def attempt_repair(
         "You are a PostgreSQL expert for a materials science database. Fix the SQL.",
         model, api_key,
     )
+    if sql:
+        sql = _fix_known_literals(sql)
     return {
         "repaired_sql": sql if sql else original_sql,
         "repair_prompt": prompt,
@@ -326,7 +330,7 @@ def execution_repair_loop(
     allowed_joins: list[str],
     coverage: dict[str, Any] | None = None,
     conditions: dict[str, Any] | None = None,
-    max_retries: int = 2,
+    max_retries: int = 3,
     model: str | None = None,
     api_key: str | None = None,
     allow_empty_result: bool = False,


### PR DESCRIPTION
## Summary

Devin Review #297 で指摘された実バグ2件を修正。

**Bug 1: `repair_loop.attempt_repair()` が `_fix_known_literals` 未適用**

リペアループがLLMから再生成したSQLに `'A'`/`'PBE'` 等の旧リテラルが残り、DBで0行になる問題。`_fix_known_literals(sql)` を `attempt_repair` の返却前に適用。

**Bug 2: generic「サイト」で `site_label=True` → `AttributeError` crash**

`_EXTENDED_KEYWORDS` の `"サイト"` が generic に match → `result['site_label'] = True` (bool) → `condition_mapper._escape_sql_value(True)` で `.replace()` がなく crash。A/B prefix がない場合は `del result['site_label']` で boolean を除去。

**Also:** `execution_repair_loop` の `max_retries` デフォルトを 2→3 に統一（評価スクリプトと一致）。

Link to Devin session: https://app.devin.ai/sessions/5c4cf372d3d54d638f06fe4ed622b85b
Requested by: @minimumtone