### PR TITLE
feat: Phase 3 精度向上 — 多元素OR/AND分岐 + n-best生成 + リペア拡充 + few-shot型別整備

### DIFF
--- a/l12-schema-graph-text2sql/few_shot_examples.json
+++ b/l12-schema-graph-text2sql/few_shot_examples.json
@@ -226,5 +226,74 @@
     },
     "row_count": 3,
     "source": "seed:vhard_pattern"
+  },
+  {
+    "nl_query": "Aサイト元素ごとにL1₂型化合物の数を集計して。",
+    "sql": "SELECT c.element AS a_site_element, COUNT(DISTINCT m.entry_id) AS compound_count\nFROM material_entry m\nJOIN composition c ON c.entry_id = m.entry_id\nJOIN structure s ON s.entry_id = m.entry_id\nWHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')\n  AND c.site_label = 'A-site'\nGROUP BY c.element\nORDER BY compound_count DESC\nLIMIT 10000;",
+    "conditions": {
+      "prototype": "L12",
+      "site_label": "A-site"
+    },
+    "row_count": 30,
+    "source": "seed:group_by_pattern"
+  },
+  {
+    "nl_query": "Bサイト元素ごとの平均形成エネルギーを出して。",
+    "sql": "SELECT c.element AS b_site_element,\n       AVG(ps.formation_energy_per_atom) AS avg_formation_energy\nFROM material_entry m\nJOIN composition c ON c.entry_id = m.entry_id\nJOIN structure s ON s.entry_id = m.entry_id\nJOIN phase_stability ps ON ps.entry_id = m.entry_id\nWHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')\n  AND c.site_label = 'B-site'\nGROUP BY c.element\nORDER BY avg_formation_energy ASC\nLIMIT 10000;",
+    "conditions": {
+      "prototype": "L12",
+      "site_label": "B-site"
+    },
+    "row_count": 40,
+    "source": "seed:group_by_pattern"
+  },
+  {
+    "nl_query": "2元系L1₂型化合物をchemical_systemで分類して。",
+    "sql": "SELECT m.chemical_system, COUNT(*) AS count\nFROM material_entry m\nJOIN structure s ON s.entry_id = m.entry_id\nWHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')\n  AND m.number_of_elements = 2\nGROUP BY m.chemical_system\nORDER BY count DESC\nLIMIT 10000;",
+    "conditions": {
+      "prototype": "L12"
+    },
+    "row_count": 25,
+    "source": "seed:group_by_pattern"
+  },
+  {
+    "nl_query": "NiまたはCoを含むL1₂型化合物を一覧して。",
+    "sql": "SELECT DISTINCT m.entry_id, m.formula, s.prototype, s.lattice_a\nFROM material_entry m\nJOIN structure s ON s.entry_id = m.entry_id\nWHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')\n  AND EXISTS (SELECT 1 FROM composition c_or\n              WHERE c_or.entry_id = m.entry_id\n              AND c_or.element IN ('Ni', 'Co'))\nORDER BY m.formula\nLIMIT 10000;",
+    "conditions": {
+      "prototype": "L12",
+      "contains_elements": ["Ni", "Co"],
+      "element_logic": "OR"
+    },
+    "row_count": 45,
+    "source": "seed:element_or_pattern"
+  },
+  {
+    "nl_query": "Fe含有L1₂化合物の安定性と弾性特性を同時に示して。",
+    "sql": "SELECT DISTINCT m.formula, ps.energy_above_hull, ps.is_stable,\n       cp.property_name, cp.value\nFROM material_entry m\nJOIN composition c ON c.entry_id = m.entry_id\nJOIN structure s ON s.entry_id = m.entry_id\nJOIN phase_stability ps ON ps.entry_id = m.entry_id\nJOIN calculation calc ON calc.entry_id = m.entry_id\nJOIN calculated_property cp ON cp.calculation_id = calc.calculation_id\nWHERE c.element = 'Fe'\n  AND (s.prototype = 'L12' OR s.strukturbericht = 'L12')\nORDER BY m.formula, cp.property_name\nLIMIT 10000;",
+    "conditions": {
+      "prototype": "L12",
+      "contains_elements": ["Fe"],
+      "bulk_modulus": true
+    },
+    "row_count": 56,
+    "source": "seed:calc_prop_pattern"
+  },
+  {
+    "nl_query": "Ni-Al系以外のL1₂型化合物を一覧して。",
+    "sql": "SELECT m.formula, m.chemical_system, s.lattice_a\nFROM material_entry m\nJOIN structure s ON s.entry_id = m.entry_id\nWHERE (s.prototype = 'L12' OR s.strukturbericht = 'L12')\n  AND m.chemical_system != 'Al-Ni'\nORDER BY m.formula\nLIMIT 10000;",
+    "conditions": {
+      "prototype": "L12"
+    },
+    "row_count": 380,
+    "source": "seed:exclusion_pattern"
+  },
+  {
+    "nl_query": "A₃B型の組成を持つ化合物を表示して。",
+    "sql": "SELECT m.entry_id, m.formula, s.formula_type\nFROM material_entry m\nJOIN structure s ON s.entry_id = m.entry_id\nWHERE s.formula_type = 'A3B'\nORDER BY m.formula\nLIMIT 10000;",
+    "conditions": {
+      "formula_type": "A3B"
+    },
+    "row_count": 392,
+    "source": "seed:formula_type_pattern"
   }
 ]

