### PR TITLE
fix: SQLGuard節・リペアループ記述12件を実装に統一

### DIFF
--- a/l12-schema-graph-text2sql/llm/sql_sanity_checker.py
+++ b/l12-schema-graph-text2sql/llm/sql_sanity_checker.py
@@ -1,9 +1,9 @@
 """Rule-based SQL sanity checker: detect structural mismatches between
 the user's query intent and the generated SQL.
 
-Unlike the LLM-based semantic checker, this uses deterministic rules
-for fast, reliable mismatch detection. Runs BEFORE execution and
-triggers re-generation when a clear structural error is detected.
+Uses deterministic rules for fast, reliable mismatch detection.
+Runs BEFORE execution and triggers re-generation when a clear
+structural error is detected.
 """
 from __future__ import annotations
 

--- a/l12-schema-graph-text2sql/paper/t2sql_materials_paper.tex
+++ b/l12-schema-graph-text2sql/paper/t2sql_materials_paper.tex
@@ -324,7 +324,7 @@ FK関係だけでなくドメイン知識に基づくJOINパス選択が可能�
 \node[stepbox, fill=cyan!12, right=of steiner] (llmgen) {制約付き\\ LLM SQL生成\\
   {\scriptsize gpt-5.5}};
 
-\node[stepbox, fill=red!10, right=of llmgen] (guard) {SQLGuard\\ 8層安全検証\\
+\node[stepbox, fill=red!10, right=of llmgen] (guard) {SQLGuard\\ 多層安全検証\\
   {\scriptsize \textcircled{\scriptsize 1}BL
   \textcircled{\scriptsize 2}SELECT
   \textcircled{\scriptsize 3}複文\\
@@ -358,7 +358,7 @@ FK関係だけでなくドメイン知識に基づくJOINパス選択が可能�
   自然言語クエリから条件抽出（Step 2）を経て、
   Steiner木近似（Step 3）が30テーブルから必要最小限のサブグラフを抽出する。
   抽出されたテーブル・カラム・JOIN条件をYAMLでLLMに注入し（Step 4）、
-  8層SQLGuard（Step 5）を経て安全なSQLFNを実行する。
+  多層SQLGuard（Step 5）を経て安全なSQLFNを実行する。
   LLMの視界が必要テーブルに限定されるため、
   不要JOINとテーブル幻覚が原理的に排除される。}
 \label{fig:step3_pipeline}
@@ -446,7 +446,7 @@ FK関係だけでなくドメイン知識に基づくJOINパス選択が可能�
 \node[module, fill=violet!15, right=1.0cm of coverage, yshift=-0.9cm] (llm) {LLM SQL生成\\{\scriptsize (\S\ref{sec:llm_mode})}\\{\scriptsize gpt-5.5}};
 
 % === Layer 5: Guard ===
-\node[module, fill=red!12, right=0.6cm of rb, yshift=-0.9cm] (guard) {SQLGuard\\8層検証\\{\scriptsize (\S\ref{sec:sql_guard})}\\{\scriptsize BL/SELECT/複文/関数/\\テーブル/カラム/JOIN/LIMIT}};
+\node[module, fill=red!12, right=0.6cm of rb, yshift=-0.9cm] (guard) {SQLGuard\\多層検証\\{\scriptsize (\S\ref{sec:sql_guard})}\\{\scriptsize BL/SELECT/複文/関数/\\テーブル/カラム/JOIN/LIMIT}};
 
 % === Layer 6: Output ===
 \node[module, fill=green!12, right=0.6cm of guard] (exec) {SQL実行\\結果返却\\{\scriptsize PostgreSQL}};
@@ -498,9 +498,9 @@ FK関係だけでなくドメイン知識に基づくJOINパス選択が可能�
   実線矢印は主要データフロー、破線矢印（橙色）はデータ参照・フィードバックループを示す。
   Coverage Scoreに基づきRule-based（高カバレッジ）またはLLM（低カバレッジ）経路に分岐し、
   いずれもSchema Graph（30テーブルFK走査）によるJOINパス制約と
-  SQLGuard 8層検証を経て安全なSQLが生成・実行される。
+  SQLGuard 多層検証を経て安全なSQLが生成・実行される。
   実行エラーまたは空結果が検出された場合は、
-  エラー診断情報付きでLLMにリペアを依頼するリペアループ（最大2回）が作動する。
+  エラー診断情報付きでLLMにリペアを依頼するリペアループ（最大3回）が作動する。
   成功したクエリペアはFew-Shot RAGストアに蓄積され、以降のLLM生成に活用される。}
 \label{fig:architecture}
 \end{figure*}
@@ -1096,11 +1096,10 @@ LaTeX原稿からの自動種事例抽出を実装した。
 本手法はCRUD操作のうち参照系（Read）のみを対象とし、
 生成SQLはSELECT文に限定される。
 Rule-basedモード・LLMモードを問わず、
-生成された全SQLはデータベース実行前に8層検証パイプラインを通過する。
-前稿の5層構成に対し、カラムホワイトリスト検証（層6）、
-FK整合JOIN検証（層7）、ガード判定分類（層8）を追加した。
+生成された全SQLはデータベース実行前に14種の検査から成る多層検証パイプラインを通過する。
+論理的に以下の8カテゴリに分類される。
 
-\subsubsection{基本安全性検証（層1--5）}
+\subsubsection{基本安全性検証（カテゴリ1--5）}
 
 \begin{enumerate}
   \item \textbf{複数文検出}：文字列リテラル除去後のSQL本体内にセミコロンがあれば拒否
@@ -1109,12 +1108,24 @@ FK整合JOIN検証（層7）、ガード判定分類（層8）を追加した。
   \item \textbf{禁止キーワード検出}：INSERT, UPDATE, DELETE, DROP, ALTER,
     TRUNCATE, CREATE, GRANT, REVOKE, COPYをワード境界正規表現で走査。
   \item \textbf{SELECT専用制約}：SELECTまたはWITHで始まらない文を拒否。
-  \item \textbf{テーブルホワイトリスト検証}：FROM/JOIN句の全テーブル名を抽出し、
-    \texttt{allowed\_schema.yaml}に存在するか検証。
-    未宣言テーブル（例：\texttt{secret\_passwords}）参照クエリは拒否。
+  \item \textbf{危険関数検出}：\texttt{pg\_sleep}, \texttt{dblink},
+    \texttt{lo\_import/export}, \texttt{pg\_read\_file}等の
+    ファイルシステムアクセス・遅延注入関数を検出し拒否。
   \item \textbf{自動LIMIT注入}：LIMIT句がなければ\texttt{LIMIT 10000}を付加し、
     無制限結果セットによる過剰メモリ・計算消費を防止。
 \end{enumerate}
+
+さらに以下の検査が独立に実行される：
+\textbf{システムテーブル検出}（\texttt{pg\_shadow}, \texttt{pg\_authid}等への参照を拒否）、
+\textbf{writable CTE検出}（WITH句内のINSERT/UPDATE/DELETEを拒否）、
+\textbf{トートロジー検出}（\texttt{OR 1=1}等のインジェクションパターンを拒否）、
+\textbf{サブクエリ深度検査}（ネスト深度が上限$d_{\max}=3$を超えるクエリを拒否）、
+\textbf{AST構文検証}（SQLGlotパーサーで構文エラーを検出）。
+合計14種の独立検査がカテゴリ1--5に包含される。
+
+\textbf{テーブルホワイトリスト検証}：FROM/JOIN句の全テーブル名を抽出し、
+\texttt{allowed\_schema.yaml}に存在するか検証。
+未宣言テーブル（例：\texttt{secret\_passwords}）参照クエリは拒否。
 
 \subsubsection{カラムホワイトリスト検証（層6）}
 \label{sec:column_wl}
@@ -1139,21 +1150,27 @@ Schema Graph走査（\ref{sec:schema_graph}節）が生成したJOIN経路と
   \item JOIN条件の欠落（Cartesian product リスク）
 \end{itemize}
 
-原則としてFKメタデータに存在する結合のみを許可する。
+非FK JOINを検出し警告する（拒否はせず、DB権限層に委ねる）。
 FKが存在しないが業務上必要な結合（将来のマスタテーブル拡張等）は、
-\texttt{allowed\_joins.yaml}に明示登録することで許可する拡張点を設けている。
+\texttt{allowed\_schema.yaml}の\texttt{allowed\_joins}キーに
+明示登録することで警告を抑制する拡張点を設けている。
 
 \subsubsection{ガード判定分類（層8）}
 \label{sec:guard_categories}
 
-8層検証の結果に基づき、生成SQLを以下の4カテゴリに分類する：
+多層検証の結果に基づき、生成SQLを以下の6分類値で判定する：
 
 \begin{enumerate}
-  \item \textbf{SAFE}：全層パス。実行可能。
-  \item \textbf{MODIFIED}：自動修正適用（LIMIT注入等）。修正後実行可能。
-  \item \textbf{BLOCKED}：安全性違反により実行拒否。ユーザーに理由を通知。
-  \item \textbf{WARNING}：軽微な逸脱（カラム幻覚疑い等）。実行するが警告付き。
+  \item \texttt{accepted}：全層パス。実行可能。
+  \item \texttt{modified}：自動修正適用（LIMIT注入等）。修正後実行可能。
+  \item \texttt{rejected\_security}：セキュリティ違反（禁止KW、DML、システムテーブル、トートロジー等）により拒否。
+  \item \texttt{rejected\_syntax}：AST解析エラーにより拒否。
+  \item \texttt{rejected\_schema}：スキーマ違反（未許可テーブル・カラム参照）により拒否。
+  \item \texttt{rejected\_complexity}：サブクエリ深度超過により拒否。
 \end{enumerate}
+
+これらに加え、\texttt{warnings}リスト（非FK JOIN検出、型安全警告、LIMIT付加通知）が
+分類値と独立に記録される。警告は実行を止めないが、ログとして保持される。
 
 層1--5の正規表現ベース検証に加え、SQLGlot~\citep{sqlglot2023}による
 AST（抽象構文木）レベルの構文検証を標準で併用する。
@@ -1214,7 +1231,7 @@ SQLが正常に実行され結果が0行となった場合、
     Schema Graph制約付きLLM生成にエスカレーション（Level 2、2.4--6.1秒）。
   \item \textbf{明確化要求（Coverage $< 0.5$）}：
     ユーザーに追加情報を要求。
-  \item \textbf{SQLガード}：生成モードによらず8層検証（\ref{sec:sql_guard}節）を常に適用。
+  \item \textbf{SQLガード}：生成モードによらず多層検証（\ref{sec:sql_guard}節）を常に適用。
 \end{enumerate}
 
 このアプローチは、辞書がカバーするクエリを
@@ -1279,7 +1296,7 @@ LLMによるSQL再生成を試みるリペアループを実装した。
 
 \subsubsection{失敗モードの分類}
 
-リペアループは以下の3種の失敗モードを区別する：
+リペアループは以下の4種の失敗モードを区別する：
 
 \begin{enumerate}
   \item \textbf{実行エラー}：PostgreSQLが返すランタイムエラー
@@ -1291,7 +1308,7 @@ LLMによるSQL再生成を試みるリペアループを実装した。
     未認識語彙リストを診断情報としてLLMに提供し、
     WHERE条件の緩和（完全一致$\to$ILIKE、値の正規化等）や
     JOIN経路の修正を促す。
-  \item \textbf{SQLGuard拒否}：8層検証で拒否されたSQL。
+  \item \textbf{SQLGuard拒否}：多層検証で拒否されたSQL。
     拒否理由（禁止テーブル、DML検出等）をフィードバックして再生成する。
   \item \textbf{SUPERSET検出}：クエリは正常に実行され結果が非空だが、
     返却行数が過大（WHERE条件数に対して不釣り合いに多い行を返却）な場合。
@@ -1305,7 +1322,7 @@ LLMによるSQL再生成を試みるリペアループを実装した。
 
 \subsubsection{リペアプロセス}
 
-リペアは最大2回まで試行する（初回生成を含め最大3回の実行機会）。
+リペアは最大3回まで試行する（初回生成を含め最大4回の実行機会）。
 各リペア試行では以下の情報をLLMに提供する：
 
 \begin{itemize}
@@ -2268,7 +2285,7 @@ precision/F1の併記が必要である。
 \subsubsection{ベースラインの公平性}
 \label{sec:fairness}
 
-リペアループ（リペア最大2回、初回生成を含め最大3回の実行機会）、
+リペアループ（リペア最大3回、初回生成を含め最大4回の実行機会）、
 Few-Shot RAG、出力スキーマ指定（Section~\ref{sec:output_schema_specifier}）、
 およびSQL構造整合性チェッカー（Section~\ref{sec:sql_sanity_checker}）は
 Proposedのみに適用されている。
@@ -2589,7 +2606,7 @@ NL $\to$ データ検索 $\to$ 材料設計仮説生成の
   \item \textbf{評価指標の改善}：
     共通カラム照合とLIMIT 10{,}000正規化の併用（合計+53.0pt）により、
     T2SQL評価におけるSELECT列差異とLIMIT切り詰めの影響を排除。
-  \item \textbf{回帰テスト125/125 PASS}：
+  \item \textbf{ユニットテスト125/125 PASS}：
     SQLインジェクション安全処理、Intent分類を含む
     安全性・頑健性テストに全件合格。
 \end{enumerate}
@@ -2629,7 +2646,7 @@ OQMDの開発・維持管理にあたるNorthwestern大学Wolvertonグループ�
 
 本研究で使用した検証データベース（5プロトタイプ1{,}470エントリ）のseedデータ、
 評価クエリ100件（gold SQL・期待結果セット）、
-5手法の実験結果CSV、回帰テスト39件、
+5手法の実験結果CSV、回帰テスト39件（付録S2掲載分。全ユニットテスト125件）、
 ソースコード一式（Schema Graph走査エンジン・SQLガード・条件抽出器・LLMモード）、
 および検証手順書（VERIFICATION\_GUIDE.md）は
 検証資材リポジトリに収録されている。

--- a/l12-schema-graph-text2sql/safety/sql_validator.py
+++ b/l12-schema-graph-text2sql/safety/sql_validator.py
@@ -657,6 +657,40 @@ def check_allowed_columns(
     return disallowed
 
 
+def _extract_aliases_from_sql(sql: str) -> dict[str, str]:
+    """Extract alias→table mappings from FROM/JOIN clauses in SQL.
+
+    Handles: FROM table alias, JOIN table alias ON ..., FROM table AS alias.
+    Falls back to identity (alias=table name) if no alias is found.
+    """
+    alias_map: dict[str, str] = {}
+    clean = _strip_literals(sql)
+    # FROM table [AS] alias
+    for m in re.finditer(
+        r"\bFROM\s+(\w+)(?:\s+AS\s+(\w+)|\s+(\w+))?",
+        clean, re.IGNORECASE,
+    ):
+        table = m.group(1).lower()
+        alias = (m.group(2) or m.group(3) or table).lower()
+        # Skip if "alias" is a SQL keyword
+        if alias.upper() in {"WHERE", "ON", "JOIN", "INNER", "LEFT", "RIGHT",
+                              "FULL", "CROSS", "ORDER", "GROUP", "HAVING",
+                              "LIMIT", "UNION", "EXCEPT", "INTERSECT"}:
+            alias = table
+        alias_map[alias] = table
+        alias_map[table] = table  # table name also resolves to itself
+    # JOIN table [AS] alias
+    for m in re.finditer(
+        r"\bJOIN\s+(\w+)(?:\s+AS\s+(\w+)|\s+(\w+))?\s+ON\b",
+        clean, re.IGNORECASE,
+    ):
+        table = m.group(1).lower()
+        alias = (m.group(2) or m.group(3) or table).lower()
+        alias_map[alias] = table
+        alias_map[table] = table
+    return alias_map
+
+
 def check_join_validity(
     sql: str,
     schema_path: Path | None = None,
@@ -678,36 +712,26 @@ def check_join_validity(
             j["source_table"].lower(),
             j["source_column"].lower(),
         ))
-    alias_to_table = {
-        "m": "material_entry", "c": "composition", "s": "structure",
-        "ps": "phase_stability", "calc": "calculation", "cp": "calculated_property",
-        "pd": "prototype_definition", "et": "elastic_tensor",
-        "tp": "thermal_property", "mp": "magnetic_property",
-        "se": "surface_energy", "gb": "grain_boundary",
-        "bs": "band_structure", "dos": "density_of_states",
-        "e": "element", "ep": "element_property",
-        "md": "material_defect", "dt": "defect_type",
-        "ms": "material_synthesis", "sm": "synthesis_method",
-        "lr": "literature_reference", "mr": "material_reference",
-        "ad": "application_domain", "ma": "material_application",
-        "em": "experimental_measurement", "mpr": "measured_property",
-        "pde": "phase_diagram_entry", "als": "alloy_system",
-        "mas": "material_alloy_system", "sg": "space_group",
-    }
+    alias_to_table = _extract_aliases_from_sql(sql)
     warnings: list[str] = []
-    # Match JOINs with or without explicit alias
+    clean = _strip_literals(sql)
+    # Match all ON conditions including AND-chained ones
     for m in re.finditer(
-        r"JOIN\s+(\w+)(?:\s+(\w+))?\s+ON\s+(\w+)\.(\w+)\s*=\s*(\w+)\.(\w+)",
-        _strip_literals(sql), re.IGNORECASE,
+        r"\bON\s+(.*?)(?=\s+(?:JOIN|WHERE|ORDER|GROUP|HAVING|LIMIT|UNION|$))",
+        clean, re.IGNORECASE | re.DOTALL,
     ):
-        alias1 = m.group(3).lower()
-        col1 = m.group(4).lower()
-        alias2 = m.group(5).lower()
-        col2 = m.group(6).lower()
-        t1 = alias_to_table.get(alias1, alias1)
-        t2 = alias_to_table.get(alias2, alias2)
-        if (t1, col1, t2, col2) not in valid_pairs:
-            warnings.append(f"Non-FK JOIN: {t1}.{col1} = {t2}.{col2}")
+        on_clause = m.group(1)
+        for cond in re.finditer(
+            r"(\w+)\.(\w+)\s*=\s*(\w+)\.(\w+)", on_clause
+        ):
+            alias1 = cond.group(1).lower()
+            col1 = cond.group(2).lower()
+            alias2 = cond.group(3).lower()
+            col2 = cond.group(4).lower()
+            t1 = alias_to_table.get(alias1, alias1)
+            t2 = alias_to_table.get(alias2, alias2)
+            if (t1, col1, t2, col2) not in valid_pairs:
+                warnings.append(f"Non-FK JOIN: {t1}.{col1} = {t2}.{col2}")
     return warnings
 
 

--- a/l12-schema-graph-text2sql/scripts/compute_paper_figures.py
+++ b/l12-schema-graph-text2sql/scripts/compute_paper_figures.py
@@ -54,9 +54,18 @@ def read_csv(path):
 
 
 def count_tables_in_sql(sql_text: str) -> int:
-    """gold SQL の FROM / JOIN 句から参照テーブル数を数える。"""
+    """gold SQL の FROM / JOIN 句から参照テーブル数を数える。
+
+    制約: CTE (WITH ... AS) の名前をテーブルとして誤計上する潜在弱点あり。
+    現行の gold SQL 100件に CTE・サブクエリ・EXISTS は皆無のため実害なし。
+    将来 CTE を含む gold SQL を追加する場合は WITH 句名の除外が必要。
+    """
     sql_upper = sql_text.upper()
     tables = set()
+    # Extract CTE names to exclude (future-proofing comment; no CTEs in current gold SQL)
+    cte_names: set[str] = set()
+    for m in re.finditer(r'\bWITH\s+(\w+)\s+AS\s*\(', sql_upper):
+        cte_names.add(m.group(1))
     # FROM table
     for m in re.finditer(r'\bFROM\s+(\w+)', sql_upper):
         tables.add(m.group(1))
@@ -65,6 +74,7 @@ def count_tables_in_sql(sql_text: str) -> int:
         tables.add(m.group(1))
     # remove common aliases / keywords that aren't tables
     tables -= {"SELECT", "WHERE", "AND", "OR", "ON", "AS", "LATERAL"}
+    tables -= cte_names
     return len(tables)
 
 

--- a/l12-schema-graph-text2sql/scripts/run_proposed_only.py
+++ b/l12-schema-graph-text2sql/scripts/run_proposed_only.py
@@ -191,7 +191,7 @@ def main():
         "execution_accuracy", "execution_precision", "execution_recall", "execution_f1",
         "raw_execution_accuracy", "raw_execution_precision", "raw_execution_f1",
         "hallucinated_table_rate", "hallucinated_column_rate", "hallucinated_join_rate",
-        "token_usage", "latency_ms", "repair_attempts", "repair_tokens",
+        "token_usage", "latency_ms", "sanity_regen", "repair_attempts", "repair_tokens",
     ]
 
     output_path = EVAL_DIR / "proposed_result.csv"
@@ -212,6 +212,7 @@ def main():
             sql = gen.get("sql", "")
             tokens = gen.get("tokens", 0)
             latency_ms = gen.get("latency_ms", 0)
+            sanity_regen = 0
             repair_attempts = 0
             repair_tokens = 0
 
@@ -232,7 +233,7 @@ def main():
                     if gen2.get("sql", ""):
                         sql = normalize_limit(gen2["sql"])
                         tokens += gen2.get("tokens", 0)
-                        repair_attempts += 1
+                        sanity_regen += 1
 
             exec_result = execute_sql(conn, sql) if sql else {"success": False, "rows": [], "row_count": 0}
 
@@ -324,6 +325,7 @@ def main():
                 "hallucinated_join_rate": h_join,
                 "token_usage": tokens,
                 "latency_ms": latency_ms,
+                "sanity_regen": sanity_regen,
                 "repair_attempts": repair_attempts,
                 "repair_tokens": repair_tokens,
             }
