### PR TITLE
fix: proposed_result.csvをrun2バイト同一に復元 + annotated版別出し + ZIP刈り込み

### DIFF
--- a/l12-schema-graph-text2sql/README_DELIVERY.md
+++ b/l12-schema-graph-text2sql/README_DELIVERY.md
@@ -9,6 +9,7 @@
 
 - **論文PDF** (`paper/t2sql_materials_paper.pdf`)
 - **評価結果CSV** (`evaluation/proposed_result*.csv`, `baseline_result.csv`)
+- **分析用注釈付CSV** (`evaluation/proposed_result_annotated.csv` — `n_tables`/`ntables_difficulty`/`original_difficulty`列付き。代表ランCSVはrun2とバイト同一を維持)
 - **Gold SQL** (`evaluation/gold_sql/` 100件)
 - **期待結果JSON** (`evaluation/expected_results/` 100件)
 - **材料分析CSV** (`evaluation/known_l12_recovery.csv`, `stable_l12_candidates.csv`, `gamma_prime_candidate_ranking.csv`, `ni3al_lattice_matched_candidates.csv`)

--- a/l12-schema-graph-text2sql/evaluation/proposed_result_annotated.csv
+++ b/l12-schema-graph-text2sql/evaluation/proposed_result_annotated.csv
@@ -1,10 +1,10 @@
-query_id,question,difficulty,hop_count,method,sql,syntax_valid,execution_valid,execution_accuracy,execution_precision,execution_recall,execution_f1,raw_execution_accuracy,raw_execution_precision,raw_execution_f1,hallucinated_table_rate,hallucinated_column_rate,hallucinated_join_rate,token_usage,latency_ms,repair_attempts,repair_tokens
+query_id,question,difficulty,hop_count,method,sql,syntax_valid,execution_valid,execution_accuracy,execution_precision,execution_recall,execution_f1,raw_execution_accuracy,raw_execution_precision,raw_execution_f1,hallucinated_table_rate,hallucinated_column_rate,hallucinated_join_rate,token_usage,latency_ms,repair_attempts,repair_tokens,n_tables,ntables_difficulty,original_difficulty
 q_easy_001,L1₂構造を持つ化合物を一覧にして。,easy,1,proposed,"SELECT DISTINCT m.formula, s.prototype, s.strukturbericht
 FROM material_entry m
 JOIN structure s ON s.entry_id = m.entry_id
 WHERE s.prototype = 'L12' OR s.strukturbericht = 'L12'
 ORDER BY m.formula
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2265,6619,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2265,6619,0,0,2,easy,easy
 q_easy_002,Niを含むL1₂型金属間化合物を抽出して。,easy,2,proposed,"SELECT DISTINCT m.formula, c.element, c.atomic_fraction
 FROM material_entry m
 JOIN composition c ON c.entry_id = m.entry_id
@@ -12,7 +12,7 @@ JOIN structure s ON s.entry_id = m.entry_id
 WHERE c.element = 'Ni'
   AND (s.prototype = 'L12' OR s.strukturbericht = 'L12')
 ORDER BY m.formula
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2785,14534,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2785,14534,0,0,3,medium,easy
 q_easy_003,A₃B型組成を持つ化合物を表示して。,easy,1,proposed,"SELECT DISTINCT m.formula, c.element, c.atomic_fraction
 FROM material_entry m
 JOIN composition c ON c.entry_id = m.entry_id
@@ -30,20 +30,20 @@ WHERE m.number_of_elements = 2
       AND ABS(composition.atomic_fraction - 0.25) < 0.000001
   )
 ORDER BY m.formula, c.atomic_fraction DESC, c.element
-LIMIT 10000;",True,True,1.0,0.9522058823529411,1.0,0.975517890772128,0.0,0.0,0.0,0.0,0.0,0.0,3096,22930,0,0
+LIMIT 10000;",True,True,1.0,0.9522058823529411,1.0,0.975517890772128,0.0,0.0,0.0,0.0,0.0,0.0,3096,22930,0,0,2,easy,easy
 q_easy_004,L12型化合物の格子定数を一覧にして。,easy,1,proposed,"SELECT m.formula, s.lattice_a
 FROM material_entry m
 JOIN structure s ON s.entry_id = m.entry_id
 WHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')
   AND s.lattice_a IS NOT NULL
 ORDER BY m.formula
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,3148,3542,1,1017
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,3148,3542,1,1017,2,easy,easy
 q_easy_005,Coを含む化合物を表示して。,easy,1,proposed,"SELECT DISTINCT m.formula, c.element, c.atomic_fraction
 FROM material_entry m
 JOIN composition c ON c.entry_id = m.entry_id
 WHERE c.element = 'Co'
 ORDER BY m.formula
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2353,4528,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2353,4528,0,0,2,easy,easy
 q_easy_006,cubic構造の化合物を一覧にして。,easy,1,proposed,"SELECT DISTINCT
     m.formula,
     s.crystal_system
@@ -51,7 +51,7 @@ FROM material_entry m
 JOIN structure s ON s.entry_id = m.entry_id
 WHERE s.crystal_system = 'cubic'
 ORDER BY m.formula
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2138,3093,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2138,3093,0,0,2,easy,easy
 q_easy_007,L1₂型化合物のリストを出して。,easy,1,proposed,"SELECT DISTINCT
     m.formula,
     s.prototype,
@@ -61,17 +61,17 @@ JOIN structure s ON s.entry_id = m.entry_id
 WHERE s.prototype = 'L12'
    OR s.strukturbericht = 'L12'
 ORDER BY m.formula
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2343,6444,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2343,6444,0,0,2,easy,easy
 q_easy_008,Alを含む化合物を抽出して。,easy,1,proposed,"SELECT DISTINCT m.formula, c.element, c.atomic_fraction
 FROM material_entry m
 JOIN composition c ON c.entry_id = m.entry_id
 WHERE c.element = 'Al'
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2302,3829,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2302,3829,0,0,2,easy,easy
 q_easy_009,空間群番号221の化合物を表示して。,easy,1,proposed,"SELECT DISTINCT m.formula, s.space_group_number
 FROM material_entry m
 JOIN structure s ON s.entry_id = m.entry_id
 WHERE s.space_group_number = 221
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2289,4262,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2289,4262,0,0,2,easy,easy
 q_easy_010,Tiを含むL1₂型化合物を一覧にして。,easy,2,proposed,"SELECT DISTINCT m.formula, c.element, c.atomic_fraction
 FROM material_entry m
 JOIN composition c ON c.entry_id = m.entry_id
