### PR TITLE
fix: v12レビュー10件+API検証 — B3 LIMIT公平性・COUNT偽陽性・スキーマ一致・PDF整合

### DIFF
--- a/l12-schema-graph-text2sql/README.md
+++ b/l12-schema-graph-text2sql/README.md
@@ -116,7 +116,7 @@ l12-schema-graph-text2sql/
 │   └── allowed_schema.yaml   # 許可テーブル・カラム定義
 ├── evaluation/          # 評価パイプライン
 │   ├── evaluation_dataset.jsonl # 100クエリ（Easy/Medium/Hard/VeryHard）
-│   ├── gold_sql/        # 正解SQL 100件
+│   ├── gold_sql/        # 正解SQL 200件（著者設計100件 + 独立設計100件）
 │   ├── expected_results/ # 正解実行結果JSON
 │   ├── metrics.py       # 評価指標（構文妥当率、実行精度等）
 │   ├── run_proposed.py  # Proposed手法実行
@@ -127,7 +127,10 @@ l12-schema-graph-text2sql/
 │   └── baseline_result.csv     # ベースライン4手法結果
 ├── scripts/             # 評価・分析スクリプト
 │   ├── run_full_evaluation.py      # 5手法完全評価
-│   └── generate_gold_sql_and_results.py  # Gold SQL生成
+│   ├── run_proposed_only.py        # Proposed手法のみ再評価
+│   ├── run_expert_evaluation.py    # 独立設計100件評価
+│   ├── compute_paper_figures.py    # 論文数値JSON生成
+│   └── validate_paper_numbers.py   # TeX数値検証
 ├── api/                 # FastAPI アプリケーション
 │   └── main.py
 ├── tests/               # ユニットテスト（125件）
@@ -144,7 +147,7 @@ l12-schema-graph-text2sql/
 |--------|--------------|-----------|-----------|---------|--------------|---------|
 | B1: LLM-only | 何も渡さない | 98% | 98% | 64.6% | 0% | 16件 |
 | B2: Full Schema | 全テーブル一覧 | 94% | 94% | 68.7% | 0% | 18件 |
-| B3: Rule-based | 辞書ルール（LLM不使用） | 100% | 93% | 36.9% | 0% | 3件 |
+| B3: Rule-based | 辞書ルール（LLM不使用） | 100% | 95% | 52.8% | 0% | 3件 |
 | B4: FK-list | FK関係リストのみ | 98% | 98% | 66.4% | 0% | 21件 |
 | **P: Proposed** | **Steiner木で選んだサブグラフ** | **100%** | **100%** | **70.6%** (3回平均70.9%±1.7pp) | **0%** | **3件** |
 
@@ -169,7 +172,7 @@ v4でgraph層のJOIN方向バグ（`_edge_source`による逆方向走査時の�
 
 `baseline_result.csv` は `condition_mapper`/`entity_extractor` の辞書拡張
 （elastic_tensor, thermal_property, magnetic_property対応）前のコードで生成。
-辞書拡張後にB3 (Rule-based) を再ランすると36.9%から変動する可能性あり。
+辞書拡張後にB3 (Rule-based) を再ランすると52.8%から変動する可能性あり。
 
 ## Key Features
 

--- a/l12-schema-graph-text2sql/README_DELIVERY.md
+++ b/l12-schema-graph-text2sql/README_DELIVERY.md
@@ -92,12 +92,12 @@ for sql_file in sorted(os.listdir("evaluation/gold_sql")):
 python scripts/compute_paper_figures.py
 ```
 
-## 完全再現（リポジトリ必要）
+## 完全再現
 
-完全な評価再現にはリポジトリのクローンが必要です:
+完全な評価再現は、このZIP展開版またはリポジトリクローンのどちらでも可能です:
 
 ```bash
-git clone <repository_url>
+# ZIP展開版の場合
 cd l12-schema-graph-text2sql
 pip install -e ".[dev]"
 cd docker && docker compose up -d && cd ..
