### PR TITLE
fix: multi_hop_success rename follow-up — error fallback key/threshold修正

### DIFF
--- a/l12-schema-graph-text2sql/scripts/run_full_evaluation.py
+++ b/l12-schema-graph-text2sql/scripts/run_full_evaluation.py
@@ -557,7 +557,7 @@ def run_evaluation():
                     "hallucinated_table_rate": 0.0,
                     "hallucinated_column_rate": 0.0,
                     "hallucinated_join_rate": 0.0,
-                    "multi_hop": {"hop_count": hop_count, "is_multi_hop": hop_count >= 2, "correct": False},
+                    "multi_hop": {"n_tables": hop_count, "is_multi_hop": hop_count >= 3, "correct": False},
                     "token_usage": 0,
                     "latency_ms": 0,
                 })


### PR DESCRIPTION
## Summary

#309 で `multi_hop_success` の引数を `hop_count` → `n_tables` にリネームした際、`run_full_evaluation.py` L560 のエラーフォールバック辞書が追従漏れ:

```diff
- "multi_hop": {"hop_count": hop_count, "is_multi_hop": hop_count >= 2, ...}
+ "multi_hop": {"n_tables": hop_count, "is_multi_hop": hop_count >= 3, ...}
```

- キー名: `hop_count` → `n_tables`（`metrics.py` の返り値と一致）
- 閾値: `>= 2` → `>= 3`（multi-hop の定義は n_tables >= 3）

Devin Review #309 comment 2 の指摘対応。125テスト PASS。

Link to Devin session: https://app.devin.ai/sessions/5c4cf372d3d54d638f06fe4ed622b85b
Requested by: @minimumtone