@@ -79,21 +79,21 @@ JOIN structure s ON s.entry_id = m.entry_id
 WHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')
   AND c.element = 'Ti'
 ORDER BY m.formula
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2553,9537,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2553,9537,0,0,3,medium,easy
 q_easy_011,全化合物のformula一覧を出して。,easy,0,proposed,"SELECT m.formula
 FROM material_entry m
 ORDER BY m.formula
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2057,3201,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2057,3201,0,0,1,easy,easy
 q_easy_012,L12型化合物の数を教えて。,easy,1,proposed,"SELECT COUNT(*) AS count
 FROM material_entry m
 JOIN structure s ON s.entry_id = m.entry_id
 WHERE s.prototype = 'L12' OR s.strukturbericht = 'L12'
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,2096,2284,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,2096,2284,0,0,2,easy,easy
 q_easy_013,Ptを含む化合物を表示して。,easy,1,proposed,"SELECT DISTINCT m.formula, c.element, c.atomic_fraction
 FROM material_entry m
 JOIN composition c ON c.entry_id = m.entry_id
 WHERE c.element = 'Pt'
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2292,3629,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2292,3629,0,0,2,easy,easy
 q_easy_014,NiとAlの両方を含む化合物を抽出して。,easy,1,proposed,"SELECT DISTINCT m.formula
 FROM material_entry m
 WHERE EXISTS (
@@ -109,43 +109,43 @@ AND EXISTS (
       AND c.element = 'Al'
 )
 ORDER BY m.formula
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2561,10351,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2561,10351,0,0,2,easy,easy
 q_easy_015,Gaを含むL1₂型化合物を表示して。,easy,2,proposed,"SELECT DISTINCT m.formula, c.element, c.atomic_fraction, s.prototype
 FROM material_entry m
 JOIN composition c ON c.entry_id = m.entry_id
 JOIN structure s ON s.entry_id = m.entry_id
 WHERE c.element = 'Ga'
   AND (s.prototype = 'L12' OR s.strukturbericht = 'L12')
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2456,6947,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2456,6947,0,0,3,medium,easy
 q_easy_016,Feを含む化合物を一覧にして。,easy,1,proposed,"SELECT DISTINCT m.formula, c.element, c.atomic_fraction
 FROM material_entry m
 JOIN composition c ON c.entry_id = m.entry_id
 WHERE c.element = 'Fe'
 ORDER BY m.formula
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2345,6732,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2345,6732,0,0,2,easy,easy
 q_easy_017,Aサイトの元素を一覧にして。,easy,1,proposed,"SELECT DISTINCT c.element, c.site_label
 FROM composition c
 WHERE c.site_label = 'A-site'
 ORDER BY c.element
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,2143,2565,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,2143,2565,0,0,1,easy,easy
 q_easy_018,化合物の元素系を表示して。,easy,0,proposed,"SELECT m.formula, m.chemical_system
 FROM material_entry m
 ORDER BY m.chemical_system, m.formula
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2212,3131,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2212,3131,0,0,1,easy,easy
 q_easy_019,L1₂型でcubic構造の化合物を出して。,easy,1,proposed,"SELECT DISTINCT m.formula, s.prototype, s.strukturbericht, s.crystal_system
 FROM material_entry m
 JOIN structure s ON s.entry_id = m.entry_id
 WHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')
   AND s.crystal_system = 'cubic'
 ORDER BY m.formula
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2313,4597,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2313,4597,0,0,2,easy,easy
 q_easy_020,Wを含むL1₂型化合物を表示して。,easy,2,proposed,"SELECT DISTINCT m.formula, c.element, c.atomic_fraction
 FROM material_entry m
 JOIN composition c ON c.entry_id = m.entry_id
 JOIN structure s ON s.entry_id = m.entry_id
 WHERE c.element = 'W'
   AND (s.prototype = 'L12' OR s.strukturbericht = 'L12')
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2561,9794,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2561,9794,0,0,3,medium,easy
 q_medium_001,Niを含む安定なL1₂型化合物を抽出して。,medium,3,proposed,"SELECT DISTINCT
   m.formula,
   c.element,
@@ -160,7 +160,7 @@ WHERE c.element = 'Ni'
   AND ps.is_stable = TRUE
   AND (s.prototype = 'L12' OR s.strukturbericht = 'L12')
 ORDER BY m.formula
-LIMIT 10000;",True,True,1.0,0.4,1.0,0.5714285714285715,0.0,0.0,0.0,0.0,0.0,0.0,2879,13514,0,0
+LIMIT 10000;",True,True,1.0,0.4,1.0,0.5714285714285715,0.0,0.0,0.0,0.0,0.0,0.0,2879,13514,0,0,4,hard,medium
 q_medium_002,形成エネルギーが負のL1₂型化合物を元素組み合わせごとに整理して。,medium,2,proposed,"SELECT DISTINCT
     m.chemical_system,
     m.formula,
@@ -174,7 +174,7 @@ WHERE
 ORDER BY
     m.chemical_system ASC,
     ps.formation_energy_per_atom ASC
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2667,8434,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2667,8434,0,0,3,medium,medium
 q_medium_003,Alを含む安定なL1₂型金属間化合物を抽出して。,medium,3,proposed,"SELECT DISTINCT m.formula, c.element, c.atomic_fraction, ps.is_stable, ps.energy_above_hull
 FROM material_entry m
 JOIN composition c ON c.entry_id = m.entry_id
@@ -183,7 +183,7 @@ JOIN structure s ON s.entry_id = m.entry_id
 WHERE c.element = 'Al'
   AND ps.is_stable = TRUE
   AND (s.prototype = 'L12' OR s.strukturbericht = 'L12')
-LIMIT 10000;",True,True,1.0,0.6,1.0,0.7499999999999999,0.0,0.0,0.0,0.0,0.0,0.0,2614,8456,0,0
+LIMIT 10000;",True,True,1.0,0.6,1.0,0.7499999999999999,0.0,0.0,0.0,0.0,0.0,0.0,2614,8456,0,0,4,hard,medium
 q_medium_004,Ni₃Alに近い格子定数を持つL1₂化合物を探して。,medium,2,proposed,"SELECT DISTINCT
     m.formula,
     s.lattice_a,
@@ -206,7 +206,7 @@ WHERE
           AND c.element = 'Al'
     )
 ORDER BY lattice_diff ASC
-LIMIT 10000;",True,True,0.002551020408163265,1.0,0.002551020408163265,0.0050890585241730275,0.002551020408163265,1.0,0.0050890585241730275,0.0,0.0,0.0,4252,7886,1,1508
+LIMIT 10000;",True,True,0.002551020408163265,1.0,0.002551020408163265,0.0050890585241730275,0.002551020408163265,1.0,0.0050890585241730275,0.0,0.0,0.0,4252,7886,1,1508,2,easy,medium
 q_medium_005,安定なL1₂型化合物を形成エネルギーが低い順に出して。,medium,2,proposed,"SELECT DISTINCT
     m.formula,
     ps.formation_energy_per_atom,
@@ -219,7 +219,7 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.is_stable = TRUE
 ORDER BY ps.formation_energy_per_atom ASC
-LIMIT 10000;",True,True,1.0,0.21621621621621623,1.0,0.35555555555555557,1.0,0.21621621621621623,0.35555555555555557,0.0,0.0,0.0,2691,8493,0,0
+LIMIT 10000;",True,True,1.0,0.21621621621621623,1.0,0.35555555555555557,1.0,0.21621621621621623,0.35555555555555557,0.0,0.0,0.0,2691,8493,0,0,3,medium,medium
 q_medium_006,準安定なL1₂型化合物を抽出して。,medium,2,proposed,"SELECT DISTINCT m.formula, ps.is_stable, ps.energy_above_hull
 FROM material_entry m
 JOIN phase_stability ps ON ps.entry_id = m.entry_id
@@ -228,7 +228,7 @@ WHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')
   AND ps.is_stable = FALSE
   AND ps.energy_above_hull <= 0.05
 ORDER BY ps.energy_above_hull ASC
-LIMIT 10000;",True,True,0.8449197860962567,1.0,0.8449197860962567,0.9159420289855073,0.0,0.0,0.0,0.0,0.0,0.0,2821,10554,0,0
+LIMIT 10000;",True,True,0.8449197860962567,1.0,0.8449197860962567,0.9159420289855073,0.0,0.0,0.0,0.0,0.0,0.0,2821,10554,0,0,3,medium,medium
 q_medium_007,L1₂型化合物の形成エネルギー分布を教えて。,medium,2,proposed,"SELECT DISTINCT
     m.formula,
     ps.formation_energy_per_atom
@@ -239,7 +239,7 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.formation_energy_per_atom IS NOT NULL
 ORDER BY ps.formation_energy_per_atom ASC
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,3603,6787,1,1165
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,3603,6787,1,1165,3,medium,medium
 q_medium_008,Co含有L1₂型化合物を安定性の高い順に表示して。,medium,3,proposed,"SELECT DISTINCT m.formula, s.prototype, ps.is_stable, ps.energy_above_hull
 FROM material_entry m
 JOIN composition c ON c.entry_id = m.entry_id
@@ -248,7 +248,7 @@ JOIN phase_stability ps ON ps.entry_id = m.entry_id
 WHERE c.element = 'Co'
   AND (s.prototype = 'L12' OR s.strukturbericht = 'L12')
 ORDER BY ps.is_stable DESC, ps.energy_above_hull ASC
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2956,11645,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2956,11645,0,0,4,hard,medium
 q_medium_009,格子定数が3.5Å以上のL1₂化合物を出して。,medium,2,proposed,"SELECT DISTINCT
     m.formula,
     s.lattice_a
@@ -258,7 +258,7 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND s.lattice_a >= 3.5
 ORDER BY s.lattice_a ASC
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,2291,4350,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,2291,4350,0,0,2,easy,medium
 q_medium_010,NiまたはCoを含むL1₂型化合物を一覧にして。,medium,2,proposed,"SELECT DISTINCT m.formula, c.element, c.atomic_fraction
 FROM material_entry m
 JOIN composition c ON c.entry_id = m.entry_id
