### PR TITLE
fix: Devin Review #307 — debye_temperature_k修正 + alias_map同期

### DIFF
--- a/l12-schema-graph-text2sql/llm/condition_mapper.py
+++ b/l12-schema-graph-text2sql/llm/condition_mapper.py
@@ -135,6 +135,9 @@ def map_sort_condition(sort_by: str, sort_order: str) -> dict[str, Any]:
             "structure": "s",
             "material_entry": "m",
             "composition": "c",
+            "elastic_tensor": "et",
+            "thermal_property": "tp",
+            "magnetic_property": "mp",
         }
         alias = alias_map.get(table, table[:2])
         order_sql = f"{alias}.{col} {sort_order.upper()}"
@@ -162,6 +165,9 @@ def map_numeric_condition(cond: dict[str, Any]) -> dict[str, Any]:
         "composition": "c",
         "calculation": "calc",
         "calculated_property": "cp",
+        "elastic_tensor": "et",
+        "thermal_property": "tp",
+        "magnetic_property": "mp",
     }
     if len(col_parts) == 2:
         table, col = col_parts

--- a/l12-schema-graph-text2sql/llm/entity_extractor.py
+++ b/l12-schema-graph-text2sql/llm/entity_extractor.py
@@ -235,9 +235,9 @@ _PROPERTY_COLUMN_MAP: dict[str, str] = {
     "shear_modulus_vrh": "elastic_tensor.shear_modulus_vrh",
     "弾性係数": "calculated_property.value",
     # Thermal properties
-    "debye_temperature": "thermal_property.debye_temperature",
-    "debye temperature": "thermal_property.debye_temperature",
-    "デバイ温度": "thermal_property.debye_temperature",
+    "debye_temperature": "thermal_property.debye_temperature_k",
+    "debye temperature": "thermal_property.debye_temperature_k",
+    "デバイ温度": "thermal_property.debye_temperature_k",
 }
 
 _UNIT_CONVERSION.update({

--- a/l12-schema-graph-text2sql/llm/sql_generator.py
+++ b/l12-schema-graph-text2sql/llm/sql_generator.py
@@ -280,7 +280,7 @@ def _rule_based_fallback(
         select_cols.append(f"{et_alias}.shear_modulus_vrh")
     if "thermal_property" in tables_needed:
         tp_alias = alias_map.get("thermal_property", "tp")
-        select_cols.append(f"{tp_alias}.debye_temperature")
+        select_cols.append(f"{tp_alias}.debye_temperature_k")
 
     sql_parts = [f"SELECT DISTINCT\n    {', '.join(select_cols)}"]
     sql_parts.append("FROM material_entry m")


### PR DESCRIPTION
## Summary

Devin Review #307 で発見された実バグ3件を修正。

1. **`debye_temperature` → `debye_temperature_k`**: DB実カラム名は `_k` suffix付き（`extended_schema.sql:263`）。`_PROPERTY_COLUMN_MAP` と rule-based SELECT の両方で修正。
2. **alias_map同期**: `condition_mapper.py` の `map_sort_condition` / `map_numeric_condition` に `elastic_tensor→et`, `thermal_property→tp`, `magnetic_property→mp` を追加。`sql_generator.py` の `alias_map` と一致させ、WHERE句で `th.debye_temperature_k` のような未定義エイリアス参照を防止。

125テスト PASS。

Link to Devin session: https://app.devin.ai/sessions/5c4cf372d3d54d638f06fe4ed622b85b
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->