### PR TITLE
fix: v9レビュー17件対応 — 古い材料名差替え・fallbackバグ修正・検証強化

### DIFF
--- a/l12-schema-graph-text2sql/README.md
+++ b/l12-schema-graph-text2sql/README.md
@@ -1,5 +1,8 @@
 # L1₂ Schema-Graph-Assisted Text-to-SQL
 
+> **デリバリZIPをお持ちの方は [README_DELIVERY.md](README_DELIVERY.md) を先にお読みください。**
+> 本READMEは完全リポジトリ（Docker・DB・テスト含む）向けです。
+
 L1₂型金属間化合物探索のためのスキーマグラフ支援型Text-to-SQLシステム。
 
 ## Overview

--- a/l12-schema-graph-text2sql/README_DELIVERY.md
+++ b/l12-schema-graph-text2sql/README_DELIVERY.md
@@ -132,6 +132,9 @@ join_list = get_allowed_join_list(db_connection)  # requires live DB
 result = pipeline(query, join_list=join_list)
 ```
 
+**LIMIT値について**: rule-based fallbackのデフォルトは `LIMIT 100`（環境変数 `SQL_ROW_LIMIT` で変更可）。
+論文評価時は `SQL_ROW_LIMIT=10000` を使用しています。「L12型化合物を全て出して」のような広いクエリでは結果数が異なります。
+
 ## LaTeX再コンパイルに必要な環境
 
 論文PDFの再コンパイルには以下が必要です:

--- a/l12-schema-graph-text2sql/README_DELIVERY.md
+++ b/l12-schema-graph-text2sql/README_DELIVERY.md
@@ -18,7 +18,7 @@
 - **評価スクリプト** (`scripts/run_full_evaluation.py`, `scripts/run_proposed_only.py`, `scripts/compute_paper_figures.py`)
 - **安全検査定義** (`safety/allowed_schema.yaml`)
 - **論文数値JSON** (`paper/paper_figures.json` — Single Source of Truth)
-- **pytest設定** (`pytest.ini` — テスト収集を `tests/` に制限。ZIP単体では `tests/` 未同梱のため実行不可）
+- **数値検証スクリプト** (`scripts/validate_paper_numbers.py` — `paper_figures.json`とTeX本文の整合検証）
 
 ## ZIP に含まれないもの
 
@@ -33,6 +33,7 @@
 | `api/` | FastAPIアプリケーション |
 | `.env.example` | 環境変数テンプレート |
 | `experiments/` | アブレーション実験スクリプト・結果 |
+| `pytest.ini` | pytest設定（`tests/`に収集制限） |
 | `VERIFICATION_GUIDE.md` | 検証手順書 |
 
 ## 検証可能な項目（ZIP単体）

--- a/l12-schema-graph-text2sql/evaluation/ni3al_lattice_matched_candidates.csv
+++ b/l12-schema-graph-text2sql/evaluation/ni3al_lattice_matched_candidates.csv
@@ -1,5 +1,5 @@
 # Paper ref: Supplementary (tab:sup_lattice_match) -- Ni3Al lattice-matched 32 candidates
-# a_ref = 3.57 A (hardcoded), |da| <= 0.03 A, ROUND() for float boundary
+# a_ref = 3.57 A (rounded from Ni3Al CSV value 3.572 A), |da| <= 0.03 A after ROUND(4) for float boundary
 formula,lattice_a,lattice_diff_ni3al,energy_above_hull,formation_energy_per_atom
 Ag3Ti,3.5642,0.005799999999999805,0.0393,0.0882
 Au3Mn,3.5868,0.01680000000000037,0.0452,-0.2608

--- a/l12-schema-graph-text2sql/llm/condition_mapper.py
+++ b/l12-schema-graph-text2sql/llm/condition_mapper.py
@@ -118,9 +118,10 @@ def map_lattice_reference_condition(
     tolerance: float = 0.03,
 ) -> dict[str, Any]:
     val = ref["reference_lattice_a"]
+    tol = ref.get("tolerance", tolerance)
     return {
         "type": "lattice_reference",
-        "sql_fragment": f"ABS(s.lattice_a - {val}) <= {tolerance}",
+        "sql_fragment": f"ABS(s.lattice_a - {val}) <= {tol}",
         "tables": ["structure"],
         "columns": ["structure.lattice_a"],
     }

--- a/l12-schema-graph-text2sql/llm/entity_extractor.py
+++ b/l12-schema-graph-text2sql/llm/entity_extractor.py
@@ -171,10 +171,14 @@ def extract_sort(query: str, terms: dict[str, Any] | None = None) -> dict[str, s
 
 
 def extract_lattice_reference(query: str) -> dict[str, float] | None:
-    """Detect 'near Ni3Al lattice constant'-type queries."""
+    """Detect 'near Ni3Al lattice constant'-type queries.
+
+    Also extracts user-specified tolerance (e.g. '0.05 Å以内') if present.
+    """
     q = _normalize(query)
     pattern = r"([A-Z][a-z]?)3([A-Z][a-z]?).*(?:格子定数|lattice)"
     m = re.search(pattern, q, re.IGNORECASE)
+    result: dict[str, float] | None = None
     if m:
         ref_formulas = {
             "Ni3Al": 3.572,
@@ -184,10 +188,17 @@ def extract_lattice_reference(query: str) -> dict[str, float] | None:
         formula = f"{m.group(1)}3{m.group(2)}"
         ref_val = ref_formulas.get(formula)
         if ref_val:
-            return {"reference_formula": formula, "reference_lattice_a": ref_val}
-    if "ni3al" in q.lower() and ("格子定数" in query or "lattice" in q.lower()):
-        return {"reference_formula": "Ni3Al", "reference_lattice_a": 3.572}
-    return None
+            result = {"reference_formula": formula, "reference_lattice_a": ref_val}
+    if result is None and "ni3al" in q.lower() and ("格子定数" in query or "lattice" in q.lower()):
+        result = {"reference_formula": "Ni3Al", "reference_lattice_a": 3.572}
+    if result is not None:
+        # Extract user-specified tolerance: "0.05 Å以内" or "±0.05" or "within 0.05"
+        tol_m = re.search(r"(?:±|以内|within)\s*(\d+\.?\d*)\s*(?:Å|A\b|angstrom)?|(\d+\.?\d*)\s*(?:Å|A\b)\s*以内", q, re.IGNORECASE)
+        if tol_m:
+            tol_val = float(tol_m.group(1) or tol_m.group(2))
+            if 0 < tol_val < 1.0:
+                result["tolerance"] = tol_val
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/l12-schema-graph-text2sql/llm/sql_generator.py
+++ b/l12-schema-graph-text2sql/llm/sql_generator.py
@@ -211,6 +211,10 @@ def _rule_based_fallback(
     conditions = extract_conditions(user_query)  # cached at caller if possible
     linked = link_schema(conditions)
 
+    # Detect COUNT-type queries
+    _q = user_query.lower()
+    is_count_query = any(kw in _q for kw in ["総数", "何件", "いくつ", "数を", "count", "何種類"])
+
     select_cols = ["m.entry_id", "m.formula"]
     where_clauses: list[str] = []
     order_by = ""
@@ -286,17 +290,27 @@ def _rule_based_fallback(
     if "thermal_property" in tables_needed:
         tp_alias = alias_map.get("thermal_property", "tp")
         select_cols.append(f"{tp_alias}.debye_temperature_k")
+    if "literature_reference" in tables_needed:
+        select_cols.append("lr.doi")
+        select_cols.append("lr.title")
+        select_cols.append("lr.year")
 
-    sql_parts = [f"SELECT DISTINCT\n    {', '.join(select_cols)}"]
+    if is_count_query:
+        sql_parts = ["SELECT COUNT(*) AS total_count"]
+    else:
+        sql_parts = [f"SELECT DISTINCT\n    {', '.join(select_cols)}"]
     sql_parts.append("FROM material_entry m")
     for j in joins:
         sql_parts.append(f"    {j}")
     if where_clauses:
         sql_parts.append("WHERE\n    " + "\n    AND ".join(where_clauses))
-    if order_by:
-        sql_parts.append(order_by)
-    row_limit = int(os.getenv("SQL_ROW_LIMIT", "100"))
-    sql_parts.append(f"LIMIT {row_limit};")
+    if not is_count_query:
+        if order_by:
+            sql_parts.append(order_by)
+        row_limit = int(os.getenv("SQL_ROW_LIMIT", "100"))
+        sql_parts.append(f"LIMIT {row_limit};")
+    else:
+        sql_parts.append(";")
 
     return "\n".join(sql_parts)
 

--- a/l12-schema-graph-text2sql/paper/t2sql_materials_paper.tex
+++ b/l12-schema-graph-text2sql/paper/t2sql_materials_paper.tex
@@ -2020,9 +2020,11 @@ Proposed手法による探索で\textbf{全11件を正しく再発見}した。
 
 \subsubsection{$\gamma'$相候補ランキング}
 
+L1$_2$型化合物全259件を対象に、
 安定性（$E_\text{hull}$）、格子整合性（$|a - a_{\text{Ni}_3\text{Al}}|$）、
 バルクモジュラス$B$の3指標による重み付き複合スコアで
 $\gamma'$相候補をランキングした（表~\ref{tab:gamma_prime}）。
+このうち安定・準安定162件（安定8件、準安定154件）がスクリーニングを通過した。
 
 \begin{equation}
   S = w_1 \cdot S_\text{stability} + w_2 \cdot S_\text{lattice} + w_3 \cdot S_\text{bulk}
@@ -2077,9 +2079,9 @@ $E_\text{hull} \leq 0.05$~eV/atomを満たす安定・準安定L1$_2$候補162�
 （安定8件、準安定154件）を抽出した。
 拡張インポート後のDBでは従前の57件から大幅に増加している。
 安定相のうち最も負の形成エネルギーを持つのは
-YPt$_3$（$E_f = -0.981$~eV/atom）であり、
-次いでErPd$_3$（$-0.914$）、PaRh$_3$（$-0.900$）、
-ScPd$_3$（$-0.854$）が続く。
+Pt$_3$Al（$E_f = -0.550$~eV/atom）であり、
+次いでAl$_3$Sc（$-0.500$）、Co$_3$Ti（$-0.450$）、
+Ni$_3$Al（$-0.420$）が続く。
 詳細はSupplementary S6節に掲載する。
 
 \subsubsection{材料設計仮説の生成}
@@ -2925,8 +2927,8 @@ $|a - a_{\text{Ni}_3\text{Al}}| \leq 0.03$~\AA を満たす候補を
 
 \begin{table}[htbp]
   \centering
-  \caption{Ni$_3$Al近傍格子定数候補（$|a - a_{\text{ref}}| \leq 0.03$~\AA、$a_{\text{ref}} = 3.57$~\AA、全32件中代表14件）。
-  代表14件は格子差が小さい順に選定した。
+  \caption{Ni$_3$Al近傍格子定数候補（丸め後$|a - a_{\text{ref}}| \leq 0.03$~\AA、$a_{\text{ref}} = 3.57$~\AA{}はNi$_3$AlのCSV値3.572~\AA{}を丸めた参照値、全32件中代表14件）。
+  代表14件は、格子整合性に加えて安定性および材料工学的関心を考慮して選定した。
   完全な一覧は \texttt{ni3al\_lattice\_matched\_candidates.csv} を参照。}
   \label{tab:sup_lattice_match}
   \small
@@ -2967,9 +2969,9 @@ $E_\text{hull} \leq 0.05$~eV/atomを満たす安定・準安定L1$_2$候補を�
 安定（$E_\text{hull} \leq 0.001$）8件、準安定（$0.001 < E_\text{hull} \leq 0.05$）154件の
 計162件が候補として抽出された。
 安定相のうち、最も負の形成エネルギーを持つのは
-YPt$_3$（$E_f = -0.981$~eV/atom）であり、
-次いでErPd$_3$（$-0.914$）、PaRh$_3$（$-0.900$）、
-ScPd$_3$（$-0.854$）が続く。
+Pt$_3$Al（$E_f = -0.550$~eV/atom）であり、
+次いでAl$_3$Sc（$-0.500$）、Co$_3$Ti（$-0.450$）、
+Ni$_3$Al（$-0.420$）が続く。
 
 % =====================================================================
 \section{LLMモード設定}

--- a/l12-schema-graph-text2sql/safety/sql_validator.py
+++ b/l12-schema-graph-text2sql/safety/sql_validator.py
@@ -264,7 +264,11 @@ def _regex_extract_columns(sql: str) -> list[str]:
     clean = _strip_literals(sql)
     cols: set[str] = set()
     for m in re.finditer(r"(\w+)\.(\w+)", clean):
-        cols.add(f"{m.group(1)}.{m.group(2)}")
+        lhs, rhs = m.group(1), m.group(2)
+        # Skip numeric literals (e.g. 180.0, 3.57)
+        if lhs.isdigit() or rhs.isdigit():
+            continue
+        cols.add(f"{lhs}.{rhs}")
     return sorted(cols)
 
 

--- a/l12-schema-graph-text2sql/scripts/compute_paper_figures.py
+++ b/l12-schema-graph-text2sql/scripts/compute_paper_figures.py
@@ -504,7 +504,7 @@ output = {
         "known_l12_total": len(known_l12),
         "known_l12_recovered": len(recovered),
         "known_l12_recovery_rate_pct": pct(len(recovered) / len(known_l12)) if known_l12 else 0,
-        "total_l12_in_db": 392,  # from db/insert_data.sql, not from CSV subset
+        "total_l12_in_db": _proto_dist.get("L12", 392),
         "stable_candidates": stable_count,
         "metastable_candidates": metastable_count,
         "stable_l12_screened_total": stable_count + metastable_count,

--- a/l12-schema-graph-text2sql/scripts/run_expert_evaluation.py
+++ b/l12-schema-graph-text2sql/scripts/run_expert_evaluation.py
@@ -289,8 +289,9 @@ def main():
             },
             "comparison": {
                 "note": ("author_designed and expert_designed were evaluated with different "
-                         "pipeline versions. Current author-designed mean execution_accuracy "
-                         "is 70.2%. Expert-designed mean execution_accuracy is "
+                         "pipeline versions. Current author-designed representative run "
+                         "execution_accuracy is 70.6% (3-run mean 70.9%). "
+                         "Expert-designed mean execution_accuracy is "
                          f"{round(mean_exec_acc, 1)}%, and binary correct rate is "
                          f"{round(100*correct/total, 1)}%."),
                 "expert_designed": {

--- a/l12-schema-graph-text2sql/scripts/validate_paper_numbers.py
+++ b/l12-schema-graph-text2sql/scripts/validate_paper_numbers.py
@@ -6,6 +6,7 @@ Usage:
 
 Checks key numeric values in paper/t2sql_materials_paper.tex against
 paper/paper_figures.json to detect drift between the two.
+Additionally validates a hardcoded list of critical values that must appear in TeX.
 """
 from __future__ import annotations
 
@@ -17,6 +18,19 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 TEX = ROOT / "paper" / "t2sql_materials_paper.tex"
 JSON_PATH = ROOT / "paper" / "paper_figures.json"
+
+
+def _tex_contains(tex: str, value: str | int | float) -> bool:
+    """Check if value appears in TeX, considering LaTeX number formatting."""
+    s = str(value)
+    if s in tex:
+        return True
+    # LaTeX thousand separator: 1{,}470
+    if s.isdigit() and len(s) >= 4:
+        latex_num = re.sub(r"(\d)(?=(\d{3})+$)", r"\1{,}", s)
+        if latex_num in tex:
+            return True
+    return False
 
 
 def main() -> int:
@@ -33,84 +47,131 @@ def main() -> int:
 
     errors: list[str] = []
     warnings: list[str] = []
+    checked = 0
 
-    def check(label: str, json_val: str, tex_pattern: str, *, required: bool = True):
-        """Check if json_val appears in TeX matching the pattern."""
-        if re.search(tex_pattern, tex):
+    def check(label: str, value, *, required: bool = True):
+        nonlocal checked
+        checked += 1
+        if _tex_contains(tex, value):
             return
-        # Try plain containment
-        if str(json_val) in tex:
-            return
-        # Try LaTeX number format (e.g. 1{,}470 for 1470)
-        val_str = str(json_val)
-        if val_str.isdigit() and len(val_str) >= 4:
-            latex_num = re.sub(r'(\d)(?=(\d{3})+$)', r'\1{,}', val_str)
-            if latex_num in tex:
-                return
-        msg = f"{label}: JSON={json_val}, pattern not found in TeX"
+        msg = f"{label}: value={value} not found in TeX"
         if required:
             errors.append(msg)
         else:
             warnings.append(msg)
 
-    # --- Proposed accuracy ---
+    # ================================================================
+    # Part 1: JSON-driven checks (keys must match paper_figures.json)
+    # ================================================================
+
+    # Proposed overall
     proposed = fig.get("proposed_overall", {})
-    acc = proposed.get("exec_accuracy_pct")
-    if acc is not None:
-        check("Proposed accuracy", acc, rf"{acc}\s*\\?%")
+    if proposed.get("exec_accuracy_pct") is not None:
+        check("Proposed accuracy", proposed["exec_accuracy_pct"])
+    else:
+        errors.append("KEY MISSING: proposed_overall.exec_accuracy_pct")
 
-    # --- 3-run stats ---
+    # 3-run stats
     stats = fig.get("proposed_3run_stats", {})
-    mean_acc = stats.get("mean_accuracy_pct")
-    std_acc = stats.get("stdev_pp")
-    if mean_acc is not None:
-        check("3-run mean", mean_acc, rf"{mean_acc}")
-    if std_acc is not None:
-        check("3-run std", std_acc, rf"{std_acc}")
+    if stats.get("mean_accuracy_pct") is not None:
+        check("3-run mean", stats["mean_accuracy_pct"])
+    else:
+        errors.append("KEY MISSING: proposed_3run_stats.mean_accuracy_pct")
+    if stats.get("stdev_pp") is not None:
+        check("3-run stdev", stats["stdev_pp"])
+    else:
+        errors.append("KEY MISSING: proposed_3run_stats.stdev_pp")
 
-    # --- DB stats ---
+    # DB stats
     db = fig.get("db_stats", {})
     proto = db.get("prototype_distribution", {})
-    l12_count = proto.get("L12")
-    if l12_count is not None:
-        check("L12 count", l12_count, rf"\b{l12_count}\b")
+    for pname in ["L12", "B2", "NaCl", "NiAs", "BiF3"]:
+        if proto.get(pname) is not None:
+            check(f"Prototype {pname}", proto[pname], required=(pname == "L12"))
 
     n_entries = db.get("n_entries")
     if n_entries is not None:
-        check("DB entries", n_entries, rf"\b{n_entries}\b", required=False)
+        check("DB total entries", n_entries)
+    n_tables = db.get("n_tables")
+    if n_tables is not None:
+        check("DB n_tables", n_tables, required=False)
 
-    # --- Materials engineering ---
+    # Materials engineering
     mat = fig.get("materials_engineering", {})
-    screened = mat.get("stable_l12_screened_total")
-    if screened is not None:
-        check("Stable+metastable L12", screened, rf"\b{screened}\b")
+    for key in ["stable_l12_screened_total", "stable_candidates", "metastable_candidates",
+                "gamma_prime_ranking_total"]:
+        val = mat.get(key)
+        if val is not None:
+            check(f"materials_engineering.{key}", val)
 
-    # --- Baselines ---
+    # L12 recovery
+    recovery = mat.get("known_l12_recovery")
+    if recovery:
+        total = recovery.get("total")
+        recovered = recovery.get("recovered")
+        if total is not None and recovered is not None:
+            check("L12 recovery", f"{recovered}/{total}")
+
+    # Baselines
     bl_comp = fig.get("baseline_comparison", {})
-    for bl_key, bl_label in [("B1", "LLM-only"), ("B2", "Full-schema"), ("B3", "Rule-based"), ("B4", "FK-list")]:
+    for bl_key in ["B1", "B2", "B3", "B4"]:
         bl = bl_comp.get(bl_key, {})
         bl_acc = bl.get("exec_accuracy")
         if bl_acc is not None:
-            check(f"{bl_label} ({bl_key}) accuracy", bl_acc, rf"{bl_acc}", required=False)
+            check(f"Baseline {bl_key} accuracy", bl_acc, required=False)
 
-    # --- Independent evaluation ---
-    expert = fig.get("independent_eval", {})
-    if expert:
-        binary = expert.get("binary_correct_rate")
-        if binary is not None:
-            check("Expert binary correct", binary, rf"{binary}")
-        expert_acc = expert.get("mean_exec_accuracy")
-        if expert_acc is not None:
-            check("Expert mean accuracy", expert_acc, rf"{expert_acc}")
+    # Independent evaluation
+    indep = fig.get("independent_eval", {})
+    if indep:
+        for key in ["binary_correct_rate", "mean_exec_accuracy"]:
+            val = indep.get(key)
+            if val is not None:
+                check(f"independent_eval.{key}", val)
 
-    # --- Latency ---
+    # Latency
     latency = proposed.get("avg_latency_ms")
     if latency is not None:
-        # check() handles LaTeX {,} format for integers >= 4 digits
-        lat_int = int(latency) if isinstance(latency, (int, float)) else latency
-        check("Avg latency", lat_int, rf"\b{lat_int}\b", required=False)
+        check("Avg latency (ms)", int(latency))
+    avg_tokens = proposed.get("avg_token_usage")
+    if avg_tokens is not None:
+        check("Avg token usage", int(avg_tokens), required=False)
 
-    # --- Report ---
+    # Difficulty breakdown (by_difficulty from proposed)
+    by_diff = fig.get("proposed_by_difficulty", {})
+    for diff_key in ["Easy", "Medium", "Hard", "Very Hard"]:
+        d = by_diff.get(diff_key, {})
+        acc = d.get("exec_accuracy_pct")
+        if acc is not None:
+            check(f"Difficulty {diff_key} accuracy", acc, required=False)
+        n = d.get("n")
+        if n is not None:
+            check(f"Difficulty {diff_key} count", n, required=False)
+
+    # ================================================================
+    # Part 2: Explicit critical values (safety net)
+    # These MUST appear in TeX regardless of JSON structure.
+    # ================================================================
+    critical_values = {
+        "Proposed representative accuracy": 70.6,
+        "3-run mean accuracy": 70.9,
+        "3-run stdev": 1.7,
+        "Very Hard query count": 23,
+        "L12 prototype count": 392,
+        "DB total entries": 1470,
+        "Stable+metastable L12 total": 162,
+        "Stable L12 count": 8,
+        "Metastable L12 count": 154,
+        "Gamma-prime ranking total": 259,
+        "Independent binary correct rate": 79.3,
+        "Independent mean accuracy": 77.0,
+    }
+    for label, val in critical_values.items():
+        check(f"[CRITICAL] {label}", val)
+
+    # ================================================================
+    # Report
+    # ================================================================
+    print(f"Checked {checked} values.")
     if errors:
         print(f"\n{'='*60}")
         print(f"VALIDATION FAILED: {len(errors)} error(s), {len(warnings)} warning(s)")
@@ -121,7 +182,7 @@ def main() -> int:
             print(f"  WARN:  {w}")
         return 1
 
-    print(f"✓ All key values in paper_figures.json found in TeX ({len(warnings)} warning(s))")
+    print(f"All {checked} values verified in TeX ({len(warnings)} warning(s))")
     for w in warnings:
         print(f"  WARN: {w}")
     return 0


### PR DESCRIPTION
## Summary

S6に残っていた古い安定候補名(YPt₃,ErPd₃,PaRh₃,ScPd₃)をCSV実データ(Pt₃Al,Al₃Sc,Co₃Ti,Ni₃Al)に差替え。S5キャプションの選定基準を実態に合わせ修正。`validate_paper_numbers.py`を34値の明示検証に強化。

**論文修正**: S6の形成エネルギー値をCSV実データに(-0.981→-0.550等)。γ'ランキング対象259件をTeX本文に追記。

**fallbackバグ**: `literature_reference`参加時に`lr.doi/title/year`をSELECT追加。COUNT系クエリ(「総数」「何件」等)で`SELECT COUNT(*)`生成。`_regex_extract_columns`で`180.0`等の数値リテラルを列名候補から除外。格子定数toleranceのユーザー指定値抽出(`extract_lattice_reference` → `condition_mapper`連携)。

**スクリプト修正**: `run_expert_evaluation.py`の70.2%→70.6%。`compute_paper_figures.py`の`total_l12_in_db`をCSV動的参照に。

125テスト PASS, `validate_paper_numbers.py` 34値 PASS

Link to Devin session: https://app.devin.ai/sessions/5c4cf372d3d54d638f06fe4ed622b85b
Requested by: @minimumtone