@@ -266,7 +266,7 @@ JOIN structure s ON s.entry_id = m.entry_id
 WHERE c.element IN ('Ni', 'Co')
   AND (s.prototype = 'L12' OR s.strukturbericht = 'L12')
 ORDER BY m.formula, c.element
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2424,6418,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2424,6418,0,0,3,medium,medium
 q_medium_011,形成エネルギーが-0.4以下のL1₂型化合物を出して。,medium,2,proposed,"SELECT DISTINCT m.formula, ps.formation_energy_per_atom
 FROM material_entry m
 JOIN phase_stability ps ON ps.entry_id = m.entry_id
@@ -274,7 +274,7 @@ JOIN structure s ON s.entry_id = m.entry_id
 WHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')
   AND ps.formation_energy_per_atom <= -0.4
 ORDER BY ps.formation_energy_per_atom ASC
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,2544,5519,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,2544,5519,0,0,3,medium,medium
 q_medium_012,energy above hullが0.01以下のL1₂型化合物を表示して。,medium,2,proposed,"SELECT DISTINCT m.formula, ps.energy_above_hull, ps.is_stable
 FROM material_entry m
 JOIN phase_stability ps ON ps.entry_id = m.entry_id
@@ -282,7 +282,7 @@ JOIN structure s ON s.entry_id = m.entry_id
 WHERE ps.energy_above_hull <= 0.01
   AND (s.prototype = 'L12' OR s.strukturbericht = 'L12')
 ORDER BY ps.energy_above_hull ASC
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2398,4562,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2398,4562,0,0,3,medium,medium
 q_medium_013,Ti含有L1₂型化合物の格子定数と形成エネルギーを表示して。,medium,3,proposed,"SELECT DISTINCT
     m.formula,
     s.lattice_a,
@@ -296,14 +296,14 @@ WHERE c.element = 'Ti'
   AND s.lattice_a IS NOT NULL
   AND ps.formation_energy_per_atom IS NOT NULL
 ORDER BY m.formula
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,3804,5682,1,1379
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,3804,5682,1,1379,4,hard,medium
 q_medium_014,L1₂化合物の格子定数を小さい順にソートして。,medium,2,proposed,"SELECT m.formula, s.lattice_a
 FROM material_entry m
 JOIN structure s ON s.entry_id = m.entry_id
 WHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')
   AND s.lattice_a IS NOT NULL
 ORDER BY s.lattice_a ASC
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,3255,3357,1,961
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,3255,3357,1,961,2,easy,medium
 q_medium_015,化学系Al-Niに属するL1₂化合物を抽出して。,medium,2,proposed,"SELECT DISTINCT
   m.formula,
   m.chemical_system,
@@ -314,7 +314,7 @@ JOIN structure s ON s.entry_id = m.entry_id
 WHERE m.chemical_system = 'Al-Ni'
   AND (s.prototype = 'L12' OR s.strukturbericht = 'L12')
 ORDER BY m.formula
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2543,6647,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2543,6647,0,0,2,easy,medium
 q_medium_016,安定で格子定数が3.6Å未満のL1₂化合物を出して。,medium,2,proposed,"SELECT DISTINCT
     m.formula,
     ps.is_stable,
@@ -328,7 +328,7 @@ WHERE
     AND ps.is_stable = TRUE
     AND s.lattice_a < 3.6
 ORDER BY s.lattice_a ASC
-LIMIT 10000;",True,True,1.0,0.18181818181818182,1.0,0.3076923076923077,0.0,0.0,0.0,0.0,0.0,0.0,2447,3563,0,0
+LIMIT 10000;",True,True,1.0,0.18181818181818182,1.0,0.3076923076923077,0.0,0.0,0.0,0.0,0.0,0.0,2447,3563,0,0,3,medium,medium
 q_medium_017,Nbを含むL1₂型化合物の安定性情報を出して。,medium,3,proposed,"SELECT DISTINCT
   m.formula,
   ps.is_stable,
@@ -340,7 +340,7 @@ JOIN structure s ON s.entry_id = m.entry_id
 JOIN phase_stability ps ON ps.entry_id = m.entry_id
 WHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')
   AND c.element = 'Nb'
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2680,8775,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2680,8775,0,0,4,hard,medium
 q_medium_018,Scを含むL1₂型化合物を格子定数と共に表示して。,medium,2,proposed,"SELECT DISTINCT m.formula, s.lattice_a
 FROM material_entry m
 JOIN composition c ON c.entry_id = m.entry_id
@@ -348,7 +348,7 @@ JOIN structure s ON s.entry_id = m.entry_id
 WHERE c.element = 'Sc'
   AND (s.prototype = 'L12' OR s.strukturbericht = 'L12')
 ORDER BY m.formula
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,2581,6832,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,2581,6832,0,0,3,medium,medium
 q_medium_019,L1₂型化合物のうちis_stableがtrueのものを出して。,medium,2,proposed,"SELECT DISTINCT m.formula, ps.is_stable, ps.energy_above_hull
 FROM material_entry m
 JOIN structure s ON s.entry_id = m.entry_id
@@ -356,14 +356,14 @@ JOIN phase_stability ps ON ps.entry_id = m.entry_id
 WHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')
   AND ps.is_stable = TRUE
 ORDER BY m.formula ASC
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,2450,4471,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,2450,4471,0,0,3,medium,medium
 q_medium_020,Ni-Al系以外のL1₂型化合物を一覧にして。,medium,2,proposed,"SELECT DISTINCT m.formula, m.chemical_system, s.prototype, s.strukturbericht
 FROM material_entry m
 JOIN structure s ON s.entry_id = m.entry_id
 WHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')
   AND (m.chemical_system IS NULL OR m.chemical_system NOT IN ('Ni-Al', 'Al-Ni'))
 ORDER BY m.chemical_system, m.formula
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2717,12409,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2717,12409,0,0,2,easy,medium
 q_medium_021,Aサイト元素ごとのL1₂型化合物数を集計して。,medium,2,proposed,"SELECT c.element, COUNT(*) AS l12_compound_count
 FROM material_entry m
 JOIN composition c ON c.entry_id = m.entry_id
@@ -372,14 +372,14 @@ WHERE c.site_label = 'A-site'
   AND (s.prototype = 'L12' OR s.strukturbericht = 'L12')
 GROUP BY c.element
 ORDER BY l12_compound_count DESC, c.element
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,2580,9565,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,2580,9565,0,0,3,medium,medium
 q_medium_022,形成エネルギーが最も低いL1₂型化合物TOP5を出して。,medium,2,proposed,"SELECT DISTINCT m.formula, ps.formation_energy_per_atom
 FROM material_entry m
 JOIN phase_stability ps ON ps.entry_id = m.entry_id
 JOIN structure s ON s.entry_id = m.entry_id
 WHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')
 ORDER BY ps.formation_energy_per_atom ASC
-LIMIT 5;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,2500,4736,0,0
+LIMIT 5;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,2500,4736,0,0,3,medium,medium
 q_medium_023,格子定数が4.0Å以上のL1₂化合物を出して。,medium,2,proposed,"SELECT DISTINCT
     m.formula,
     s.lattice_a
@@ -388,7 +388,7 @@ JOIN structure s ON s.entry_id = m.entry_id
 WHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')
   AND s.lattice_a >= 4.0
 ORDER BY s.lattice_a ASC
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,2299,4389,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,2299,4389,0,0,2,easy,medium
 q_medium_024,Pdを含むL1₂型化合物を形成エネルギー順に出して。,medium,3,proposed,"SELECT DISTINCT
     m.formula,
     c.element,
@@ -401,7 +401,7 @@ JOIN phase_stability ps ON ps.entry_id = m.entry_id
 WHERE c.element = 'Pd'
   AND (s.prototype = 'L12' OR s.strukturbericht = 'L12')
 ORDER BY ps.formation_energy_per_atom ASC
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2754,9275,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2754,9275,0,0,4,hard,medium
 q_medium_025,Cu含有のL1₂型化合物を安定性で分類して。,medium,3,proposed,"SELECT DISTINCT m.formula, ps.is_stable, ps.energy_above_hull
 FROM material_entry m
 JOIN composition c ON c.entry_id = m.entry_id