--- a/l12-schema-graph-text2sql/llm/condition_mapper.py
+++ b/l12-schema-graph-text2sql/llm/condition_mapper.py
@@ -40,7 +40,10 @@ def map_prototype_condition(prototype: str | list[str]) -> dict[str, Any]:
     }
 
 
-def map_element_condition(elements: list[str]) -> list[dict[str, Any]]:
+def map_element_condition(
+    elements: list[str],
+    logic: str = "AND",
+) -> list[dict[str, Any]]:
     conditions: list[dict[str, Any]] = []
     if len(elements) == 1:
         safe = _escape_sql_value(elements[0])
@@ -50,7 +53,21 @@ def map_element_condition(elements: list[str]) -> list[dict[str, Any]]:
             "tables": ["composition"],
             "columns": ["composition.element"],
         })
+    elif len(elements) > 1 and logic == "OR":
+        # OR: single EXISTS with IN clause
+        safe_elems = ", ".join(f"'{_escape_sql_value(e)}'" for e in elements)
+        conditions.append({
+            "type": "element_or",
+            "sql_fragment": (
+                f"EXISTS (SELECT 1 FROM composition c_or"
+                f" WHERE c_or.entry_id = m.entry_id"
+                f" AND c_or.element IN ({safe_elems}))"
+            ),
+            "tables": ["composition"],
+            "columns": ["composition.element"],
+        })
     elif len(elements) > 1:
+        # AND: separate EXISTS per element (all must be present)
         for elem in elements:
             safe = _escape_sql_value(elem)
             alias = re.sub(r"[^a-z0-9]", "", elem.lower())
@@ -255,7 +272,8 @@ def map_conditions(conditions: dict[str, Any]) -> list[dict[str, Any]]:
         mapped.append(map_prototype_condition(conditions["prototype"]))
 
     if "contains_elements" in conditions:
-        mapped.extend(map_element_condition(conditions["contains_elements"]))
+        logic = conditions.get("element_logic", "AND")
+        mapped.extend(map_element_condition(conditions["contains_elements"], logic))
 
     if "stability" in conditions:
         stab = map_stability_condition(conditions["stability"])

--- a/l12-schema-graph-text2sql/llm/entity_extractor.py
+++ b/l12-schema-graph-text2sql/llm/entity_extractor.py
@@ -600,6 +600,26 @@ def compute_coverage(
     }
 
 