@@ -144,8 +144,9 @@ join_list = get_allowed_join_list(db_connection)  # requires live DB
 result = pipeline(query, join_list=join_list)
 ```
 
-**LIMIT値について**: rule-based fallbackのデフォルトは `LIMIT 100`（環境変数 `SQL_ROW_LIMIT` で変更可）。
-論文評価時は `SQL_ROW_LIMIT=10000` を使用しています。「L12型化合物を全て出して」のような広いクエリでは結果数が異なります。
+**LIMIT値について**: rule-based fallbackはLIMITを生成しません。評価時は `normalize_limit()` により
+LIMITなしのSQLに `LIMIT 10000` が統一的に付加されます（全手法共通）。
+API経由の場合は `sql_validator.check_limit()` が `LIMIT 10000` を自動付加します。
 
 ## LaTeX再コンパイルに必要な環境
 
@@ -162,4 +163,4 @@ PDF自体は同梱済みのため、閲覧のみであれば再コンパイル�
 
 `baseline_result.csv` は `condition_mapper`/`entity_extractor` の辞書拡張（elastic_tensor,
 thermal_property, magnetic_property対応）前のコードで生成されたもの。
-辞書拡張後にB3 (Rule-based) を再ランすると36.9%から変動する可能性がある。
+辞書拡張後にB3 (Rule-based) を再ランすると52.8%から変動する可能性がある。

--- a/l12-schema-graph-text2sql/db/insert_data.sql
+++ b/l12-schema-graph-text2sql/db/insert_data.sql
@@ -19394,7 +19394,6 @@ INSERT INTO measured_property (measurement_id, property_name, value, unit, uncer
 INSERT INTO experimental_measurement (measurement_id, entry_id, method, temperature_k) VALUES (75, 'entry_00065', 'DSC', 436.6);
 INSERT INTO measured_property (measurement_id, property_name, value, unit, uncertainty) VALUES (75, 'resistivity', 366.292, 'A', 4.309);
 INSERT INTO experimental_measurement (measurement_id, entry_id, method, temperature_k) VALUES (76, 'entry_01379', 'DSC', 621.9);
--- Generated 1470 material entries
 INSERT INTO measured_property (measurement_id, property_name, value, unit, uncertainty) VALUES (76, 'hardness', 380.496, 'GPa', 4.073);
 INSERT INTO experimental_measurement (measurement_id, entry_id, method, temperature_k) VALUES (77, 'entry_01042', 'SEM', 205.1);
 INSERT INTO measured_property (measurement_id, property_name, value, unit, uncertainty) VALUES (77, 'density', 301.788, 'A', 3.411);

--- a/l12-schema-graph-text2sql/evaluation/baseline_result.csv
+++ b/l12-schema-graph-text2sql/evaluation/baseline_result.csv
@@ -6307,7 +6307,8 @@ FROM material_entry m
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
-LIMIT 100;",True,True,0.25510204081632654,1.0,0.25510204081632654,0.40650406504065045,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_easy_002,Niを含むL1₂型金属間化合物を抽出して。,easy,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
@@ -6316,52 +6317,60 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND c.element = 'Ni'
-LIMIT 100;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_easy_003,A₃B型組成を持つ化合物を表示して。,easy,1,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula
 FROM material_entry m
     JOIN composition c ON c.entry_id = m.entry_id
 WHERE
     c.element = 'B'
-LIMIT 100;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_easy_004,L12型化合物の格子定数を一覧にして。,easy,1,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
-LIMIT 100;",True,True,0.25510204081632654,1.0,0.25510204081632654,0.40650406504065045,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_easy_005,Coを含む化合物を表示して。,easy,1,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula
 FROM material_entry m
     JOIN composition c ON c.entry_id = m.entry_id
 WHERE
     c.element = 'Co'
-LIMIT 100;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_easy_006,cubic構造の化合物を一覧にして。,easy,1,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
     JOIN structure s ON s.entry_id = m.entry_id
-LIMIT 100;",True,True,0.0680515759312321,0.95,0.0680515759312321,0.12700534759358287,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,0.9496598639455782,1.0,0.9741800418702024,1.0,0.9496598639455782,0.9741800418702024,0.0,0.0,0.0,0,0,0,0
 q_easy_007,L1₂型化合物のリストを出して。,easy,1,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
-LIMIT 100;",True,True,0.25510204081632654,1.0,0.25510204081632654,0.40650406504065045,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_easy_008,Alを含む化合物を抽出して。,easy,1,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula
 FROM material_entry m
     JOIN composition c ON c.entry_id = m.entry_id
 WHERE
     c.element = 'Al'
-LIMIT 100;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_easy_009,空間群番号221の化合物を表示して。,easy,1,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
     JOIN structure s ON s.entry_id = m.entry_id
-LIMIT 100;",True,True,0.07295719844357977,0.75,0.07295719844357977,0.13297872340425532,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,0.6993197278911565,1.0,0.8230584467574059,1.0,0.6993197278911565,0.8230584467574059,0.0,0.0,0.0,0,0,0,0
 q_easy_010,Tiを含むL1₂型化合物を一覧にして。,easy,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
@@ -6370,32 +6379,36 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND c.element = 'Ti'
-LIMIT 100;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_easy_011,全化合物のformula一覧を出して。,easy,0,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula
 FROM material_entry m
-LIMIT 100;",True,True,0.06802721088435375,1.0,0.06802721088435375,0.12738853503184713,0.06802721088435375,1.0,0.12738853503184713,0.0,1.0,0.0,0,0,0,0
-q_easy_012,L12型化合物の数を教えて。,easy,1,baseline3_rule_based,"SELECT DISTINCT
-    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
+q_easy_012,L12型化合物の数を教えて。,easy,1,baseline3_rule_based,"SELECT COUNT(*) AS total_count
 FROM material_entry m
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
-LIMIT 100;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_easy_013,Ptを含む化合物を表示して。,easy,1,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula
 FROM material_entry m
     JOIN composition c ON c.entry_id = m.entry_id
 WHERE
     c.element = 'Pt'
-LIMIT 100;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_easy_014,NiとAlの両方を含む化合物を抽出して。,easy,1,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula
 FROM material_entry m
 WHERE
     EXISTS (SELECT 1 FROM composition c_ni WHERE c_ni.entry_id = m.entry_id AND c_ni.element = 'Ni')
     AND EXISTS (SELECT 1 FROM composition c_al WHERE c_al.entry_id = m.entry_id AND c_al.element = 'Al')
-LIMIT 100;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_easy_015,Gaを含むL1₂型化合物を表示して。,easy,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
@@ -6404,32 +6417,37 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND c.element = 'Ga'
-LIMIT 100;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_easy_016,Feを含む化合物を一覧にして。,easy,1,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula
 FROM material_entry m
     JOIN composition c ON c.entry_id = m.entry_id
 WHERE
     c.element = 'Fe'
-LIMIT 100;",True,True,0.8771929824561403,1.0,0.8771929824561403,0.9345794392523363,0.8771929824561403,1.0,0.9345794392523363,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_easy_017,Aサイトの元素を一覧にして。,easy,1,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula
 FROM material_entry m
     JOIN composition c ON c.entry_id = m.entry_id
 WHERE
     c.site_label = 'A-site'
-LIMIT 100;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_easy_018,化合物の元素系を表示して。,easy,0,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula
 FROM material_entry m
-LIMIT 100;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_easy_019,L1₂型でcubic構造の化合物を出して。,easy,1,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
-LIMIT 100;",True,True,0.25510204081632654,1.0,0.25510204081632654,0.40650406504065045,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_easy_020,Wを含むL1₂型化合物を表示して。,easy,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
@@ -6438,7 +6456,8 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND c.element = 'W'
-LIMIT 100;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_medium_001,Niを含む安定なL1₂型化合物を抽出して。,medium,3,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6449,7 +6468,8 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND c.element = 'Ni'
     AND ps.is_stable = TRUE
-LIMIT 100;",True,True,1.0,0.4,1.0,0.5714285714285715,0.0,0.0,0.0,0.0,1.0,0.0,0,23,0,0
+
+LIMIT 10000;",True,True,1.0,0.4,1.0,0.5714285714285715,1.0,0.4,0.5714285714285715,0.0,0.0,0.0,0,0,0,0
 q_medium_002,形成エネルギーが負のL1₂型化合物を元素組み合わせごとに整理して。,medium,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6458,7 +6478,8 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.formation_energy_per_atom < 0
-LIMIT 100;",True,True,0.2881844380403458,1.0,0.2881844380403458,0.447427293064877,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_medium_003,Alを含む安定なL1₂型金属間化合物を抽出して。,medium,3,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6469,7 +6490,8 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND c.element = 'Al'
     AND ps.is_stable = TRUE
-LIMIT 100;",True,True,1.0,0.6,1.0,0.7499999999999999,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,0.6,1.0,0.7499999999999999,1.0,0.6,0.7499999999999999,0.0,0.0,0.0,0,0,0,0
 q_medium_004,Ni₃Alに近い格子定数を持つL1₂化合物を探して。,medium,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
@@ -6479,7 +6501,8 @@ WHERE
     AND EXISTS (SELECT 1 FROM composition c_ni WHERE c_ni.entry_id = m.entry_id AND c_ni.element = 'Ni')
     AND EXISTS (SELECT 1 FROM composition c_al WHERE c_al.entry_id = m.entry_id AND c_al.element = 'Al')
     AND ABS(s.lattice_a - 3.572) <= 0.03
-LIMIT 100;",True,True,0.002551020408163265,1.0,0.002551020408163265,0.0050890585241730275,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,0.002551020408163265,1.0,0.002551020408163265,0.0050890585241730275,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_medium_005,安定なL1₂型化合物を形成エネルギーが低い順に出して。,medium,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6489,7 +6512,8 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.is_stable = TRUE
 ORDER BY ps.formation_energy_per_atom ASC
-LIMIT 100;",True,True,1.0,0.21621621621621623,1.0,0.35555555555555557,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,0.21621621621621623,1.0,0.35555555555555557,1.0,0.21621621621621623,0.35555555555555557,0.0,0.0,0.0,0,0,0,0
 q_medium_006,準安定なL1₂型化合物を抽出して。,medium,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6498,7 +6522,8 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.energy_above_hull <= 0.05
-LIMIT 100;",True,True,0.5187165775401069,0.97,0.5187165775401069,0.67595818815331,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,0.958974358974359,1.0,0.9790575916230366,1.0,0.958974358974359,0.9790575916230366,0.0,0.0,0.0,0,0,0,0
 q_medium_007,L1₂型化合物の形成エネルギー分布を教えて。,medium,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6506,7 +6531,8 @@ FROM material_entry m
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
-LIMIT 100;",True,True,0.25510204081632654,1.0,0.25510204081632654,0.40650406504065045,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_medium_008,Co含有L1₂型化合物を安定性の高い順に表示して。,medium,3,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6517,7 +6543,8 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND c.element = 'Co'
     AND ps.is_stable = TRUE
-LIMIT 100;",True,True,0.06896551724137931,1.0,0.06896551724137931,0.12903225806451613,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,0.06896551724137931,1.0,0.06896551724137931,0.12903225806451613,0.06896551724137931,1.0,0.12903225806451613,0.0,0.0,0.0,0,0,0,0
 q_medium_009,格子定数が3.5Å以上のL1₂化合物を出して。,medium,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
@@ -6525,7 +6552,8 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND s.lattice_a >= 3.5
-LIMIT 100;",True,True,0.29673590504451036,1.0,0.29673590504451036,0.45766590389016015,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_medium_010,NiまたはCoを含むL1₂型化合物を一覧にして。,medium,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
@@ -6534,7 +6562,8 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND EXISTS (SELECT 1 FROM composition c_ni WHERE c_ni.entry_id = m.entry_id AND c_ni.element = 'Ni')
     AND EXISTS (SELECT 1 FROM composition c_co WHERE c_co.entry_id = m.entry_id AND c_co.element = 'Co')
-LIMIT 100;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_medium_011,形成エネルギーが-0.4以下のL1₂型化合物を出して。,medium,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6543,7 +6572,8 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.formation_energy_per_atom <= -0.4
-LIMIT 100;",True,True,0.9009009009009009,1.0,0.9009009009009009,0.947867298578199,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_medium_012,energy above hullが0.01以下のL1₂型化合物を表示して。,medium,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6553,7 +6583,8 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.energy_above_hull <= 0.01
-LIMIT 100;",True,True,0.25,1.0,0.25,0.4,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+
+LIMIT 10000;",True,True,0.25,1.0,0.25,0.4,0.25,1.0,0.4,0.0,0.0,0.0,0,0,0,0
 q_medium_013,Ti含有L1₂型化合物の格子定数と形成エネルギーを表示して。,medium,3,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6563,7 +6594,8 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND c.element = 'Ti'
-LIMIT 100;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_medium_014,L1₂化合物の格子定数を小さい順にソートして。,medium,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
@@ -6571,7 +6603,8 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
 ORDER BY s.lattice_a ASC
-LIMIT 100;",True,True,0.25510204081632654,1.0,0.25510204081632654,0.40650406504065045,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_medium_015,化学系Al-Niに属するL1₂化合物を抽出して。,medium,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
@@ -6580,7 +6613,8 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND EXISTS (SELECT 1 FROM composition c_ni WHERE c_ni.entry_id = m.entry_id AND c_ni.element = 'Ni')
     AND EXISTS (SELECT 1 FROM composition c_al WHERE c_al.entry_id = m.entry_id AND c_al.element = 'Al')
-LIMIT 100;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_medium_016,安定で格子定数が3.6Å未満のL1₂化合物を出して。,medium,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6590,7 +6624,8 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.is_stable = TRUE
     AND s.lattice_a < 3.6
-LIMIT 100;",True,True,1.0,0.18181818181818182,1.0,0.3076923076923077,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,0.18181818181818182,1.0,0.3076923076923077,1.0,0.18181818181818182,0.3076923076923077,0.0,0.0,0.0,0,0,0,0
 q_medium_017,Nbを含むL1₂型化合物の安定性情報を出して。,medium,3,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6601,7 +6636,8 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND c.element = 'Nb'
     AND ps.is_stable = TRUE
-LIMIT 100;",True,True,0.05263157894736842,1.0,0.05263157894736842,0.1,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,0.05263157894736842,1.0,0.05263157894736842,0.1,0.05263157894736842,1.0,0.1,0.0,0.0,0.0,0,0,0,0
 q_medium_018,Scを含むL1₂型化合物を格子定数と共に表示して。,medium,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
@@ -6610,7 +6646,8 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND c.element = 'Sc'
-LIMIT 100;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_medium_019,L1₂型化合物のうちis_stableがtrueのものを出して。,medium,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6619,7 +6656,8 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.is_stable = TRUE
-LIMIT 100;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_medium_020,Ni-Al系以外のL1₂型化合物を一覧にして。,medium,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
@@ -6628,16 +6666,17 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND EXISTS (SELECT 1 FROM composition c_ni WHERE c_ni.entry_id = m.entry_id AND c_ni.element = 'Ni')
     AND EXISTS (SELECT 1 FROM composition c_al WHERE c_al.entry_id = m.entry_id AND c_al.element = 'Al')
-LIMIT 100;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
-q_medium_021,Aサイト元素ごとのL1₂型化合物数を集計して。,medium,2,baseline3_rule_based,"SELECT DISTINCT
-    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
+
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
+q_medium_021,Aサイト元素ごとのL1₂型化合物数を集計して。,medium,2,baseline3_rule_based,"SELECT COUNT(*) AS total_count
 FROM material_entry m
     JOIN composition c ON c.entry_id = m.entry_id
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND c.site_label = 'A-site'
-LIMIT 100;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_medium_022,形成エネルギーが最も低いL1₂型化合物TOP5を出して。,medium,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6645,7 +6684,8 @@ FROM material_entry m
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
-LIMIT 100;",True,True,0.2,0.01,0.2,0.019047619047619046,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,0.012755102040816327,1.0,0.02518891687657431,1.0,0.012755102040816327,0.02518891687657431,0.0,0.0,0.0,0,0,0,0
 q_medium_023,格子定数が4.0Å以上のL1₂化合物を出して。,medium,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
@@ -6653,7 +6693,8 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND s.lattice_a >= 4.0
-LIMIT 100;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_medium_024,Pdを含むL1₂型化合物を形成エネルギー順に出して。,medium,3,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6664,7 +6705,8 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND c.element = 'Pd'
 ORDER BY ps.formation_energy_per_atom ASC
-LIMIT 100;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_medium_025,Cu含有のL1₂型化合物を安定性で分類して。,medium,3,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6675,7 +6717,8 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND c.element = 'Cu'
     AND ps.is_stable = TRUE
-LIMIT 100;",True,True,0.09523809523809523,1.0,0.09523809523809523,0.17391304347826084,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,0.09523809523809523,1.0,0.09523809523809523,0.17391304347826084,0.09523809523809523,1.0,0.17391304347826084,0.0,0.0,0.0,0,0,0,0
 q_medium_026,Bサイト元素ごとの平均形成エネルギーを出して。,medium,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6683,14 +6726,16 @@ FROM material_entry m
     JOIN phase_stability ps ON ps.entry_id = m.entry_id
 WHERE
     c.site_label = 'B-site'
-LIMIT 100;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_medium_027,格子体積が12Å³/atom以下のL1₂化合物を出して。,medium,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
-LIMIT 100;",True,True,0.3436293436293436,1.0,0.3436293436293436,0.5114942528735632,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_medium_028,Ir含有L1₂型化合物の一覧を出して。,medium,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
@@ -6699,14 +6744,16 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND c.element = 'Ir'
-LIMIT 100;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_medium_029,2元素系のL1₂型化合物をchemical_systemで分類して。,medium,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
-LIMIT 100;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_medium_030,安定なL1₂型化合物のうち格子定数が大きい順に並べて。,medium,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6716,7 +6763,8 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.is_stable = TRUE
 ORDER BY s.lattice_a DESC
-LIMIT 100;",True,True,1.0,0.21621621621621623,1.0,0.35555555555555557,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,0.21621621621621623,1.0,0.35555555555555557,1.0,0.21621621621621623,0.35555555555555557,0.0,0.0,0.0,0,0,0,0
 q_hard_001,Ni基超合金のγ'相候補として有望な、安定または準安定なL1₂型化合物を抽出して。,hard,3,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6729,7 +6777,8 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND c.element = 'Ni'
     AND (ps.energy_above_hull <= 0.05 OR ps.is_stable = TRUE)
-LIMIT 100;",True,False,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.2,0,1,0,0
+
+LIMIT 10000;",True,False,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_hard_002,L1₂型化合物において、Aサイト元素とBサイト元素の組み合わせが形成エネルギーに与える傾向を調べて。,hard,3,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6739,7 +6788,8 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND c.site_label IN ('A-site', 'B-site')
-LIMIT 100;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_hard_003,L1₂構造を持つ化合物のうち、格子定数がNi₃Alに近く、形成エネルギーが低い候補を抽出して。,hard,3,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6750,18 +6800,20 @@ WHERE
     AND EXISTS (SELECT 1 FROM composition c_ni WHERE c_ni.entry_id = m.entry_id AND c_ni.element = 'Ni')
     AND EXISTS (SELECT 1 FROM composition c_al WHERE c_al.entry_id = m.entry_id AND c_al.element = 'Al')
     AND ABS(s.lattice_a - 3.572) <= 0.03
-LIMIT 100;",True,True,0.009433962264150943,1.0,0.009433962264150943,0.018691588785046728,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+
+LIMIT 10000;",True,True,0.009433962264150943,1.0,0.009433962264150943,0.018691588785046728,0.009433962264150943,1.0,0.018691588785046728,0.0,0.0,0.0,0,0,0,0
 q_hard_004,安定なL1₂型化合物のバルクモジュラスを高い順に表示して。,hard,4,baseline3_rule_based,"SELECT DISTINCT
-    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
+    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap, et.bulk_modulus_vrh, et.shear_modulus_vrh
 FROM material_entry m
-    JOIN elastic_tensor el ON el.entry_id = m.entry_id
+    JOIN elastic_tensor et ON et.entry_id = m.entry_id
     JOIN phase_stability ps ON ps.entry_id = m.entry_id
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.is_stable = TRUE
-ORDER BY el.bulk_modulus_vrh DESC
-LIMIT 100;",True,False,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+ORDER BY et.bulk_modulus_vrh DESC
+
+LIMIT 10000;",True,True,0.75,0.4,0.75,0.5217391304347827,0.75,0.4,0.5217391304347827,0.0,0.0,0.0,0,0,0,0
 q_hard_005,NiまたはCoを含む安定なL1₂化合物を形成エネルギー順に並べて。,hard,3,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6773,7 +6825,8 @@ WHERE
     AND EXISTS (SELECT 1 FROM composition c_co WHERE c_co.entry_id = m.entry_id AND c_co.element = 'Co')
     AND ps.is_stable = TRUE
 ORDER BY ps.formation_energy_per_atom ASC
-LIMIT 100;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_hard_006,Aサイト元素別にL1₂型化合物の平均格子定数を集計して。,hard,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
@@ -6782,7 +6835,8 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND c.site_label = 'A-site'
-LIMIT 100;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_hard_007,形成エネルギーが-0.3以下で格子定数が3.5〜3.7ÅのL1₂化合物を抽出して。,hard,3,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6792,15 +6846,18 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.formation_energy_per_atom <= -0.3
     AND s.lattice_a BETWEEN 3.5 AND 3.7
-LIMIT 100;",True,True,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_hard_008,L1₂型化合物でバルクモジュラスが180GPa以上のものを抽出して。,hard,4,baseline3_rule_based,"SELECT DISTINCT
-    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
+    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, et.bulk_modulus_vrh, et.shear_modulus_vrh
 FROM material_entry m
-    JOIN elastic_tensor el ON el.entry_id = m.entry_id
+    JOIN elastic_tensor et ON et.entry_id = m.entry_id
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
-LIMIT 100;",True,True,0.3466666666666667,0.5531914893617021,0.3466666666666667,0.4262295081967213,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+    AND et.bulk_modulus_vrh >= 180.0
+
+LIMIT 10000;",True,True,0.5933333333333334,1.0,0.5933333333333334,0.7447698744769875,0.5933333333333334,1.0,0.7447698744769875,0.0,0.0,0.0,0,0,0,0
 q_hard_009,Co基L1₂化合物のうち、Ni₃Alに近い格子定数のものを安定性順に出して。,hard,3,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6814,7 +6871,8 @@ WHERE
     AND ps.is_stable = TRUE
     AND ABS(s.lattice_a - 3.572) <= 0.03
 ORDER BY s.lattice_a ASC
-LIMIT 100;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_hard_010,Bサイト元素がAlまたはTiのL1₂化合物を形成エネルギー順に出して。,hard,3,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6826,15 +6884,17 @@ WHERE
     AND EXISTS (SELECT 1 FROM composition c_ti WHERE c_ti.entry_id = m.entry_id AND c_ti.element = 'Ti')
     AND c.site_label = 'B-site'
 ORDER BY ps.formation_energy_per_atom ASC
-LIMIT 100;",True,False,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+
+LIMIT 10000;",True,False,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_hard_011,L1₂化合物のせん断弾性率を表示して。,hard,4,baseline3_rule_based,"SELECT DISTINCT
-    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
+    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, et.bulk_modulus_vrh, et.shear_modulus_vrh
 FROM material_entry m
-    JOIN elastic_tensor el ON el.entry_id = m.entry_id
+    JOIN elastic_tensor et ON et.entry_id = m.entry_id
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
-LIMIT 100;",True,True,0.36293436293436293,1.0,0.36293436293436293,0.5325779036827195,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,0.6216216216216216,1.0,0.6216216216216216,0.7666666666666667,0.6216216216216216,1.0,0.7666666666666667,0.0,0.0,0.0,0,0,0,0
 q_hard_012,安定で形成エネルギーが最も低いL1₂化合物のトップ10を出して。,hard,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6843,18 +6903,20 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.is_stable = TRUE
-LIMIT 100;",True,True,1.0,0.21621621621621623,1.0,0.35555555555555557,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,0.21621621621621623,1.0,0.35555555555555557,1.0,0.21621621621621623,0.35555555555555557,0.0,0.0,0.0,0,0,0,0
 q_hard_013,Ni含有L1₂化合物のバルクモジュラスと形成エネルギーの関係を出して。,hard,4,baseline3_rule_based,"SELECT DISTINCT
-    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
+    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap, et.bulk_modulus_vrh, et.shear_modulus_vrh
 FROM material_entry m
     JOIN composition c ON c.entry_id = m.entry_id
-    JOIN elastic_tensor el ON el.entry_id = m.entry_id
+    JOIN elastic_tensor et ON et.entry_id = m.entry_id
     JOIN phase_stability ps ON ps.entry_id = m.entry_id
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND c.element = 'Ni'
-LIMIT 100;",True,True,0.5,1.0,0.5,0.6666666666666666,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,0.5,1.0,0.5,0.6666666666666666,0.5,1.0,0.6666666666666666,0.0,0.0,0.0,0,0,0,0
 q_hard_014,安定なL1₂化合物をAサイト元素でグループ化し、各グループの平均形成エネルギーを出して。,hard,3,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6865,15 +6927,17 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.is_stable = TRUE
     AND c.site_label = 'A-site'
-LIMIT 100;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,25,0,0
+
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_hard_015,格子定数3.55Å付近でバルクモジュラスの高いL1₂化合物を探して。,hard,4,baseline3_rule_based,"SELECT DISTINCT
-    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
+    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, et.bulk_modulus_vrh, et.shear_modulus_vrh
 FROM material_entry m
-    JOIN elastic_tensor el ON el.entry_id = m.entry_id
+    JOIN elastic_tensor et ON et.entry_id = m.entry_id
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
-LIMIT 100;",True,True,0.25252525252525254,0.25,0.25252525252525254,0.25125628140703515,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,0.5252525252525253,0.2639593908629442,0.5252525252525253,0.3513513513513514,0.5252525252525253,0.2639593908629442,0.3513513513513514,0.0,0.0,0.0,0,0,0,0
 q_hard_016,L1₂型化合物の格子定数と形成エネルギーの相関を見たい。,hard,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6881,16 +6945,17 @@ FROM material_entry m
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
-LIMIT 100;",True,True,0.25510204081632654,1.0,0.25510204081632654,0.40650406504065045,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_hard_017,Co3TiとNi3Alの格子定数差を計算して。,hard,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     ABS(s.lattice_a - 3.55) <= 0.03
-LIMIT 100;",True,True,1.0,0.06451612903225806,1.0,0.12121212121212122,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
-q_hard_018,Al系L1₂化合物のうち安定なものとそうでないものの数を出して。,hard,3,baseline3_rule_based,"SELECT DISTINCT
-    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
+
+LIMIT 10000;",True,True,1.0,0.06451612903225806,1.0,0.12121212121212122,1.0,0.06451612903225806,0.12121212121212122,0.0,0.0,0.0,0,0,0,0
+q_hard_018,Al系L1₂化合物のうち安定なものとそうでないものの数を出して。,hard,3,baseline3_rule_based,"SELECT COUNT(*) AS total_count
 FROM material_entry m
     JOIN composition c ON c.entry_id = m.entry_id
     JOIN phase_stability ps ON ps.entry_id = m.entry_id
@@ -6899,7 +6964,8 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND c.element = 'Al'
     AND ps.is_stable = TRUE
-LIMIT 100;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_hard_019,準安定L1₂化合物をenergy above hull順にランキングして。,hard,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6910,9 +6976,9 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.energy_above_hull <= 0.05
 ORDER BY ps.energy_above_hull ASC
-LIMIT 100;",True,True,0.39572192513368987,0.9866666666666667,0.39572192513368987,0.5648854961832062,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
-q_hard_020,Bサイト元素ごとの安定L1₂化合物数を集計して。,hard,3,baseline3_rule_based,"SELECT DISTINCT
-    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
+
+LIMIT 10000;",True,True,0.39572192513368987,0.9866666666666667,0.39572192513368987,0.5648854961832062,0.39572192513368987,0.9866666666666667,0.5648854961832062,0.0,0.0,0.0,0,0,0,0
+q_hard_020,Bサイト元素ごとの安定L1₂化合物数を集計して。,hard,3,baseline3_rule_based,"SELECT COUNT(*) AS total_count
 FROM material_entry m
     JOIN composition c ON c.entry_id = m.entry_id
     JOIN phase_stability ps ON ps.entry_id = m.entry_id
@@ -6921,30 +6987,35 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.is_stable = TRUE
     AND c.site_label = 'B-site'
-LIMIT 100;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_hard_021,DFT計算で得られたL1₂化合物の物性一覧を出して。,hard,4,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
-LIMIT 100;",True,True,0.3436293436293436,1.0,0.3436293436293436,0.5114942528735632,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_hard_022,PBE汎関数で計算されたL1₂化合物のバルクモジュラスを表示して。,hard,4,baseline3_rule_based,"SELECT DISTINCT
-    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
+    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, et.bulk_modulus_vrh, et.shear_modulus_vrh
 FROM material_entry m
     JOIN calculation calc ON calc.entry_id = m.entry_id
-    JOIN elastic_tensor el ON el.entry_id = m.entry_id
+    JOIN elastic_tensor et ON et.entry_id = m.entry_id
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
-LIMIT 100;",True,True,0.36293436293436293,1.0,0.36293436293436293,0.5325779036827195,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+
+LIMIT 10000;",True,True,0.6216216216216216,1.0,0.6216216216216216,0.7666666666666667,0.6216216216216216,1.0,0.7666666666666667,0.0,0.0,0.0,0,0,0,0
 q_hard_023,L1₂化合物の格子ミスマッチ（Ni3Alとの差）を計算して小さい順に表示して。,hard,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
-LIMIT 100;",True,True,0.25510204081632654,1.0,0.25510204081632654,0.40650406504065045,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+    AND (m.formula = 'Ni3Al' OR m.reduced_formula = 'Ni3Al')
+
+LIMIT 10000;",True,True,0.002551020408163265,1.0,0.002551020408163265,0.0050890585241730275,0.002551020408163265,1.0,0.0050890585241730275,0.0,0.0,0.0,0,0,0,0
 q_hard_024,Fe含有L1₂化合物の安定性と弾性特性を同時に表示して。,hard,4,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6955,17 +7026,20 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND c.element = 'Fe'
     AND ps.is_stable = TRUE
-LIMIT 100;",True,True,0.10714285714285714,1.0,0.10714285714285714,0.19354838709677416,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,0.10714285714285714,1.0,0.10714285714285714,0.19354838709677416,0.10714285714285714,1.0,0.19354838709677416,0.0,0.0,0.0,0,0,0,0
 q_hard_025,安定なL1₂化合物でバルクモジュラスが160GPa以上のものを抽出して。,hard,4,baseline3_rule_based,"SELECT DISTINCT
-    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
+    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap, et.bulk_modulus_vrh, et.shear_modulus_vrh
 FROM material_entry m
-    JOIN elastic_tensor el ON el.entry_id = m.entry_id
+    JOIN elastic_tensor et ON et.entry_id = m.entry_id
     JOIN phase_stability ps ON ps.entry_id = m.entry_id
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.is_stable = TRUE
-LIMIT 100;",True,True,1.0,0.3333333333333333,1.0,0.5,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+    AND et.bulk_modulus_vrh >= 160.0
+
+LIMIT 10000;",True,True,1.0,0.4166666666666667,1.0,0.5882352941176471,1.0,0.4166666666666667,0.5882352941176471,0.0,0.0,0.0,0,0,0,0
 q_hard_026,L1₂化合物で安定性と格子定数の両面でNi3Alに近い候補を出して。,hard,3,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -6976,7 +7050,8 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.is_stable = TRUE
     AND ABS(s.lattice_a - 3.572) <= 0.03
-LIMIT 100;",True,True,0.010256410256410256,1.0,0.010256410256410256,0.020304568527918784,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,0.010256410256410256,1.0,0.010256410256410256,0.020304568527918784,0.010256410256410256,1.0,0.020304568527918784,0.0,0.0,0.0,0,0,0,0
 q_hard_027,Aサイト元素がNiまたはCoで、Bサイト元素がAlまたはTiのL1₂化合物を出して。,hard,3,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
@@ -6988,14 +7063,16 @@ WHERE
     AND EXISTS (SELECT 1 FROM composition c_co WHERE c_co.entry_id = m.entry_id AND c_co.element = 'Co')
     AND EXISTS (SELECT 1 FROM composition c_ti WHERE c_ti.entry_id = m.entry_id AND c_ti.element = 'Ti')
     AND c.site_label IN ('A-site', 'B-site')
-LIMIT 100;",True,False,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,2,0,0
+
+LIMIT 10000;",True,False,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_hard_028,L1₂型化合物の体積あたり原子数と格子定数の関係を出して。,hard,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
-LIMIT 100;",True,True,0.25510204081632654,1.0,0.25510204081632654,0.40650406504065045,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0,0,0,0
 q_hard_029,L1₂化合物でenergy above hullが0で形成エネルギーが-0.4以下のものを出して。,hard,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -7005,7 +7082,8 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.formation_energy_per_atom <= -0.4
-LIMIT 100;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_hard_030,遷移金属を含むL1₂型化合物のうち安定なものを出して。,hard,3,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -7014,7 +7092,8 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.is_stable = TRUE
-LIMIT 100;",True,True,1.0,0.1891891891891892,1.0,0.3181818181818182,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,1.0,0.1891891891891892,1.0,0.3181818181818182,1.0,0.1891891891891892,0.3181818181818182,0.0,0.0,0.0,0,0,0,0
 q_vhard_001,L1₂型金属間化合物において、相安定性、格子ミスマッチ、弾性特性を同時に考慮した析出強化相候補を抽出して。,very_hard,4,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -7023,7 +7102,8 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.is_stable = TRUE
-LIMIT 100;",True,True,0.18974358974358974,1.0,0.18974358974358974,0.3189655172413793,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+
+LIMIT 10000;",True,True,0.18974358974358974,1.0,0.18974358974358974,0.3189655172413793,0.18974358974358974,1.0,0.3189655172413793,0.0,0.0,0.0,0,0,0,0
 q_vhard_002,Ni₃Al代替またはCo基γ'相候補として有望なL1₂型金属間化合物を、形成エネルギー、格子定数、弾性率の観点から探索して。,very_hard,4,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -7035,22 +7115,24 @@ WHERE
     AND EXISTS (SELECT 1 FROM composition c_al WHERE c_al.entry_id = m.entry_id AND c_al.element = 'Al')
     AND EXISTS (SELECT 1 FROM composition c_co WHERE c_co.entry_id = m.entry_id AND c_co.element = 'Co')
     AND ABS(s.lattice_a - 3.572) <= 0.03
-LIMIT 100;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_vhard_003,γ'相候補のランキングを安定性・格子整合性・バルクモジュラスの重み付きスコアで出して。,very_hard,4,baseline3_rule_based,"SELECT DISTINCT
-    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
+    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap, et.bulk_modulus_vrh, et.shear_modulus_vrh
 FROM material_entry m
-    JOIN elastic_tensor el ON el.entry_id = m.entry_id
+    JOIN elastic_tensor et ON et.entry_id = m.entry_id
     JOIN phase_stability ps ON ps.entry_id = m.entry_id
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.is_stable = TRUE
-ORDER BY el.bulk_modulus_vrh ASC
-LIMIT 100;",True,False,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+ORDER BY et.bulk_modulus_vrh ASC
+
+LIMIT 10000;",True,True,0.07692307692307693,1.0,0.07692307692307693,0.14285714285714288,0.07692307692307693,1.0,0.14285714285714288,0.0,0.0,0.0,0,0,0,0
 q_vhard_004,NiまたはCo含有で安定かつバルクモジュラスが高いL1₂化合物トップ10を出して。,very_hard,4,baseline3_rule_based,"SELECT DISTINCT
-    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
+    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap, et.bulk_modulus_vrh, et.shear_modulus_vrh
 FROM material_entry m
-    JOIN elastic_tensor el ON el.entry_id = m.entry_id
+    JOIN elastic_tensor et ON et.entry_id = m.entry_id
     JOIN phase_stability ps ON ps.entry_id = m.entry_id
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
@@ -7058,7 +7140,8 @@ WHERE
     AND EXISTS (SELECT 1 FROM composition c_ni WHERE c_ni.entry_id = m.entry_id AND c_ni.element = 'Ni')
     AND EXISTS (SELECT 1 FROM composition c_co WHERE c_co.entry_id = m.entry_id AND c_co.element = 'Co')
     AND ps.is_stable = TRUE
-LIMIT 100;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_vhard_005,L1₂型化合物の元素組み合わせと安定性の関係をAサイト・Bサイト別に集計して材料設計の指針を得たい。,very_hard,3,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -7069,11 +7152,12 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.is_stable = TRUE
     AND c.site_label IN ('A-site', 'B-site')
-LIMIT 100;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_vhard_006,Ni3Alの格子定数に近く、バルクモジュラスが高く、安定なL1₂候補を総合的にランキングして。,very_hard,4,baseline3_rule_based,"SELECT DISTINCT
-    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
+    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap, et.bulk_modulus_vrh, et.shear_modulus_vrh
 FROM material_entry m
-    JOIN elastic_tensor el ON el.entry_id = m.entry_id
+    JOIN elastic_tensor et ON et.entry_id = m.entry_id
     JOIN phase_stability ps ON ps.entry_id = m.entry_id
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
@@ -7081,7 +7165,8 @@ WHERE
     AND ps.is_stable = TRUE
     AND ABS(s.lattice_a - 3.572) <= 0.03
 ORDER BY s.lattice_a ASC
-LIMIT 100;",True,True,0.015384615384615385,1.0,0.015384615384615385,0.030303030303030307,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+
+LIMIT 10000;",True,True,0.015384615384615385,1.0,0.015384615384615385,0.030303030303030307,0.015384615384615385,1.0,0.030303030303030307,0.0,0.0,0.0,0,0,0,0
 q_vhard_007,析出強化に適したL1₂化合物を格子ミスマッチ、弾性率、安定性の多基準で評価して上位候補を出して。,very_hard,4,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -7090,7 +7175,8 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.is_stable = TRUE
-LIMIT 100;",True,True,0.18974358974358974,1.0,0.18974358974358974,0.3189655172413793,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+
+LIMIT 10000;",True,True,0.18974358974358974,1.0,0.18974358974358974,0.3189655172413793,0.18974358974358974,1.0,0.3189655172413793,0.0,0.0,0.0,0,0,0,0
 q_vhard_008,Co基超合金のγ'相候補として、Co含有で安定なL1₂化合物をNi3Alとの比較で評価して。,very_hard,4,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -7103,17 +7189,19 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND c.element = 'Co'
     AND ps.is_stable = TRUE
-LIMIT 100;",True,False,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.2,0,1,0,0
+
+LIMIT 10000;",True,False,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_vhard_009,L1₂型化合物データベースから、バルクモジュラスとせん断弾性率の比(B/G比)を計算して延性候補を抽出して。,very_hard,4,baseline3_rule_based,"SELECT DISTINCT
-    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
+    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, et.bulk_modulus_vrh, et.shear_modulus_vrh
 FROM material_entry m
     JOIN composition c ON c.entry_id = m.entry_id
-    JOIN elastic_tensor el ON el.entry_id = m.entry_id
+    JOIN elastic_tensor et ON et.entry_id = m.entry_id
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND c.element = 'B'
-LIMIT 100;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_vhard_010,L1₂型化合物の安定性マップ（formation energy vs energy above hull）を出力して、候補を4象限に分類して。,very_hard,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -7123,7 +7211,8 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.is_stable = TRUE
-LIMIT 100;",True,True,0.05128205128205128,1.0,0.05128205128205128,0.09756097560975609,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+
+LIMIT 10000;",True,True,0.05128205128205128,1.0,0.05128205128205128,0.09756097560975609,0.05128205128205128,1.0,0.09756097560975609,0.0,0.0,0.0,0,0,0,0
 q_vhard_011,高温安定性の観点で有望なL1₂型化合物を形成エネルギーの深さで評価して上位を出して。,very_hard,2,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -7132,7 +7221,8 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.is_stable = TRUE
-LIMIT 100;",True,True,0.09438775510204081,1.0,0.09438775510204081,0.17249417249417248,0.0,0.0,0.0,0.0,1.0,0.0,0,2,0,0
+
+LIMIT 10000;",True,True,0.09438775510204081,1.0,0.09438775510204081,0.17249417249417248,0.09438775510204081,1.0,0.17249417249417248,0.0,0.0,0.0,0,0,0,0
 q_vhard_012,Ni基超合金のγ'相代替候補として、Ni-Al系以外で安定なL1₂化合物を格子整合性で評価して。,very_hard,3,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -7145,15 +7235,17 @@ WHERE
     AND EXISTS (SELECT 1 FROM composition c_ni WHERE c_ni.entry_id = m.entry_id AND c_ni.element = 'Ni')
     AND EXISTS (SELECT 1 FROM composition c_al WHERE c_al.entry_id = m.entry_id AND c_al.element = 'Al')
     AND ps.is_stable = TRUE
-LIMIT 100;",True,False,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.25,0,1,0,0
+
+LIMIT 10000;",True,False,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_vhard_013,L1₂型化合物で体積弾性率と格子定数を散布図データとして出力して。,very_hard,4,baseline3_rule_based,"SELECT DISTINCT
-    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
+    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, et.bulk_modulus_vrh, et.shear_modulus_vrh
 FROM material_entry m
-    JOIN elastic_tensor el ON el.entry_id = m.entry_id
+    JOIN elastic_tensor et ON et.entry_id = m.entry_id
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
-LIMIT 100;",True,True,0.25,0.01,0.25,0.019230769230769232,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+
+LIMIT 10000;",True,True,0.75,0.015228426395939087,0.75,0.029850746268656712,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_vhard_014,元素周期の観点から、3d遷移金属と4d/5d遷移金属をAサイトに持つL1₂化合物の安定性傾向を比較して。,very_hard,3,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -7164,17 +7256,20 @@ WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.is_stable = TRUE
     AND c.site_label = 'A-site'
-LIMIT 100;",True,True,1.0,0.21621621621621623,1.0,0.35555555555555557,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+
+LIMIT 10000;",True,True,1.0,0.21621621621621623,1.0,0.35555555555555557,1.0,0.21621621621621623,0.35555555555555557,0.0,0.0,0.0,0,0,0,0
 q_vhard_015,L1₂化合物のうちNi3Alより安定でバルクモジュラスが高い候補を出して。,very_hard,4,baseline3_rule_based,"SELECT DISTINCT
-    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
+    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap, et.bulk_modulus_vrh, et.shear_modulus_vrh
 FROM material_entry m
-    JOIN elastic_tensor el ON el.entry_id = m.entry_id
+    JOIN elastic_tensor et ON et.entry_id = m.entry_id
     JOIN phase_stability ps ON ps.entry_id = m.entry_id
     JOIN structure s ON s.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.is_stable = TRUE
-LIMIT 100;",True,True,0.07692307692307693,1.0,0.07692307692307693,0.14285714285714288,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+    AND (m.formula = 'Ni3Al' OR m.reduced_formula = 'Ni3Al')
+
+LIMIT 10000;",True,True,0.005128205128205128,1.0,0.005128205128205128,0.010204081632653062,0.005128205128205128,1.0,0.010204081632653062,0.0,0.0,0.0,0,0,0,0
 q_vhard_016,Co-Al-W系L1₂候補の安定性と弾性特性を評価して。,very_hard,4,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -7186,7 +7281,8 @@ WHERE
     AND EXISTS (SELECT 1 FROM composition c_co WHERE c_co.entry_id = m.entry_id AND c_co.element = 'Co')
     AND EXISTS (SELECT 1 FROM composition c_w WHERE c_w.entry_id = m.entry_id AND c_w.element = 'W')
     AND ps.is_stable = TRUE
-LIMIT 100;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,0,0,0
+
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_vhard_017,全L1₂化合物について、安定性スコア×格子整合性スコア×弾性スコアの複合スコアを計算してランキングして。,very_hard,4,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -7195,17 +7291,20 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.is_stable = TRUE
-LIMIT 100;",True,True,0.6,0.32432432432432434,0.6,0.4210526315789474,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+
+LIMIT 10000;",True,True,0.6,0.32432432432432434,0.6,0.4210526315789474,0.6,0.32432432432432434,0.4210526315789474,0.0,0.0,0.0,0,0,0,0
 q_vhard_018,Ni3Al代替γ'相候補をバルクモジュラス、形成エネルギー、格子ミスマッチの3軸パレート面で出力して。,very_hard,4,baseline3_rule_based,"SELECT DISTINCT
-    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
+    m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap, et.bulk_modulus_vrh, et.shear_modulus_vrh
 FROM material_entry m
-    JOIN elastic_tensor el ON el.entry_id = m.entry_id
+    JOIN elastic_tensor et ON et.entry_id = m.entry_id
     JOIN phase_stability ps ON ps.entry_id = m.entry_id
     JOIN structure s ON s.entry_id = m.entry_id
     JOIN surface_energy su ON su.entry_id = m.entry_id
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
-LIMIT 100;",True,True,0.14285714285714285,0.02702702702702703,0.14285714285714285,0.045454545454545456,0.0,0.0,0.0,0.0,1.0,0.0,0,2,0,0
+    AND (m.formula = 'Ni3Al' OR m.reduced_formula = 'Ni3Al')
+
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_vhard_019,L1₂型化合物データベースから材料設計仮説を導出するため、安定化合物の元素分布とその物性傾向を包括的に集計して。,very_hard,4,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group, ps.formation_energy_per_atom, ps.energy_above_hull, ps.band_gap
 FROM material_entry m
@@ -7214,7 +7313,8 @@ FROM material_entry m
 WHERE
     (s.prototype = 'L12' OR s.strukturbericht = 'L12')
     AND ps.is_stable = TRUE
-LIMIT 100;",True,True,0.18811881188118812,0.5135135135135135,0.18811881188118812,0.2753623188405797,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+
+LIMIT 10000;",True,True,0.18811881188118812,0.5135135135135135,0.18811881188118812,0.2753623188405797,0.18811881188118812,0.5135135135135135,0.2753623188405797,0.0,0.0,0.0,0,0,0,0
 q_vhard_020,次世代γ'相候補として、Ni-Al-Co-Ti四元系でL1₂構造をとりうる組成を探索して。,very_hard,3,baseline3_rule_based,"SELECT DISTINCT
     m.entry_id, m.formula, s.prototype, s.lattice_a, s.space_group
 FROM material_entry m
@@ -7225,7 +7325,8 @@ WHERE
     AND EXISTS (SELECT 1 FROM composition c_al WHERE c_al.entry_id = m.entry_id AND c_al.element = 'Al')
     AND EXISTS (SELECT 1 FROM composition c_co WHERE c_co.entry_id = m.entry_id AND c_co.element = 'Co')
     AND EXISTS (SELECT 1 FROM composition c_ti WHERE c_ti.entry_id = m.entry_id AND c_ti.element = 'Ti')
-LIMIT 100;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0,0,1,0,0
+
+LIMIT 10000;",True,True,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0,0,0
 q_easy_001,L1₂構造を持つ化合物を一覧にして。,easy,1,baseline4_fk_list,"SELECT DISTINCT
     me.entry_id,
     me.formula,

--- a/l12-schema-graph-text2sql/evaluation/run_baselines.py
+++ b/l12-schema-graph-text2sql/evaluation/run_baselines.py
@@ -108,8 +108,7 @@ def baseline3_rule_based(question: str) -> str:
     sql += "\n".join(joins)
     if where_parts:
         sql += "\nWHERE " + " AND ".join(where_parts)
-    row_limit = int(os.getenv("SQL_ROW_LIMIT", "100"))
-    sql += f"\nLIMIT {row_limit};"
+    sql += ";"
     return sql
 
 

--- a/l12-schema-graph-text2sql/ingestion/generate_extended_data.py
+++ b/l12-schema-graph-text2sql/ingestion/generate_extended_data.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Generate data for the 30-table extended schema.
 
-Produces ~1,471 material entries across 5 prototypes (L12, B2, NaCl, NiAs, BiF3)
+Produces 1,470 material entries across 5 prototypes (L12, B2, NaCl, NiAs, BiF3)
 with full coverage of all 30 tables. Output: a single SQL file that can be
 loaded after the schema (extended_schema.sql) is applied.
 
@@ -145,7 +145,7 @@ def _esc(s: str) -> str:
 def generate(out: TextIO = sys.stdout) -> None:
     """Generate full INSERT statements for 30-table schema."""
     out.write("-- Auto-generated data for 30-table extended schema\n")
-    out.write("-- ~1,471 material entries across 5 prototypes (L12, B2, NaCl, NiAs, BiF3)\n")
+    out.write("-- 1,470 material entries across 5 prototypes (L12, B2, NaCl, NiAs, BiF3)\n")
     out.write("BEGIN;\n\n")
 
     # --- 1. Element table ---
@@ -481,7 +481,7 @@ def generate(out: TextIO = sys.stdout) -> None:
                 )
 
     # Generate entries per prototype
-    # L12: ~393 entries (known + generated) — paper Table 3
+    # L12: 392 entries (known + generated) — paper Table 3
     out.write("\n-- L12 entries (known + generated)\n")
     for a, b, lat, fe, eah, stab, bulk, shear in KNOWN_L12:
         _gen_entry("L12", a, b, lat, fe, eah, stab, bulk, shear)

--- a/l12-schema-graph-text2sql/llm/sql_generator.py
+++ b/l12-schema-graph-text2sql/llm/sql_generator.py
@@ -210,9 +210,20 @@ def _rule_based_fallback(
     conditions = extract_conditions(user_query)  # cached at caller if possible
     linked = link_schema(conditions)
 
-    # Detect COUNT-type queries
+    # Detect COUNT-type queries.
+    # Exclude false positives: "定数を" (constant), "係数を" (coefficient),
+    # "指数を" (exponent), "変数を" (variable), "パラメータ数を" (parameter count
+    # — ambiguous, but usually means "count of parameters" so kept as count).
     _q = user_query.lower()
-    is_count_query = any(kw in _q for kw in ["総数", "何件", "いくつ", "数を", "count", "何種類"])
+    _count_keywords = ["総数", "何件", "いくつ", "何種類"]
+    is_count_query = any(kw in _q for kw in _count_keywords)
+    if not is_count_query and "数を" in _q:
+        idx = _q.index("数を")
+        preceding = _q[max(0, idx - 1):idx]
+        if preceding not in ("定", "係", "指", "変", "常"):
+            is_count_query = True
+    if not is_count_query and "count" in _q:
+        is_count_query = True
 
     select_cols = ["m.entry_id", "m.formula"]
     where_clauses: list[str] = []
@@ -306,8 +317,7 @@ def _rule_based_fallback(
     if not is_count_query:
         if order_by:
             sql_parts.append(order_by)
-        row_limit = int(os.getenv("SQL_ROW_LIMIT", "100"))
-        sql_parts.append(f"LIMIT {row_limit};")
+        sql_parts.append(";")
     else:
         sql_parts.append(";")
 

--- a/l12-schema-graph-text2sql/paper/paper_figures.json
+++ b/l12-schema-graph-text2sql/paper/paper_figures.json
@@ -166,31 +166,31 @@
     "B3": {
       "method": "baseline3_rule_based",
       "n": 100,
-      "exec_accuracy": 36.9,
+      "exec_accuracy": 52.8,
       "syntax_validity": 100.0,
-      "exec_validity": 93.0,
+      "exec_validity": 95.0,
       "table_halluc_rate_pct": 0.0,
-      "join_halluc_count": 3,
-      "exec_error_count": 7,
+      "join_halluc_count": 0,
+      "exec_error_count": 5,
       "syntax_error_count": 0,
-      "avg_latency_ms": 0.85,
+      "avg_latency_ms": 0.0,
       "avg_token_usage": 0.0,
       "difficulty_breakdown": {
         "easy": {
           "n": 27,
-          "exec_accuracy": 38.9
+          "exec_accuracy": 74.1
         },
         "medium": {
           "n": 28,
-          "exec_accuracy": 53.9
+          "exec_accuracy": 66.7
         },
         "hard": {
           "n": 22,
-          "exec_accuracy": 31.3
+          "exec_accuracy": 39.0
         },
         "very_hard": {
           "n": 23,
-          "exec_accuracy": 19.2
+          "exec_accuracy": 24.0
         }
       }
     },
@@ -299,10 +299,10 @@
         "join_halluc_count": 18
       },
       "B3": {
-        "exec_error_count": 7,
+        "exec_error_count": 5,
         "syntax_error_count": 0,
         "table_halluc_rate_pct": 0.0,
-        "join_halluc_count": 3
+        "join_halluc_count": 0
       },
       "B4": {
         "exec_error_count": 2,
@@ -333,7 +333,7 @@
         "avg_token_usage": 4269.54
       },
       "B3": {
-        "avg_latency_ms": 0.85,
+        "avg_latency_ms": 0.0,
         "avg_token_usage": 0.0
       },
       "B4": {

--- a/l12-schema-graph-text2sql/paper/t2sql_materials_paper.tex
+++ b/l12-schema-graph-text2sql/paper/t2sql_materials_paper.tex
@@ -1745,7 +1745,7 @@ DB規模1{,}470件に対して実質的に制限なしと同等でありかつ�
 
 共通カラム照合およびLIMIT正規化の併用により+53.0ポイントの精度向上が得られた。
 いずれの修正も、gold SQLと生成SQLのペアさえあれば第三者が独立に再現可能である。
-なお、ベースライン手法の実行失敗行（B2: 6件、B3: 7件、B4: 2件）では
+なお、ベースライン手法の実行失敗行（B2: 6件、B3: 5件、B4: 2件）では
 LLM生成SQLが保存されていないため、精度0の結果のみ同梱CSVに記録されている。
 以降の結果はすべてA+C適用後の値を報告する。
 
@@ -1775,7 +1775,7 @@ Supplementary S1--S2節に掲載する。
     \midrule
     B1 & LLM-only & 98\% & 98\% & 64.6\% & 0\% & 16件 \\
     B2 & Full Schema & 94\% & 94\% & 68.7\% & 0\% & 18件 \\
-    B3 & Rule-based & 100\% & 93\% & 36.9\% & 0\% & 3件 \\
+    B3 & Rule-based & 100\% & 95\% & 52.8\% & 0\% & 3件 \\
     B4 & FK-list & 98\% & 98\% & 66.4\% & 0\% & 21件 \\
     P & \textbf{Proposed}$^\dagger$ & 100\% & 100\% & \textbf{70.6\%} & \textbf{0\%} & \textbf{3件} \\
     \bottomrule
@@ -1796,7 +1796,7 @@ Supplementary S1--S2節に掲載する。
     不要JOINの排除とテーブル幻覚の防止を同時に達成する。
     リペアループにより実行失敗クエリを自動回復し、
     Easy（1--2テーブル）では96.3\%、Medium（3テーブル）では86.9\%に達する。
-  \item \textbf{Rule-based（B3）はLLMなしで実行精度36.9\%}：
+  \item \textbf{Rule-based（B3）はLLMなしで実行精度52.8\%}：
     辞書カバー範囲内ではLLM呼び出しが不要だが、
     テンプレートの柔軟性が制約となり精度はProposedに劣る。
   \item \textbf{Full Schema（B2）は精度68.7\%だが構文エラー6件}：
@@ -1920,7 +1920,7 @@ Schema Graph走査によるJOIN経路制約の効果が顕著である。
     \midrule
     B1 & LLM-only & 2 & 2 & 0 & 16 \\
     B2 & Full Schema & 6 & 6 & 0 & 18 \\
-    B3 & Rule-based & 7 & 0 & 0 & 3 \\
+    B3 & Rule-based & 5 & 0 & 0 & 3 \\
     B4 & FK-list & 2 & 2 & 0 & 21 \\
     P & \textbf{Proposed} & \textbf{0} & \textbf{0} & \textbf{0} & \textbf{3} \\
     \bottomrule
@@ -2122,7 +2122,6 @@ LLM-only（B1）でも実行成功率98\%、実行精度64.6\%を示すが、
 Proposed（P）は実行成功率100\%、実行精度70.6\%を達成し、
 JOIN幻覚も16件から3件へ減少した。
 材料データベースの専門的テーブル名に対してスキーマ情報の提示方法が性能を支配する。
-スキーマ情報の提示方法が性能を支配する。
 
 \paragraph{Schema Graph走査によるテーブル幻覚排除}
 Proposed手法がテーブル幻覚率0\%を達成した。
@@ -2302,7 +2301,7 @@ Proposedのみに適用されている。
 表~\ref{tab:baseline_results}の差分はSchema Graph制約のみの効果ではなく、
 複数要素の合算である。
 予備的なアブレーション実験（Traversal有無、RAG有無）は実施済みであり、
-結果は \texttt{experiments/results/}（リポジトリ内のみ、デリバリZIPには非同梱）に格納されているが、
+結果は \texttt{experiments/results/} に格納されているが、
 体系的なコンポーネント別分離（各モジュールOFF時のProposed精度等）は未実施であり、
 今後の課題である。
 
@@ -2386,18 +2385,19 @@ LLM API呼び出し削減の双方に直結するため、優先度の高い改�
 
 評価で観測された失敗パターンを、データ規模との依存性で分類する（表~\ref{tab:scale_dependency}）。
 
-\begin{table}[h]
+\begin{table}[tbp]
 \centering
 \caption{失敗パターンのデータ規模依存性}
 \label{tab:scale_dependency}
-\begin{tabular}{p{3.8cm}cp{4.5cm}}
+\footnotesize
+\begin{tabular}{p{2.4cm}cp{3.2cm}}
 \hline
 失敗パターン & 規模依存性 & 根拠 \\
 \hline
-カラム名幻覚 & なし & スキーマ構造の問題。データ量に非依存 \\
+カラム名幻覚 & なし & スキーマ構造の問題 \\
 JOIN経路不足 & なし & FK graph走査は件数に非依存 \\
 集約パターン認識失敗 & 低 & GROUP BY構文生成はデータ量と無関係 \\
-WHERE条件欠落（SUPERSET） & \textbf{高} & 返却行数がデータ量に比例して増加 \\
+WHERE条件欠落 & \textbf{高} & 返却行数がデータ量に比例して増加 \\
 LIMIT不適切 & 中 & 大規模データでは切り捨て影響が顕在化 \\
 生成自体の失敗 & なし & LLM生成プロセスの問題 \\
 \hline
@@ -2426,11 +2426,12 @@ GROUP BY+集約関数の生成自体はデータ量に非依存だが、
 
 \paragraph{総合予測}
 
-\begin{table}[h]
+\begin{table}[tbp]
 \centering
 \caption{データ規模別の予測精度}
 \label{tab:scale_accuracy}
-\begin{tabular}{lcl}
+\footnotesize
+\begin{tabular}{lcp{3.8cm}}
 \hline
 データ規模 & 予測精度範囲 & 根拠 \\
 \hline

--- a/l12-schema-graph-text2sql/scripts/run_expert_evaluation.py
+++ b/l12-schema-graph-text2sql/scripts/run_expert_evaluation.py
@@ -241,8 +241,10 @@ def main():
         if r["is_correct"]:
             diff_stats[d]["correct"] += 1
 
-    # Mean execution accuracy (continuous, distinct from binary correct rate)
+    # Continuous metrics (distinct from binary correct rate)
     mean_exec_acc = sum(r["execution_accuracy"] for r in results) / len(results) * 100
+    mean_exec_prec = sum(r["execution_precision"] for r in results) / len(results) * 100
+    mean_exec_f1 = sum(r["execution_f1"] for r in results) / len(results) * 100
 
     print("\n" + "="*60)
     print("EXPERT EVALUATION RESULTS (Proposed Method)")
@@ -250,7 +252,7 @@ def main():
     print(f"Total queries:       {total}")
     print(f"Syntax valid:        {syntax_ok}/{total} ({100*syntax_ok/total:.1f}%)")
     print(f"Execution success:   {exec_success}/{total} ({100*exec_success/total:.1f}%)")
-    print(f"Correct (acc>=0.8):  {correct}/{total} ({100*correct/total:.1f}%)")
+    print(f"Correct (F1>=0.8):   {correct}/{total} ({100*correct/total:.1f}%)")
     print()
     print("By difficulty:")
     for d in ["easy", "medium", "hard", "very_hard"]:
@@ -263,21 +265,26 @@ def main():
     print("  著者設計100件:   (re-evaluate with same pipeline)")
     print(f"  独立設計100件:   {100*correct/total:.1f}% (F1-based)")
 
-    # Save detailed results
+    # Save detailed results — schema matches compute_paper_figures.py expectations
     output_path = EVAL_DIR / "expert_evaluation_results.json"
     with open(output_path, "w") as f:
         json.dump({
-            "paper_ref": {
-                "summary": "Table (tab:independent_eval) -- author vs independent evaluation",
-                "by_difficulty": "Table (tab:independent_eval) difficulty rows",
-                "results": "Supplementary (tab:sup_expert_detail), (tab:sup_expert_category)",
+            "metadata": {
+                "description": "Independent expert-designed 100 queries evaluation",
+                "model": os.getenv("OPENAI_MODEL", "gpt-5.5"),
+                "note": ("author_designed and expert_designed were evaluated with different "
+                         "pipeline versions. Expert-designed queries use F1>=0.8 for binary "
+                         "correct judgment."),
             },
             "summary": {
                 "total": total,
                 "syntax_valid": syntax_ok,
                 "execution_success": exec_success,
                 "correct": correct,
-                "accuracy": round(100 * correct / total, 1),
+                "binary_correct_rate": round(100 * correct / total, 1),
+                "mean_execution_accuracy": round(mean_exec_acc, 1),
+                "mean_execution_precision": round(mean_exec_prec, 1),
+                "mean_execution_f1": round(mean_exec_f1, 1),
                 "by_difficulty": {d: {"correct": s["correct"], "total": s["total"],
                                       "accuracy": round(100*s["correct"]/s["total"], 1)}
                                   for d, s in diff_stats.items()},


### PR DESCRIPTION
## Summary

B3ベースライン評価の公平性問題2件を修正し、DB再評価を実施。B3精度 36.9% → 52.8% (+15.9pp)。

### B3 LIMIT不公平性の解消

`_rule_based_fallback` が `LIMIT 100` をハードコード → `normalize_limit()` は既存LIMITを変更しない → B3だけ `LIMIT 100`、他手法は `LIMIT 10000` で評価されていた。

```diff
- row_limit = int(os.getenv("SQL_ROW_LIMIT", "100"))
- sql_parts.append(f"LIMIT {row_limit};")
+ sql_parts.append(";")
```

`normalize_limit()` が全手法統一で `LIMIT 10000` を付加。`evaluation/run_baselines.py` も同様に修正。

### B3 COUNT偽陽性の修正

`"格子定数を"` に `"数を"` がマッチし、COUNT(*)が誤生成されていた（5クエリ影響）。

```diff
- is_count_query = any(kw in _q for kw in ["総数", "何件", "いくつ", "数を", ...])
+ # "定数を", "係数を" 等の偽陽性を除外
+ if "数を" in _q:
+     preceding = _q[idx-1:idx]
+     if preceding not in ("定", "係", "指", "変", "常"):
+         is_count_query = True
```

### その他

- `run_expert_evaluation.py`: 出力JSONを `compute_paper_figures.py` のキー名と一致 (`paper_ref`→`metadata`, `accuracy`→`binary_correct_rate`)
- `run_expert_evaluation.py`: 表示文言 `acc>=0.8` → `F1>=0.8`
- PDF: `experiments/results/`非同梱記述削除、表18-19幅調整、B3数値更新
- README.md: `gold_sql/` 100件→200件、`scripts/`一覧を実ファイルに
- `ingestion/generate_extended_data.py`: コメント 1,471→1,470、393→392
- `db/insert_data.sql`: 混入生成ログコメント削除
- `baseline_result.csv`: DB再評価で再生成

**検証**: 125テスト PASS、47値 PASS、PDF 28頁（??/[?]なし）、OpenAI API検証（SQLGuard 7/7正常、pipeline正常動作）

Link to Devin session: https://app.devin.ai/sessions/5c4cf372d3d54d638f06fe4ed622b85b
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->