@@ -410,7 +410,7 @@ JOIN phase_stability ps ON ps.entry_id = m.entry_id
 WHERE c.element = 'Cu'
   AND (s.prototype = 'L12' OR s.strukturbericht = 'L12')
 ORDER BY ps.is_stable DESC, ps.energy_above_hull ASC
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2659,10665,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2659,10665,0,0,4,hard,medium
 q_medium_026,Bサイト元素ごとの平均形成エネルギーを出して。,medium,2,proposed,"SELECT
   c.element,
   AVG(ps.formation_energy_per_atom) AS avg_eform
@@ -420,14 +420,14 @@ JOIN phase_stability ps ON ps.entry_id = m.entry_id
 WHERE c.site_label = 'B-site'
 GROUP BY c.element
 ORDER BY c.element
-LIMIT 10000;",True,True,0.045454545454545456,0.045454545454545456,0.045454545454545456,0.045454545454545456,0.045454545454545456,0.045454545454545456,0.045454545454545456,0.0,0.0,0.0,2369,4853,0,0
+LIMIT 10000;",True,True,0.045454545454545456,0.045454545454545456,0.045454545454545456,0.045454545454545456,0.045454545454545456,0.045454545454545456,0.045454545454545456,0.0,0.0,0.0,2369,4853,0,0,4,hard,medium
 q_medium_027,格子体積が12Å³/atom以下のL1₂化合物を出して。,medium,2,proposed,"SELECT DISTINCT m.formula, s.volume_per_atom
 FROM material_entry m
 JOIN structure s ON s.entry_id = m.entry_id
 WHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')
   AND s.volume_per_atom <= 12
 ORDER BY s.volume_per_atom ASC
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,2337,3930,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,2337,3930,0,0,2,easy,medium
 q_medium_028,Ir含有L1₂型化合物の一覧を出して。,medium,2,proposed,"SELECT DISTINCT m.formula, s.prototype, s.strukturbericht
 FROM material_entry m
 JOIN composition c ON c.entry_id = m.entry_id
@@ -435,14 +435,14 @@ JOIN structure s ON s.entry_id = m.entry_id
 WHERE c.element = 'Ir'
   AND (s.prototype = 'L12' OR s.strukturbericht = 'L12')
 ORDER BY m.formula
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2370,5992,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2370,5992,0,0,3,medium,medium
 q_medium_029,2元素系のL1₂型化合物をchemical_systemで分類して。,medium,2,proposed,"SELECT m.chemical_system, m.formula
 FROM material_entry m
 JOIN structure s ON s.entry_id = m.entry_id
 WHERE m.number_of_elements = 2
   AND (s.prototype = 'L12' OR s.strukturbericht = 'L12')
 ORDER BY m.chemical_system ASC, m.formula ASC
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2270,6749,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2270,6749,0,0,2,easy,medium
 q_medium_030,安定なL1₂型化合物のうち格子定数が大きい順に並べて。,medium,2,proposed,"SELECT DISTINCT
   m.formula,
   s.prototype,
@@ -455,7 +455,7 @@ JOIN phase_stability ps ON ps.entry_id = m.entry_id
 WHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')
   AND ps.is_stable = TRUE
 ORDER BY s.lattice_a DESC
-LIMIT 10000;",True,True,1.0,0.21621621621621623,1.0,0.35555555555555557,0.0,0.0,0.0,0.0,0.0,0.0,2705,7976,0,0
+LIMIT 10000;",True,True,1.0,0.21621621621621623,1.0,0.35555555555555557,0.0,0.0,0.0,0.0,0.0,0.0,2705,7976,0,0,3,medium,medium
 q_hard_001,Ni基超合金のγ'相候補として有望な、安定または準安定なL1₂型化合物を抽出して。,hard,3,proposed,"SELECT DISTINCT
     m.formula,
     c.atomic_fraction AS ni_atomic_fraction,
@@ -473,7 +473,7 @@ WHERE
 ORDER BY
     ps.energy_above_hull ASC,
     c.atomic_fraction DESC
-LIMIT 10000;",True,True,0.06153846153846154,1.0,0.06153846153846154,0.11594202898550725,0.0,0.0,0.0,0.0,0.0,0.0,3064,11989,0,0
+LIMIT 10000;",True,True,0.06153846153846154,1.0,0.06153846153846154,0.11594202898550725,0.0,0.0,0.0,0.0,0.0,0.0,3064,11989,0,0,3,medium,hard
 q_hard_002,L1₂型化合物において、Aサイト元素とBサイト元素の組み合わせが形成エネルギーに与える傾向を調べて。,hard,3,proposed,"SELECT DISTINCT
   m.formula,
   c.element AS a_site,
@@ -499,7 +499,7 @@ WHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')
       AND composition.site_label = 'B-site'
   )
 ORDER BY a_site, b_site, formation_energy_per_atom
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,4809,23449,1,1360
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,4809,23449,1,1360,4,hard,hard
 q_hard_003,L1₂構造を持つ化合物のうち、格子定数がNi₃Alに近く、形成エネルギーが低い候補を抽出して。,hard,3,proposed,"SELECT DISTINCT
     m.formula,
     s.lattice_a,
@@ -527,7 +527,7 @@ WHERE
 ORDER BY
     ABS(s.lattice_a - 3.57) ASC,
     ps.formation_energy_per_atom ASC
-LIMIT 10000;",True,True,0.009433962264150943,1.0,0.009433962264150943,0.018691588785046728,0.009433962264150943,1.0,0.018691588785046728,0.0,0.0,0.0,4515,9048,1,1688
+LIMIT 10000;",True,True,0.009433962264150943,1.0,0.009433962264150943,0.018691588785046728,0.009433962264150943,1.0,0.018691588785046728,0.0,0.0,0.0,4515,9048,1,1688,3,medium,hard
 q_hard_004,安定なL1₂型化合物のバルクモジュラスを高い順に表示して。,hard,4,proposed,"SELECT DISTINCT
   m.formula,
   ps.is_stable,
@@ -542,7 +542,7 @@ WHERE
   AND ps.is_stable = TRUE
   AND et.bulk_modulus_vrh IS NOT NULL
 ORDER BY et.bulk_modulus_vrh DESC
-LIMIT 10000;",True,True,0.375,0.2,0.375,0.26086956521739135,0.0,0.0,0.0,0.0,0.0,0.0,2766,8021,0,0
+LIMIT 10000;",True,True,0.375,0.2,0.375,0.26086956521739135,0.0,0.0,0.0,0.0,0.0,0.0,2766,8021,0,0,5,very_hard,hard
 q_hard_005,NiまたはCoを含む安定なL1₂化合物を形成エネルギー順に並べて。,hard,3,proposed,"SELECT DISTINCT
     m.formula,
     ps.formation_energy_per_atom,
@@ -558,7 +558,7 @@ WHERE
     AND ps.formation_energy_per_atom IS NOT NULL
     AND m.number_of_elements > 1
 ORDER BY ps.formation_energy_per_atom ASC
-LIMIT 10000;",True,True,1.0,0.42857142857142855,1.0,0.6,0.0,0.0,0.0,0.0,0.0,0.0,4495,12346,1,1583
+LIMIT 10000;",True,True,1.0,0.42857142857142855,1.0,0.6,0.0,0.0,0.0,0.0,0.0,0.0,4495,12346,1,1583,4,hard,hard
 q_hard_006,Aサイト元素別にL1₂型化合物の平均格子定数を集計して。,hard,2,proposed,"SELECT c.element, AVG(s.lattice_a) AS avg_lattice_a
 FROM material_entry m
 JOIN composition c ON c.entry_id = m.entry_id
@@ -567,7 +567,7 @@ WHERE c.site_label = 'A-site'
   AND (s.prototype = 'L12' OR s.strukturbericht = 'L12')
 GROUP BY c.element
 ORDER BY c.element
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,2373,6398,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,2373,6398,0,0,3,medium,hard
 q_hard_007,形成エネルギーが-0.3以下で格子定数が3.5〜3.7ÅのL1₂化合物を抽出して。,hard,3,proposed,"SELECT DISTINCT
     m.formula,
     ps.formation_energy_per_atom,