@@ -342,7 +344,7 @@ def main():
                 "hallucinated_table_rate": 0.0, "hallucinated_column_rate": 0.0,
                 "hallucinated_join_rate": 0.0,
                 "token_usage": 0, "latency_ms": 0,
-                "repair_attempts": 0, "repair_tokens": 0,
+                "sanity_regen": 0, "repair_attempts": 0, "repair_tokens": 0,
             })
 
     print(f"\n\nWriting results to {output_path}...")


### PR DESCRIPTION
## Summary

論文のSQLGuard節(sec:sql_guard)とリペアループ節の記述を実装(`safety/sql_validator.py`, `scripts/run_proposed_only.py`)に統一。

**重大:**
- リペア回数: 論文「最大2回(3実行機会)」→ コード`max_retries=3`に合わせ「最大3回(4実行機会)」。CSVにrepair_attempts=3の行が実在
- `repair_attempts`計上バグ: sanity checker再生成(L235 `+=1`)がリペアループ(L281 `= len(...)`)で上書き。→ `sanity_regen`列を新設し分離

**中:**
- 層7: 「FK結合のみ許可(→拒否)」→「非FK JOINを検出し警告。拒否はDB権限層」（実装の`check_join_validity`はwarningsに積むのみ）
- 層8分類: 論文の4カテゴリ(SAFE/MODIFIED/BLOCKED/WARNING)→ 実装の6分類値(`accepted`/`modified`/`rejected_security`/`_syntax`/`_schema`/`_complexity`) + 独立`warnings`リスト
- 「8層」→「14種検査の多層」: 危険関数/システムテーブル/writable CTE/トートロジー/サブクエリ深度/AST構文検証が論文から欠落していた
- `allowed_joins.yaml`(存在しない)→ `allowed_schema.yaml`内`allowed_joins`キー
- `check_join_validity`: 固定30テーブルエイリアス辞書 → `_extract_aliases_from_sql()`でSQL本文から動的抽出。AND複合ON条件の第2条件以降も検査

**軽:**
- 失敗モード「3種」→「4種」(SUPERSET追加時の直し漏れ)
- 「回帰テスト125/125」→「ユニットテスト125/125」(回帰は80件)
- `count_tables_in_sql`: CTE名除外ロジック追加(現goldにCTEなし→実害ゼロだが将来対策)
- `sql_sanity_checker.py` docstring: 削除済みLLM-based checkerへの言及を除去

Link to Devin session: https://app.devin.ai/sessions/5c4cf372d3d54d638f06fe4ed622b85b
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->