### PR TITLE
fix: Devin Review #320 バグ3件修正 + run_proposed_only required_tables統合

### DIFF
--- a/l12-schema-graph-text2sql/llm/repair_loop.py
+++ b/l12-schema-graph-text2sql/llm/repair_loop.py
@@ -164,7 +164,8 @@ def detect_missing_columns(
     # Check for expected columns based on extracted conditions
     if conditions.get("sort_by"):
         sort_col = conditions["sort_by"].split(".")[-1].upper()
-        if sort_col not in select_clause and sort_col not in sql_upper.split("ORDER BY")[-1] if "ORDER BY" in sql_upper else "":
+        in_order_by = sort_col in sql_upper.split("ORDER BY")[-1] if "ORDER BY" in sql_upper else False
+        if sort_col not in select_clause and not in_order_by:
             missing.append(conditions["sort_by"])
 
     if conditions.get("properties"):
@@ -236,7 +237,8 @@ def count_expected_conditions(conditions: dict[str, Any]) -> int:
         count += 1
     elements = conditions.get("contains_elements", [])
     if elements:
-        count += len(elements)  # Each element → subquery or AND
+        logic = conditions.get("element_logic", "AND")
+        count += 1 if logic == "OR" else len(elements)
     if conditions.get("stability"):
         count += 1
     props = conditions.get("properties", [])

--- a/l12-schema-graph-text2sql/llm/sql_generator.py
+++ b/l12-schema-graph-text2sql/llm/sql_generator.py
@@ -123,6 +123,7 @@ def generate_sql_via_llm(
     allowed_joins: list[str],
     model: str | None = None,
     api_key: str | None = None,
+    temperature: float | None = None,
 ) -> dict[str, Any]:
     """Call the OpenAI API to generate SQL from a constrained prompt.
 
@@ -177,8 +178,10 @@ def generate_sql_via_llm(
     _is_new_model = model and any(t in model for t in ("gpt-5", "o1", "o3", "o4"))
     if _is_new_model:
         create_kwargs["max_completion_tokens"] = 4096
+        if temperature is not None and temperature > 0:
+            create_kwargs["temperature"] = temperature
     else:
-        create_kwargs["temperature"] = 0.0
+        create_kwargs["temperature"] = temperature if temperature is not None else 0.0
         create_kwargs["max_tokens"] = 4096  # Fix B7: unified budget
     resp = client.chat.completions.create(**create_kwargs)
     latency_ms = int((time.time() - t0) * 1000)
@@ -640,11 +643,14 @@ def pipeline(
     total_latency = 0
 
     for i in range(n_best):
+        # Vary temperature for candidate diversity (0.0, 0.3, 0.6, ...)
+        temp_override = round(i * 0.3, 1) if i > 0 else 0.0
         gen_result = generate_sql_via_llm(
             user_query=user_query,
             allowed_tables=linked["required_tables"],
             allowed_columns=filtered_columns,
             allowed_joins=filtered_joins,
+            temperature=temp_override,
         )
         sql = gen_result.get("sql", "")
         total_tokens += gen_result.get("tokens", 0)

--- a/l12-schema-graph-text2sql/scripts/run_proposed_only.py
+++ b/l12-schema-graph-text2sql/scripts/run_proposed_only.py
@@ -266,6 +266,7 @@ def main():
                         allowed_joins=effective_joins,
                         coverage=coverage,
                         conditions=query_conditions,
+                        required_tables=linked_tables,
                         max_retries=3,
                         model=model,
                         api_key=api_key,


### PR DESCRIPTION
## Summary

Devin Review #320 で検出された3件のバグ修正 + 評価パイプラインへの `required_tables` 統合。

### 1. `detect_missing_columns` 演算子優先度バグ

```python
# Before (broken): entire expression → "" when no ORDER BY
sort_col not in select_clause and sort_col not in sql_upper.split("ORDER BY")[-1] if "ORDER BY" in sql_upper else ""

# After: pre-compute in_order_by
in_order_by = sort_col in sql_upper.split("ORDER BY")[-1] if "ORDER BY" in sql_upper else False
if sort_col not in select_clause and not in_order_by:
```

### 2. `count_expected_conditions` — OR論理未対応

```python
# Before: OR型でもlen(elements)をカウント → 偽superset検出
count += len(elements)
# After: OR → 1条件, AND → len(elements)条件
logic = conditions.get("element_logic", "AND")
count += 1 if logic == "OR" else len(elements)
```

### 3. n-best temperature多様化

`generate_sql_via_llm(temperature=...)` パラメータ追加。n-best候補生成時に `temp=0.0, 0.3, 0.6...` で多様性確保。GPT-5/o-seriesでも `temp>0` 時に適用。

### 4. `run_proposed_only.py` — `required_tables` 渡し

`execution_repair_loop()` に `required_tables=linked_tables` を渡し、Phase 3で追加した必須テーブル検出を有効化。

検証: 125テスト PASS, 47論文値 PASS, B3 60.6%, LLM 5/5 PASS

Link to Devin session: https://app.devin.ai/sessions/5c4cf372d3d54d638f06fe4ed622b85b
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->