@@ -580,7 +580,7 @@ WHERE
     AND ps.formation_energy_per_atom <= -0.3
     AND s.lattice_a BETWEEN 3.5 AND 3.7
 ORDER BY ps.formation_energy_per_atom ASC
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2652,8575,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2652,8575,0,0,3,medium,hard
 q_hard_008,L1₂型化合物でバルクモジュラスが180GPa以上のものを抽出して。,hard,4,proposed,"SELECT DISTINCT
     m.formula,
     et.bulk_modulus_vrh AS bulk_modulus
@@ -591,7 +591,7 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND et.bulk_modulus_vrh >= 180
 ORDER BY et.bulk_modulus_vrh DESC
-LIMIT 10000;",True,True,0.08,0.14736842105263157,0.08,0.1037037037037037,0.08,0.14736842105263157,0.1037037037037037,0.0,0.0,0.0,2523,5671,0,0
+LIMIT 10000;",True,True,0.08,0.14736842105263157,0.08,0.1037037037037037,0.08,0.14736842105263157,0.1037037037037037,0.0,0.0,0.0,2523,5671,0,0,4,hard,hard
 q_hard_009,Co基L1₂化合物のうち、Ni₃Alに近い格子定数のものを安定性順に出して。,hard,3,proposed,"SELECT DISTINCT
     m.formula,
     s.lattice_a,
@@ -636,7 +636,7 @@ WHERE
 ORDER BY
     ps.energy_above_hull ASC NULLS LAST,
     lattice_diff ASC
-LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,8467,12977,3,5463
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,8467,12977,3,5463,4,hard,hard
 q_hard_010,Bサイト元素がAlまたはTiのL1₂化合物を形成エネルギー順に出して。,hard,3,proposed,"SELECT DISTINCT
   m.formula,
   c.element,
@@ -651,7 +651,7 @@ WHERE
   AND c.element IN ('Al', 'Ti')
   AND (s.prototype = 'L12' OR s.strukturbericht = 'L12')
 ORDER BY ps.formation_energy_per_atom ASC
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2533,6778,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2533,6778,0,0,4,hard,hard
 q_hard_011,L1₂化合物のせん断弾性率を表示して。,hard,4,proposed,"SELECT DISTINCT
     m.formula,
     et.shear_modulus_vrh
@@ -664,7 +664,7 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND et.shear_modulus_vrh IS NOT NULL
 ORDER BY m.formula
-LIMIT 10000;",True,True,0.6216216216216216,1.0,0.6216216216216216,0.7666666666666667,0.06887755102040816,0.13705583756345177,0.09168081494057724,0.0,0.0,0.0,3956,4938,1,1443
+LIMIT 10000;",True,True,0.6216216216216216,1.0,0.6216216216216216,0.7666666666666667,0.06887755102040816,0.13705583756345177,0.09168081494057724,0.0,0.0,0.0,3956,4938,1,1443,4,hard,hard
 q_hard_012,安定で形成エネルギーが最も低いL1₂化合物のトップ10を出して。,hard,2,proposed,"SELECT DISTINCT
     m.formula,
     ps.formation_energy_per_atom,
@@ -677,7 +677,7 @@ WHERE
     ps.is_stable = TRUE
     AND (s.prototype = 'L12' OR s.strukturbericht = 'L12')
 ORDER BY ps.formation_energy_per_atom ASC
-LIMIT 10;",True,True,0.5,0.4,0.5,0.4444444444444445,0.0,0.0,0.0,0.0,0.0,0.0,2709,8179,0,0
+LIMIT 10;",True,True,0.5,0.4,0.5,0.4444444444444445,0.0,0.0,0.0,0.0,0.0,0.0,2709,8179,0,0,3,medium,hard
 q_hard_013,Ni含有L1₂化合物のバルクモジュラスと形成エネルギーの関係を出して。,hard,4,proposed,"SELECT DISTINCT
   m.formula,
   et.bulk_modulus_vrh AS bulk_modulus,
@@ -692,7 +692,7 @@ WHERE c.element = 'Ni'
   AND et.bulk_modulus_vrh IS NOT NULL
   AND ps.formation_energy_per_atom IS NOT NULL
 ORDER BY ps.formation_energy_per_atom ASC
-LIMIT 10000;",True,True,0.125,0.25,0.125,0.16666666666666666,0.125,0.25,0.16666666666666666,0.0,0.0,0.0,4033,6037,1,1322
+LIMIT 10000;",True,True,0.125,0.25,0.125,0.16666666666666666,0.125,0.25,0.16666666666666666,0.0,0.0,0.0,4033,6037,1,1322,6,very_hard,hard
 q_hard_014,安定なL1₂化合物をAサイト元素でグループ化し、各グループの平均形成エネルギーを出して。,hard,3,proposed,"SELECT
   c.element AS a_site,
   AVG(ps.formation_energy_per_atom) AS avg_eform
@@ -706,7 +706,7 @@ WHERE
   AND ps.is_stable = TRUE
 GROUP BY c.element
 ORDER BY avg_eform ASC
-LIMIT 10000;",True,True,0.14285714285714285,0.05263157894736842,0.14285714285714285,0.07692307692307693,0.0,0.0,0.0,0.0,0.0,0.0,3628,6604,1,1039
+LIMIT 10000;",True,True,0.14285714285714285,0.05263157894736842,0.14285714285714285,0.07692307692307693,0.0,0.0,0.0,0.0,0.0,0.0,3628,6604,1,1039,4,hard,hard
 q_hard_015,格子定数3.55Å付近でバルクモジュラスの高いL1₂化合物を探して。,hard,4,proposed,"SELECT
     m.formula,
     s.lattice_a,
@@ -722,7 +722,7 @@ WHERE
 ORDER BY
     et.bulk_modulus_vrh DESC,
     ABS(s.lattice_a - 3.55) ASC
-LIMIT 10000;",True,True,0.020202020202020204,0.0625,0.020202020202020204,0.03053435114503817,0.0,0.0,0.0,0.0,0.0,0.0,2823,11859,0,0
+LIMIT 10000;",True,True,0.020202020202020204,0.0625,0.020202020202020204,0.03053435114503817,0.0,0.0,0.0,0.0,0.0,0.0,2823,11859,0,0,4,hard,hard
 q_hard_016,L1₂型化合物の格子定数と形成エネルギーの相関を見たい。,hard,2,proposed,"SELECT
   m.formula,
   s.lattice_a,
@@ -735,14 +735,14 @@ WHERE
   AND s.lattice_a IS NOT NULL
   AND ps.formation_energy_per_atom IS NOT NULL
 ORDER BY s.lattice_a ASC
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,3450,3227,1,1100
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,3450,3227,1,1100,3,medium,hard
 q_hard_017,Co3TiとNi3Alの格子定数差を計算して。,hard,2,proposed,"SELECT m.formula, s.lattice_a, ABS(s.lattice_a - 3.57) AS lattice_diff
 FROM material_entry m
 JOIN structure s ON s.entry_id = m.entry_id
 WHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')
   AND m.formula IN ('Co3Ti', 'Ni3Al')
 ORDER BY m.formula
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2628,7272,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2628,7272,0,0,2,easy,hard
 q_hard_018,Al系L1₂化合物のうち安定なものとそうでないものの数を出して。,hard,3,proposed,"SELECT
   COUNT(*) FILTER (WHERE ps.is_stable = TRUE) AS stable_l12_al_count,
   COUNT(*) FILTER (WHERE ps.is_stable = FALSE) AS unstable_l12_al_count
@@ -757,7 +757,7 @@ WHERE
     WHERE c.entry_id = m.entry_id
       AND c.element = 'Al'
   )
-LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,2918,12803,0,0
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,2918,12803,0,0,4,hard,hard
 q_hard_019,準安定L1₂化合物をenergy above hull順にランキングして。,hard,2,proposed,"SELECT DISTINCT
     m.formula,
     ps.energy_above_hull,
@@ -770,7 +770,7 @@ WHERE
     AND ps.is_stable = FALSE
     AND ps.energy_above_hull <= 0.05
 ORDER BY ps.energy_above_hull ASC
-LIMIT 10000;",True,True,0.8449197860962567,1.0,0.8449197860962567,0.9159420289855073,0.0,0.0,0.0,0.0,0.0,0.0,2889,11541,0,0
+LIMIT 10000;",True,True,0.8449197860962567,1.0,0.8449197860962567,0.9159420289855073,0.0,0.0,0.0,0.0,0.0,0.0,2889,11541,0,0,3,medium,hard
 q_hard_020,Bサイト元素ごとの安定L1₂化合物数を集計して。,hard,3,proposed,"SELECT
     c.element,
     COUNT(DISTINCT m.entry_id) AS stable_l12_count