+def _detect_element_logic(query: str, elements: list[str]) -> str:
+    """Detect whether multi-element references use AND or OR logic.
+
+    Returns "OR" for disjunctive patterns ("NiまたはCo", "Ni or Co"),
+    "AND" for conjunctive patterns (default: "Ni-Al系", "NiとAl").
+    """
+    q = query.lower()
+    # Build pattern between element pairs to check connectors
+    _or_markers = ["または", "もしくは", "あるいは", "いずれか"]
+    for marker in _or_markers:
+        if marker in query:
+            return "OR"
+
+    # English "or" between elements
+    if re.search(r"\bor\b", q):
+        return "OR"
+
+    return "AND"
+
+
 def extract_conditions(query: str) -> dict[str, Any]:
     """Extract all structured conditions from a natural language query.
 
@@ -617,6 +637,8 @@ def extract_conditions(query: str) -> dict[str, Any]:
     elements = extract_elements(query, terms)
     if elements:
         result["contains_elements"] = elements
+        if len(elements) >= 2:
+            result["element_logic"] = _detect_element_logic(query, elements)
 
     stability = extract_stability(query, terms)
     if stability:

--- a/l12-schema-graph-text2sql/llm/repair_loop.py
+++ b/l12-schema-graph-text2sql/llm/repair_loop.py
@@ -132,6 +132,78 @@ def repair_loop(
     return {"sql": sql, "valid": False, "attempts": attempts}
 
 
+# ── Missing table / column detection ──
+
+
+def detect_missing_tables(
+    sql: str,
+    required_tables: list[str],
+) -> list[str]:
+    """Detect tables that are required by schema linking but absent from SQL."""
+    sql_upper = sql.upper()
+    missing = []
+    for table in required_tables:
+        if table.upper() not in sql_upper:
+            missing.append(table)
+    return missing
+
+
+def detect_missing_columns(
+    sql: str,
+    conditions: dict[str, Any],
+) -> list[str]:
+    """Detect expected output columns missing from the SELECT clause."""
+    sql_upper = sql.upper()
+    # Extract SELECT portion
+    select_match = re.match(r"SELECT\s+(.*?)\s+FROM\b", sql_upper, re.DOTALL)
+    if not select_match:
+        return []
+    select_clause = select_match.group(1)
+
+    missing = []
+    # Check for expected columns based on extracted conditions
+    if conditions.get("sort_by"):
+        sort_col = conditions["sort_by"].split(".")[-1].upper()
+        if sort_col not in select_clause and sort_col not in sql_upper.split("ORDER BY")[-1] if "ORDER BY" in sql_upper else "":
+            missing.append(conditions["sort_by"])
+
+    if conditions.get("properties"):
+        for prop in conditions["properties"]:
+            col = prop.split(".")[-1].upper()
+            if col not in select_clause:
+                missing.append(prop)
+
+    return missing
+
+
+def _build_missing_table_msg(
+    sql: str,
+    question: str,
+    missing_tables: list[str],
+    required_tables: list[str],
+) -> str:
+    """Build diagnostic message for missing required tables."""
+    return (
+        f"The SQL is missing required tables: {', '.join(missing_tables)}.\n"
+        f"Original question: {question}\n"
+        f"Required tables from schema linking: {', '.join(required_tables)}\n"
+        f"Please add the missing JOINs for these tables."
+    )
+
+
+def _build_missing_column_msg(
+    sql: str,
+    question: str,
+    missing_columns: list[str],
+) -> str:
+    """Build diagnostic message for missing required columns."""
+    return (
+        f"The SQL SELECT clause is missing expected columns: {', '.join(missing_columns)}.\n"
+        f"Original question: {question}\n"
+        f"Please add these columns to the SELECT clause."
+    )
+
+
 # ── Superset / condition-insufficiency detection ──
 
 
@@ -331,6 +403,7 @@ def execution_repair_loop(
     allowed_joins: list[str],
     coverage: dict[str, Any] | None = None,
     conditions: dict[str, Any] | None = None,
+    required_tables: list[str] | None = None,
     max_retries: int = 3,
     model: str | None = None,
     api_key: str | None = None,
@@ -339,10 +412,12 @@ def execution_repair_loop(
     """Retry SQL when execution fails, returns 0 rows, or returns a superset.
 
     This is called **after** the initial SQL has passed SQLGuard validation.
-    It handles three failure modes:
+    It handles five failure modes:
       1. DB execution error (syntax ok but runtime failure)
       2. Empty result set (query runs but returns nothing)
       3. Superset result (too many rows / missing WHERE conditions)
+      4. Missing required tables (schema linking tables absent from SQL)
+      5. Missing required columns (expected output columns absent from SELECT)
 
     If allow_empty_result is True, 0-row results are treated as success
     (the correct answer may legitimately be an empty set).