@@ -784,7 +784,7 @@ WHERE
     AND ps.is_stable = TRUE
 GROUP BY c.element
 ORDER BY stable_l12_count DESC, c.element
-LIMIT 10000;",True,True,0.2,0.05263157894736842,0.2,0.08333333333333333,0.2,0.05263157894736842,0.08333333333333333,0.0,0.0,0.0,2570,7818,0,0
+LIMIT 10000;",True,True,0.2,0.05263157894736842,0.2,0.08333333333333333,0.2,0.05263157894736842,0.08333333333333333,0.0,0.0,0.0,2570,7818,0,0,4,hard,hard
 q_hard_021,DFT計算で得られたL1₂化合物の物性一覧を出して。,hard,4,proposed,"SELECT DISTINCT
     m.formula,
     m.source_db,
@@ -803,7 +803,7 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
 ORDER BY
     m.formula
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2497,6786,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2497,6786,0,0,4,hard,hard
 q_hard_022,PBE汎関数で計算されたL1₂化合物のバルクモジュラスを表示して。,hard,4,proposed,"SELECT DISTINCT
     m.formula,
     et.bulk_modulus_vrh AS bulk_modulus
@@ -814,7 +814,7 @@ JOIN elastic_tensor et ON et.calculation_id = calc.calculation_id
 WHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')
   AND calc.functional = 'GGA-PBE'
 ORDER BY m.formula
-LIMIT 10000;",True,True,0.05357142857142857,0.1065989847715736,0.05357142857142857,0.07130730050933787,0.05357142857142857,0.1065989847715736,0.07130730050933787,0.0,0.0,0.0,2595,6402,0,0
+LIMIT 10000;",True,True,0.05357142857142857,0.1065989847715736,0.05357142857142857,0.07130730050933787,0.05357142857142857,0.1065989847715736,0.07130730050933787,0.0,0.0,0.0,2595,6402,0,0,4,hard,hard
 q_hard_023,L1₂化合物の格子ミスマッチ（Ni3Alとの差）を計算して小さい順に表示して。,hard,2,proposed,"SELECT
   m.formula,
   s.lattice_a,
@@ -823,7 +823,7 @@ FROM material_entry m
 JOIN structure s ON s.entry_id = m.entry_id
 WHERE s.prototype = 'L12' OR s.strukturbericht = 'L12'
 ORDER BY ABS(s.lattice_a - 3.57) ASC
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,2319,2760,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,2319,2760,0,0,2,easy,hard
 q_hard_024,Fe含有L1₂化合物の安定性と弾性特性を同時に表示して。,hard,4,proposed,"SELECT DISTINCT m.formula, ps.is_stable, ps.energy_above_hull
 FROM material_entry m
 JOIN structure s ON s.entry_id = m.entry_id
@@ -832,7 +832,7 @@ JOIN composition c ON c.entry_id = m.entry_id
 WHERE c.element = 'Fe'
   AND (s.prototype = 'L12' OR s.strukturbericht = 'L12')
 ORDER BY ps.is_stable DESC, ps.energy_above_hull ASC
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2591,6864,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2591,6864,0,0,6,very_hard,hard
 q_hard_025,安定なL1₂化合物でバルクモジュラスが160GPa以上のものを抽出して。,hard,4,proposed,"SELECT DISTINCT
     m.formula,
     ps.is_stable,
@@ -847,7 +847,7 @@ WHERE
     AND ps.is_stable = TRUE
     AND et.bulk_modulus_vrh >= 160
 ORDER BY et.bulk_modulus_vrh DESC
-LIMIT 10000;",True,True,0.6,0.25,0.6,0.35294117647058826,0.0,0.0,0.0,0.0,0.0,0.0,2825,13964,0,0
+LIMIT 10000;",True,True,0.6,0.25,0.6,0.35294117647058826,0.0,0.0,0.0,0.0,0.0,0.0,2825,13964,0,0,5,very_hard,hard
 q_hard_026,L1₂化合物で安定性と格子定数の両面でNi3Alに近い候補を出して。,hard,3,proposed,"SELECT m.formula,
        ps.is_stable,
        ps.energy_above_hull,
@@ -862,7 +862,7 @@ WHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')
 ORDER BY ps.is_stable DESC,
          ps.energy_above_hull ASC NULLS LAST,
          ABS(s.lattice_a - 3.57) ASC
-LIMIT 10000;",True,True,0.06153846153846154,1.0,0.06153846153846154,0.11594202898550725,0.0,0.0,0.0,0.0,0.0,0.0,4534,12645,1,1616
+LIMIT 10000;",True,True,0.06153846153846154,1.0,0.06153846153846154,0.11594202898550725,0.0,0.0,0.0,0.0,0.0,0.0,4534,12645,1,1616,3,medium,hard
 q_hard_027,Aサイト元素がNiまたはCoで、Bサイト元素がAlまたはTiのL1₂化合物を出して。,hard,3,proposed,"SELECT DISTINCT m.formula, c.site_label, c.element, c.atomic_fraction
 FROM material_entry m
 JOIN structure s ON s.entry_id = m.entry_id
@@ -887,7 +887,7 @@ WHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     OR (c.site_label = 'B-site' AND c.element IN ('Al', 'Ti'))
   )
 ORDER BY m.formula, c.site_label, c.element
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2921,14461,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2921,14461,0,0,3,medium,hard
 q_hard_028,L1₂型化合物の体積あたり原子数と格子定数の関係を出して。,hard,2,proposed,"SELECT
   m.formula,
   1.0 / s.volume_per_atom AS atoms_per_volume,
@@ -899,7 +899,7 @@ WHERE
   AND s.volume_per_atom IS NOT NULL
   AND s.lattice_a IS NOT NULL
 ORDER BY atoms_per_volume ASC
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,3552,3220,1,1363
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,3552,3220,1,1363,2,easy,hard
 q_hard_029,L1₂化合物でenergy above hullが0で形成エネルギーが-0.4以下のものを出して。,hard,2,proposed,"SELECT DISTINCT
     m.formula,
     ps.energy_above_hull,
@@ -913,7 +913,7 @@ WHERE
     AND ps.energy_above_hull = 0
     AND ps.formation_energy_per_atom <= -0.4
 ORDER BY ps.formation_energy_per_atom ASC
-LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2783,11341,0,0
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,2783,11341,0,0,3,medium,hard
 q_hard_030,遷移金属を含むL1₂型化合物のうち安定なものを出して。,hard,3,proposed,"SELECT DISTINCT
   m.formula,
   s.prototype,
@@ -925,7 +925,7 @@ JOIN phase_stability ps ON ps.entry_id = m.entry_id
 WHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')
   AND ps.is_stable = TRUE
   AND m.chemical_system ~ '(^|-)(Sc|Ti|V|Cr|Mn|Fe|Co|Ni|Cu|Zn|Y|Zr|Nb|Mo|Tc|Ru|Rh|Pd|Ag|Cd|Hf|Ta|W|Re|Os|Ir|Pt|Au|Hg)(-|$)'
-LIMIT 10000;",True,True,1.0,0.1891891891891892,1.0,0.3181818181818182,0.0,0.0,0.0,0.0,0.0,0.0,2884,15951,0,0
+LIMIT 10000;",True,True,1.0,0.1891891891891892,1.0,0.3181818181818182,0.0,0.0,0.0,0.0,0.0,0.0,2884,15951,0,0,4,hard,hard
 q_vhard_001,L1₂型金属間化合物において、相安定性、格子ミスマッチ、弾性特性を同時に考慮した析出強化相候補を抽出して。,very_hard,4,proposed,"SELECT DISTINCT
     m.formula,
     ps.is_stable,
@@ -941,7 +941,7 @@ WHERE
 ORDER BY
     ps.energy_above_hull ASC,
     ABS(s.lattice_a - 3.57) ASC
-LIMIT 10000;",True,True,0.18974358974358974,1.0,0.18974358974358974,0.3189655172413793,0.0,0.0,0.0,0.0,0.0,0.0,2968,12880,0,0
+LIMIT 10000;",True,True,0.18974358974358974,1.0,0.18974358974358974,0.3189655172413793,0.0,0.0,0.0,0.0,0.0,0.0,2968,12880,0,0,5,very_hard,very_hard
 q_vhard_002,Ni₃Al代替またはCo基γ'相候補として有望なL1₂型金属間化合物を、形成エネルギー、格子定数、弾性率の観点から探索して。,very_hard,4,proposed,"SELECT DISTINCT
   m.formula,
   ps.formation_energy_per_atom,
@@ -976,7 +976,7 @@ WHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     )
   )
 ORDER BY ps.formation_energy_per_atom ASC, ABS(s.lattice_a - 3.57) ASC
-LIMIT 10000;",True,True,0.015384615384615385,1.0,0.015384615384615385,0.030303030303030307,0.0,0.0,0.0,0.0,0.0,0.0,3647,25540,0,0
+LIMIT 10000;",True,True,0.015384615384615385,1.0,0.015384615384615385,0.030303030303030307,0.0,0.0,0.0,0.0,0.0,0.0,3647,25540,0,0,5,very_hard,very_hard
 q_vhard_003,γ'相候補のランキングを安定性・格子整合性・バルクモジュラスの重み付きスコアで出して。,very_hard,4,proposed,"SELECT
     m.formula,
     ps.is_stable,
@@ -999,7 +999,7 @@ WHERE
     AND ps.is_stable IS NOT NULL
     AND et.bulk_modulus_vrh IS NOT NULL
 ORDER BY weighted_score DESC
-LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,3024,13930,0,0
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,3024,13930,0,0,5,very_hard,very_hard
 q_vhard_004,NiまたはCo含有で安定かつバルクモジュラスが高いL1₂化合物トップ10を出して。,very_hard,4,proposed,"SELECT DISTINCT
     m.formula,
     s.prototype,
@@ -1018,7 +1018,7 @@ WHERE
     AND et.bulk_modulus_vrh IS NOT NULL
     AND et.bulk_modulus_vrh > 0
 ORDER BY et.bulk_modulus_vrh DESC
-LIMIT 10;",True,True,0.6666666666666666,0.5,0.6666666666666666,0.5714285714285715,0.0,0.0,0.0,0.0,0.0,0.0,4729,14091,1,1735
+LIMIT 10;",True,True,0.6666666666666666,0.5,0.6666666666666666,0.5714285714285715,0.0,0.0,0.0,0.0,0.0,0.0,4729,14091,1,1735,6,very_hard,very_hard
 q_vhard_005,L1₂型化合物の元素組み合わせと安定性の関係をAサイト・Bサイト別に集計して材料設計の指針を得たい。,very_hard,3,proposed,"SELECT
     c.site_label,
     c.element,
@@ -1041,7 +1041,7 @@ ORDER BY
     c.site_label,
     c.element,
     ps.is_stable DESC
-LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,2779,17224,0,0
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,2779,17224,0,0,4,hard,very_hard
 q_vhard_006,Ni3Alの格子定数に近く、バルクモジュラスが高く、安定なL1₂候補を総合的にランキングして。,very_hard,4,proposed,"SELECT
     m.formula,
     s.lattice_a,
@@ -1062,7 +1062,7 @@ ORDER BY
     (et.bulk_modulus_vrh / (1.0 + ABS(s.lattice_a - 3.57))) DESC,
     ABS(s.lattice_a - 3.57) ASC,
     et.bulk_modulus_vrh DESC
-LIMIT 10000;",True,True,0.015384615384615385,0.42857142857142855,0.015384615384615385,0.029702970297029705,0.0,0.0,0.0,0.0,0.0,0.0,4673,13872,1,1690
+LIMIT 10000;",True,True,0.015384615384615385,0.42857142857142855,0.015384615384615385,0.029702970297029705,0.0,0.0,0.0,0.0,0.0,0.0,4673,13872,1,1690,5,very_hard,very_hard
 q_vhard_007,析出強化に適したL1₂化合物を格子ミスマッチ、弾性率、安定性の多基準で評価して上位候補を出して。,very_hard,4,proposed,"SELECT
   m.formula,
   s.lattice_a,
@@ -1080,7 +1080,7 @@ ORDER BY
   ABS(s.lattice_a - 3.57) ASC,
   ps.energy_above_hull ASC,
   ps.formation_energy_per_atom ASC
-LIMIT 10000;",True,True,0.18974358974358974,1.0,0.18974358974358974,0.3189655172413793,0.0,0.0,0.0,0.0,0.0,0.0,4157,14519,1,1257
+LIMIT 10000;",True,True,0.18974358974358974,1.0,0.18974358974358974,0.3189655172413793,0.0,0.0,0.0,0.0,0.0,0.0,4157,14519,1,1257,5,very_hard,very_hard
 q_vhard_008,Co基超合金のγ'相候補として、Co含有で安定なL1₂化合物をNi3Alとの比較で評価して。,very_hard,4,proposed,"SELECT DISTINCT
   m.formula,
   s.lattice_a,
@@ -1095,7 +1095,7 @@ WHERE c.element = 'Co'
   AND ps.is_stable = TRUE
   AND (s.prototype = 'L12' OR s.strukturbericht = 'L12')
 ORDER BY ABS(s.lattice_a - 3.57) ASC
-LIMIT 10000;",True,True,0.10526315789473684,1.0,0.10526315789473684,0.1904761904761905,0.0,0.0,0.0,0.0,0.0,0.0,2774,7998,0,0
+LIMIT 10000;",True,True,0.10526315789473684,1.0,0.10526315789473684,0.1904761904761905,0.0,0.0,0.0,0.0,0.0,0.0,2774,7998,0,0,6,very_hard,very_hard
 q_vhard_009,L1₂型化合物データベースから、バルクモジュラスとせん断弾性率の比(B/G比)を計算して延性候補を抽出して。,very_hard,4,proposed,"SELECT
   m.formula,
   et.bulk_modulus_vrh,
@@ -1110,7 +1110,7 @@ WHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')
   AND et.shear_modulus_vrh > 0
   AND et.bulk_modulus_vrh / NULLIF(et.shear_modulus_vrh, 0) >= 1.75
 ORDER BY bg_ratio DESC
-LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,2502,6244,0,0
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,2502,6244,0,0,6,very_hard,very_hard
 q_vhard_010,L1₂型化合物の安定性マップ（formation energy vs energy above hull）を出力して、候補を4象限に分類して。,very_hard,2,proposed,"SELECT
   m.formula,
   ps.formation_energy_per_atom,
@@ -1127,7 +1127,7 @@ JOIN structure s ON s.entry_id = m.entry_id
 JOIN phase_stability ps ON ps.entry_id = m.entry_id
 WHERE s.prototype = 'L12' OR s.strukturbericht = 'L12'
 ORDER BY stability_quadrant, ps.formation_energy_per_atom ASC, ps.energy_above_hull ASC
-LIMIT 10000;",True,True,1.0,0.49744897959183676,1.0,0.6643952299829642,0.0,0.0,0.0,0.0,0.0,0.5,3024,15353,0,0
+LIMIT 10000;",True,True,1.0,0.49744897959183676,1.0,0.6643952299829642,0.0,0.0,0.0,0.0,0.0,0.5,3024,15353,0,0,5,very_hard,very_hard
 q_vhard_011,高温安定性の観点で有望なL1₂型化合物を形成エネルギーの深さで評価して上位を出して。,very_hard,2,proposed,"SELECT DISTINCT
   m.formula,
   ps.is_stable,
@@ -1139,7 +1139,7 @@ JOIN phase_stability ps ON ps.entry_id = m.entry_id
 WHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')
   AND ps.is_stable = TRUE
 ORDER BY ps.formation_energy_per_atom ASC
-LIMIT 10000;",True,True,0.09438775510204081,1.0,0.09438775510204081,0.17249417249417248,0.0,0.0,0.0,0.0,0.0,0.0,2802,10719,0,0
+LIMIT 10000;",True,True,0.09438775510204081,1.0,0.09438775510204081,0.17249417249417248,0.0,0.0,0.0,0.0,0.0,0.0,2802,10719,0,0,5,very_hard,very_hard
 q_vhard_012,Ni基超合金のγ'相代替候補として、Ni-Al系以外で安定なL1₂化合物を格子整合性で評価して。,very_hard,3,proposed,"SELECT DISTINCT
     m.formula,
     s.lattice_a,