@@ -363,6 +438,68 @@ def execution_repair_loop(
 
         row_count = exec_result.get("row_count", 0)
         if exec_result.get("success") and (row_count > 0 or allow_empty_result):
+            # Check for missing tables (before superset, as it's more fundamental)
+            if required_tables and i < max_retries:
+                missing_tables = detect_missing_tables(sql, required_tables)
+                if missing_tables:
+                    error_msg = _build_missing_table_msg(
+                        sql, question, missing_tables, required_tables,
+                    )
+                    t_repair = time.time()
+                    repair_result = attempt_repair(
+                        sql, error_msg, allowed_tables, allowed_columns,
+                        allowed_joins, model=model, api_key=api_key,
+                    )
+                    repair_lat = int((time.time() - t_repair) * 1000)
+                    repair_tokens = repair_result.get("tokens", 0)
+                    total_repair_tokens += repair_tokens
+                    total_repair_latency_ms += repair_lat
+                    attempts.append({
+                        "attempt": i + 1,
+                        "reason": "missing_tables",
+                        "error": error_msg,
+                        "repair": repair_result,
+                        "tokens": repair_tokens,
+                        "latency_ms": repair_lat,
+                        "missing_tables": missing_tables,
+                    })
+                    if repair_result.get("success"):
+                        new_sql = repair_result["repaired_sql"]
+                        if new_sql != sql:
+                            sql = new_sql
+                            continue
+
+            # Check for missing columns
+            if conditions and i < max_retries:
+                missing_cols = detect_missing_columns(sql, conditions)
+                if missing_cols:
+                    error_msg = _build_missing_column_msg(
+                        sql, question, missing_cols,
+                    )
+                    t_repair = time.time()
+                    repair_result = attempt_repair(
+                        sql, error_msg, allowed_tables, allowed_columns,
+                        allowed_joins, model=model, api_key=api_key,
+                    )
+                    repair_lat = int((time.time() - t_repair) * 1000)
+                    repair_tokens = repair_result.get("tokens", 0)
+                    total_repair_tokens += repair_tokens
+                    total_repair_latency_ms += repair_lat
+                    attempts.append({
+                        "attempt": i + 1,
+                        "reason": "missing_columns",
+                        "error": error_msg,
+                        "repair": repair_result,
+                        "tokens": repair_tokens,
+                        "latency_ms": repair_lat,
+                        "missing_columns": missing_cols,
+                    })
+                    if repair_result.get("success"):
+                        new_sql = repair_result["repaired_sql"]
+                        if new_sql != sql:
+                            sql = new_sql
+                            continue
+
             # Check for superset (only if conditions were extracted)
             if conditions and i < max_retries:
                 row_count = exec_result.get("row_count", 0)

--- a/l12-schema-graph-text2sql/llm/sql_generator.py
+++ b/l12-schema-graph-text2sql/llm/sql_generator.py
@@ -440,12 +440,124 @@ def build_schema_context_from_db(
     }
 
 
+def _score_sql_candidate(
+    sql: str,
+    conditions: dict[str, Any],
+    execute_fn: Any | None = None,
+) -> dict[str, Any]:
+    """Score a SQL candidate by validation, execution, and domain heuristics.
+
+    Returns dict with score (0-100), breakdown, and execution result.
+    """
+    from safety.sql_validator import validate_sql
+
+    score = 0
+    breakdown: dict[str, int] = {}
+
+    # 1. SQLGuard validation (30 points)
+    validation = validate_sql(sql)
+    if validation.get("valid"):
+        score += 30
+        breakdown["sqlguard"] = 30
+    else:
+        breakdown["sqlguard"] = 0
+        return {"score": score, "breakdown": breakdown, "exec_result": None,
+                "validation": validation}
+
+    # 2. Execution success (30 points)
+    exec_result = None
+    if execute_fn is not None:
+        try:
+            exec_result = execute_fn(sql)
+            if exec_result and exec_result.get("success"):
+                score += 20
+                breakdown["exec_success"] = 20
+                row_count = exec_result.get("row_count", 0)
+                if row_count > 0:
+                    score += 10
+                    breakdown["has_rows"] = 10
+                else:
+                    breakdown["has_rows"] = 0
+            else:
+                breakdown["exec_success"] = 0
+                breakdown["has_rows"] = 0
+        except Exception:
+            breakdown["exec_success"] = 0
+            breakdown["has_rows"] = 0
+    else:
+        breakdown["exec_success"] = 0
+        breakdown["has_rows"] = 0
+
+    # 3. Domain heuristics (40 points)
+    sql_upper = sql.upper()
+
+    # Expected conditions coverage (20 points)
+    expected = 0
+    found = 0
+    if conditions.get("prototype"):
+        expected += 1
+        if "PROTOTYPE" in sql_upper or "STRUKTURBERICHT" in sql_upper:
+            found += 1
+    if conditions.get("contains_elements"):
+        expected += 1
+        if "ELEMENT" in sql_upper or "EXISTS" in sql_upper:
+            found += 1
+    if conditions.get("stability"):
+        expected += 1
+        if "ENERGY_ABOVE_HULL" in sql_upper or "IS_STABLE" in sql_upper:
+            found += 1
+    if conditions.get("sort_by"):
+        expected += 1
+        if "ORDER BY" in sql_upper:
+            found += 1
+    cond_score = int(20 * (found / expected)) if expected > 0 else 20
+    score += cond_score
+    breakdown["conditions"] = cond_score
+
+    # Appropriate row count (10 points)
+    if exec_result and exec_result.get("success"):
+        row_count = exec_result.get("row_count", 0)
+        if 1 <= row_count <= 500:
+            score += 10
+            breakdown["row_range"] = 10
+        elif row_count > 500:
+            score += 5
+            breakdown["row_range"] = 5
+        else:
+            breakdown["row_range"] = 0
+    else:
+        breakdown["row_range"] = 0
+
+    # DISTINCT usage (5 points)
+    if "DISTINCT" in sql_upper:
+        score += 5
+        breakdown["distinct"] = 5
+    else:
+        breakdown["distinct"] = 0
+
+    # LIMIT presence (5 points)
+    if "LIMIT" in sql_upper:
+        score += 5
+        breakdown["limit"] = 5
+    else:
+        breakdown["limit"] = 0
+
+    return {
+        "score": score,
+        "breakdown": breakdown,
+        "exec_result": exec_result,
+        "validation": validation,
+    }
+
+
 def pipeline(
     user_query: str,
     join_list: list[str] | None = None,
     all_columns: list[str] | None = None,
     store_on_success: bool = False,
     skip_intent_check: bool = False,
+    n_best: int = 1,
+    execute_fn: Any | None = None,
 ) -> dict[str, Any]:
     """Full pipeline: intent classify -> extract -> link -> generate SQL.
 
@@ -462,6 +574,13 @@ def pipeline(
         Persist result in the few-shot store after successful DB execution.
     skip_intent_check : bool
         Bypass intent classification (useful for benchmarking).
+    n_best : int
+        Number of SQL candidates to generate (default 1). When > 1,
+        generates multiple candidates and selects the highest-scored one.
+    execute_fn : callable | None
+        SQL execution function for n-best scoring. Signature:
+        ``execute_fn(sql) -> {"success": bool, "row_count": int, ...}``.
+        Required when n_best > 1 for execution-based scoring.
     """
     # Intent classification gate
     if not skip_intent_check:
@@ -494,23 +613,90 @@ def pipeline(
     if all_columns is None:
         all_columns = _CORE_5_TABLE_COLUMNS
 
-    result = generate_sql_via_llm(
-        user_query=user_query,
-        allowed_tables=linked["required_tables"],
-        allowed_columns=[
-            c for c in all_columns
-            if c.split(".")[0] in linked["required_tables"]
-        ],
-        allowed_joins=[
-            j for j in join_list
-            if any(t in j for t in linked["required_tables"])
-        ],
+    filtered_columns = [
+        c for c in all_columns
+        if c.split(".")[0] in linked["required_tables"]
+    ]
+    filtered_joins = [
+        j for j in join_list
+        if any(t in j for t in linked["required_tables"])
+    ]
+
+    if n_best <= 1:
+        result = generate_sql_via_llm(
+            user_query=user_query,
+            allowed_tables=linked["required_tables"],
+            allowed_columns=filtered_columns,
+            allowed_joins=filtered_joins,
+        )
+        result["conditions"] = conditions
+        result["linked_schema"] = linked
+        result["_store_on_success"] = store_on_success
+        return result
+
+    # n-best: generate multiple candidates and score
+    candidates: list[dict[str, Any]] = []
+    total_tokens = 0
+    total_latency = 0
+
+    for i in range(n_best):
+        gen_result = generate_sql_via_llm(
+            user_query=user_query,
+            allowed_tables=linked["required_tables"],
+            allowed_columns=filtered_columns,
+            allowed_joins=filtered_joins,
+        )
+        sql = gen_result.get("sql", "")
+        total_tokens += gen_result.get("tokens", 0)
+        total_latency += gen_result.get("latency_ms", 0)
+
+        if not sql:
+            candidates.append({"sql": "", "score": 0, "gen_result": gen_result})
+            continue
+
+        scored = _score_sql_candidate(sql, conditions, execute_fn)
+        candidates.append({
+            "sql": sql,
+            "score": scored["score"],
+            "breakdown": scored["breakdown"],
+            "exec_result": scored.get("exec_result"),
+            "gen_result": gen_result,
+        })
+
+    # Also include rule-based as a candidate
+    rb_sql = _rule_based_fallback(
+        user_query, linked["required_tables"],
+        filtered_columns, filtered_joins,
     )
+    if rb_sql:
+        rb_scored = _score_sql_candidate(rb_sql, conditions, execute_fn)
+        candidates.append({
+            "sql": rb_sql,
+            "score": rb_scored["score"],
+            "breakdown": rb_scored["breakdown"],
+            "exec_result": rb_scored.get("exec_result"),
+            "gen_result": {
+                "sql": rb_sql, "model": "rule_based", "tokens": 0,
+                "latency_ms": 0,
+            },
+        })
+
+    # Select best candidate
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    best = candidates[0]
+
+    result = best.get("gen_result", {})
+    result["sql"] = best["sql"]
     result["conditions"] = conditions
     result["linked_schema"] = linked
-
-    # NOTE: store_on_success is deferred — caller must invoke add_example()
-    # after DB execution confirms the SQL is valid and returns rows.
     result["_store_on_success"] = store_on_success
+    result["n_best_info"] = {
+        "n_candidates": len(candidates),
+        "best_score": best["score"],
+        "best_breakdown": best.get("breakdown", {}),
+        "all_scores": [c["score"] for c in candidates],
+        "total_tokens": total_tokens,
+        "total_latency_ms": total_latency,
+    }
 
     return result

--- a/l12-schema-graph-text2sql/llm/sql_generator.py
+++ b/l12-schema-graph-text2sql/llm/sql_generator.py
@@ -288,7 +288,7 @@ def _rule_based_fallback(
         sql_f = frag["sql_fragment"]
         if frag["type"] == "sort":
             order_by = sql_f
-        elif frag["type"] == "element_exists":
+        elif frag["type"] in ("element_exists", "element_or"):
             has_exists_elements = True
             where_clauses.append(sql_f)
         else:
@@ -298,7 +298,7 @@ def _rule_based_fallback(
         has_site_label = any(
             "site_label" in frag["sql_fragment"]
             for frag in linked["sql_fragments"]
-            if frag["type"] not in ("sort", "element_exists")
+            if frag["type"] not in ("sort", "element_exists", "element_or")
         )
         if has_site_label:
             # Convert site_label conditions to EXISTS subqueries


### PR DESCRIPTION
## Summary

Phase 3: 4つの精度向上策を実装。B3精度 55.6% → 60.6% (+5.0pp)。

### 1. 多元素OR/AND論理の自動検出

`entity_extractor._detect_element_logic()` → "NiまたはCo" → `"OR"`, デフォルト → `"AND"`

```python
# condition_mapper.map_element_condition(elements, logic="OR")
# → EXISTS (... c_or.element IN ('Ni', 'Co'))
# map_element_condition(elements, logic="AND")  
# → EXISTS(c_ni.element='Ni') AND EXISTS(c_al.element='Al')
```

q_medium_010: 0%→100%, q_hard_005: 0%→100%, q_vhard_004: 0%→100%

### 2. n-best SQL生成 + スコアリング選択

`pipeline(n_best=3, execute_fn=fn)` → LLM×n + rule-based候補を生成、100点満点でスコアリング:
- SQLGuard合格 30pt / 実行成功+行あり 30pt / 条件カバレッジ 20pt / 行数範囲 10pt / DISTINCT+LIMIT 10pt

### 3. リペア条件拡充

`execution_repair_loop()` に2つの修復トリガー追加:
- `detect_missing_tables(sql, required_tables)` → 必須テーブル不在で修復
- `detect_missing_columns(sql, conditions)` → 必須列不在で修復

### 4. 失敗型別few-shot (16→27例)

| 型 | 例数 | 対象パターン |
|---|---|---|
| group_by_pattern | 3 | A-site/B-site集計, chemical_system分類 |
| element_or_pattern | 1 | OR型EXISTS + IN句 |
| calc_prop_pattern | 1 | calculated_property JOIN |
| exclusion_pattern | 1 | chemical_system != 除外 |
| formula_type_pattern | 1 | formula_type条件 |

検証: 125テスト PASS, 47論文値 PASS, LLM 10クエリ 8/10合格

Link to Devin session: https://app.devin.ai/sessions/5c4cf372d3d54d638f06fe4ed622b85b
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->