@@ -1167,7 +1167,7 @@ WHERE
         )
     )
 ORDER BY lattice_diff ASC
-LIMIT 10000;",True,True,0.18461538461538463,1.0,0.18461538461538463,0.3116883116883117,0.0,0.0,0.0,0.0,0.0,0.0,3159,14725,0,0
+LIMIT 10000;",True,True,0.18461538461538463,1.0,0.18461538461538463,0.3116883116883117,0.0,0.0,0.0,0.0,0.0,0.0,3159,14725,0,0,5,very_hard,very_hard
 q_vhard_013,L1₂型化合物で体積弾性率と格子定数を散布図データとして出力して。,very_hard,4,proposed,"SELECT
   m.formula,
   et.bulk_modulus_vrh AS bulk_modulus,
@@ -1180,7 +1180,7 @@ WHERE
   AND et.bulk_modulus_vrh IS NOT NULL
   AND s.lattice_a IS NOT NULL
 ORDER BY s.lattice_a ASC
-LIMIT 10000;",True,True,0.75,0.015228426395939087,0.75,0.029850746268656712,0.0,0.0,0.0,0.0,0.0,0.0,3589,4284,1,1147
+LIMIT 10000;",True,True,0.75,0.015228426395939087,0.75,0.029850746268656712,0.0,0.0,0.0,0.0,0.0,0.0,3589,4284,1,1147,5,very_hard,very_hard
 q_vhard_014,元素周期の観点から、3d遷移金属と4d/5d遷移金属をAサイトに持つL1₂化合物の安定性傾向を比較して。,very_hard,3,proposed,"SELECT DISTINCT
     m.formula,
     c.element,
@@ -1204,7 +1204,7 @@ WHERE
                       'Y', 'Zr', 'Nb', 'Mo', 'Tc', 'Ru', 'Rh', 'Pd', 'Ag', 'Cd',
                       'Hf', 'Ta', 'W', 'Re', 'Os', 'Ir', 'Pt', 'Au', 'Hg')
 ORDER BY transition_metal_period, ps.energy_above_hull ASC, m.formula
-LIMIT 10000;",True,True,0.875,0.017948717948717947,0.875,0.035175879396984924,0.0,0.0,0.0,0.0,0.0,0.0,3143,15664,0,0
+LIMIT 10000;",True,True,0.875,0.017948717948717947,0.875,0.035175879396984924,0.0,0.0,0.0,0.0,0.0,0.0,3143,15664,0,0,6,very_hard,very_hard
 q_vhard_015,L1₂化合物のうちNi3Alより安定でバルクモジュラスが高い候補を出して。,very_hard,4,proposed,"SELECT DISTINCT
     m.formula,
     ps.formation_energy_per_atom,
@@ -1223,7 +1223,7 @@ WHERE
     AND ps.formation_energy_per_atom < ps_ref.formation_energy_per_atom
     AND et.bulk_modulus_vrh > et_ref.bulk_modulus_vrh
 ORDER BY ps.formation_energy_per_atom ASC, et.bulk_modulus_vrh DESC
-LIMIT 10000;",True,True,0.020512820512820513,0.18181818181818182,0.020512820512820513,0.03686635944700461,0.0,0.0,0.0,0.0,0.0,0.16666666666666666,3092,17156,0,0
+LIMIT 10000;",True,True,0.020512820512820513,0.18181818181818182,0.020512820512820513,0.03686635944700461,0.0,0.0,0.0,0.0,0.0,0.16666666666666666,3092,17156,0,0,5,very_hard,very_hard
 q_vhard_016,Co-Al-W系L1₂候補の安定性と弾性特性を評価して。,very_hard,4,proposed,"WITH comp AS (
   SELECT
     c.entry_id,
@@ -1292,7 +1292,7 @@ ORDER BY
   ps.energy_above_hull ASC NULLS LAST,
   ps.formation_energy_per_atom ASC NULLS LAST,
   m.formula
-LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.21428571428571427,0.3333333333333333,11004,15443,3,8006
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.21428571428571427,0.3333333333333333,11004,15443,3,8006,6,very_hard,very_hard
 q_vhard_017,全L1₂化合物について、安定性スコア×格子整合性スコア×弾性スコアの複合スコアを計算してランキングして。,very_hard,4,proposed,"SELECT DISTINCT
     m.formula,
     ps.is_stable,
@@ -1320,7 +1320,7 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.is_stable = TRUE
 ORDER BY composite_score DESC, lattice_diff ASC
-LIMIT 10000;",True,True,0.6,0.32432432432432434,0.6,0.4210526315789474,0.0,0.0,0.0,0.0,0.0,0.0,5429,36859,1,1478
+LIMIT 10000;",True,True,0.6,0.32432432432432434,0.6,0.4210526315789474,0.0,0.0,0.0,0.0,0.0,0.0,5429,36859,1,1478,5,very_hard,very_hard
 q_vhard_018,Ni3Al代替γ'相候補をバルクモジュラス、形成エネルギー、格子ミスマッチの3軸パレート面で出力して。,very_hard,4,proposed,"SELECT DISTINCT
     m.formula,
     et.bulk_modulus_vrh AS bulk_modulus,
@@ -1353,7 +1353,7 @@ WHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')
         )
   )
 ORDER BY lattice_diff ASC, ps.formation_energy_per_atom ASC, bulk_modulus DESC
-LIMIT 10000;",True,True,0.2857142857142857,0.5,0.2857142857142857,0.36363636363636365,0.0,0.0,0.0,0.0,0.0,0.0,3261,18220,0,0
+LIMIT 10000;",True,True,0.2857142857142857,0.5,0.2857142857142857,0.36363636363636365,0.0,0.0,0.0,0.0,0.0,0.0,3261,18220,0,0,5,very_hard,very_hard
 q_vhard_019,L1₂型化合物データベースから材料設計仮説を導出するため、安定化合物の元素分布とその物性傾向を包括的に集計して。,very_hard,4,proposed,"SELECT
   m.chemical_system,
   COUNT(*) AS stable_l12_count,
@@ -1372,7 +1372,7 @@ WHERE
   AND ps.is_stable = TRUE
 GROUP BY m.chemical_system
 ORDER BY stable_l12_count DESC, avg_eform ASC
-LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,4098,14269,1,1187
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,4098,14269,1,1187,5,very_hard,very_hard
 q_vhard_020,次世代γ'相候補として、Ni-Al-Co-Ti四元系でL1₂構造をとりうる組成を探索して。,very_hard,3,proposed,"SELECT DISTINCT
   m.formula,
   c.element,
@@ -1434,4 +1434,4 @@ WHERE
     ) LIKE '%pm-3m%'
   )
 ORDER BY m.formula, c.element
-LIMIT 10000;",True,True,0.007722007722007722,0.6666666666666666,0.007722007722007722,0.015267175572519085,0.0,0.0,0.0,0.0,0.0,0.0,9354,16224,3,6321
+LIMIT 10000;",True,True,0.007722007722007722,0.6666666666666666,0.007722007722007722,0.015267175572519085,0.0,0.0,0.0,0.0,0.0,0.0,9354,16224,3,6321,5,very_hard,very_hard


### PR DESCRIPTION
## Summary

#309 で `proposed_result.csv` に `n_tables`/`ntables_difficulty`/`original_difficulty` 列を追加した結果、run2とのMD5不一致が発生。`_identify_representative_run` が `"ランファイルと不一致"` を返し、`compute_paper_figures.py` 再実行時に同梱JSONと異なる出力になるSSoT違反。

**修正:**
- `proposed_result.csv` → run2とバイト同一に復元
- `proposed_result_annotated.csv` 新設（分析用3列付き版を別ファイルに分離）
- `README_DELIVERY.md` にannotated版の説明追加

ZIP再梱包時には以下も対応:
- ルート直下の古いPDF（28頁、改稿前）+ LaTeXビルド産物を除外
- `.mypy_cache/`, `.pytest_cache/`, `*.egg-info/` を除外
- `README_DELIVERY.md` のリストと整合するファイル構成に

Link to Devin session: https://app.devin.ai/sessions/5c4cf372d3d54d638f06fe4ed622b85b
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->