### PR TITLE
fix: v12レビュー残件 — PDF 18-19ページ表重なり修正 + ブランチ整理

### DIFF
--- a/l12-schema-graph-text2sql/paper/t2sql_materials_paper.tex
+++ b/l12-schema-graph-text2sql/paper/t2sql_materials_paper.tex
@@ -2176,12 +2176,12 @@ Proposed手法の精度を再評価した。
 表面・粒界・欠陥、文献・合成・応用、材料設計・スクリーニング、
 比較・統計）から構成され、30テーブルの拡張スキーマ全体を対象とする。
 
-\begin{table}[htbp]
+\begin{table}[tbp]
   \centering
   \caption{著者設計クエリと独立設計クエリの精度比較。「平均実行精度」は連続値の単純平均、
   「二値正答率」は実行F1$\geq 0.8$で二値化した正答率である。}
   \label{tab:independent_eval}
-  \small
+  \footnotesize
   \begin{tabular}{lcc}
     \toprule
     指標 & 著者設計 (100件) & 独立設計 (100件) \\
@@ -2315,11 +2315,11 @@ gpt-5.5は温度パラメータの外部制御が不可能なため、同一入�
 オープンモデルでの追試、および
 DAIL-SQL/DIN-SQL等の既存SOTAパイプラインを同DBに適用した比較も未実施である。
 
-\begin{table}[htbp]
+\begin{table}[tbp]
   \centering
   \caption{Proposed手法の3回独立実行結果。}
   \label{tab:3run_stats}
-  \small
+  \footnotesize
   \begin{tabular}{lccccc}
     \hline
     & Easy & Medium & Hard & V.Hard & \textbf{全体} \\
@@ -2390,7 +2390,7 @@ LLM API呼び出し削減の双方に直結するため、優先度の高い改�
 \caption{失敗パターンのデータ規模依存性}
 \label{tab:scale_dependency}
 \footnotesize
-\begin{tabular}{p{2.4cm}cp{3.2cm}}
+\begin{tabular}{p{2.0cm}cp{2.8cm}}
 \hline
 失敗パターン & 規模依存性 & 根拠 \\
 \hline
@@ -2431,7 +2431,7 @@ GROUP BY+集約関数の生成自体はデータ量に非依存だが、
 \caption{データ規模別の予測精度}
 \label{tab:scale_accuracy}
 \footnotesize
-\begin{tabular}{lcp{3.8cm}}
+\begin{tabular}{lcp{3.2cm}}
 \hline
 データ規模 & 予測精度範囲 & 根拠 \\
 \hline


### PR DESCRIPTION
## Summary

PDF 18-19ページの表重なりを修正。他のv12レビュー指摘7件は既に過去PRで修正済みであることを確認。

### PDF表重なり修正
```diff
-\begin{table}[htbp] ... \small   % tab:independent_eval, tab:3run_stats
+\begin{table}[tbp]  ... \footnotesize

-\begin{tabular}{p{2.4cm}cp{3.2cm}}  % tab:scale_dependency
+\begin{tabular}{p{2.0cm}cp{2.8cm}}

-\begin{tabular}{lcp{3.8cm}}  % tab:scale_accuracy
+\begin{tabular}{lcp{3.2cm}}
```

### ブランチ整理（PR外で実施済み）
- L12関連の陳腐化PR 7件 (#285,#291,#294,#301,#303,#310,#314) → Close + ブランチ削除
- update-skills PR 7件 (#126,#177,#180,#214,#268,#272,#295) → Close + ブランチ削除
- 残存: 他プロジェクトの未マージ67本（判断保留）

### 既に修正済みの確認結果
| v12指摘 | 状態 |
|---------|------|
| `run_expert_evaluation.py` スキーマ不一致 | 修正済み（`metadata`+`binary_correct_rate`出力） |
| 表示文言 `acc>=0.8` → `F1>=0.8` | 修正済み |
| PDF `experiments/results/` 非同梱記述 | 修正済み |
| `README.md` ファイル構成 | 修正済み（200件、5スクリプト） |
| `ingestion/` コメント 1471→1470 | 修正済み |
| `insert_data.sql` 生成ログ | 修正済み |
| `README_DELIVERY.md` クローン記述 | 修正済み |

検証: 125テスト PASS、47論文値 PASS、PDF 28頁（??参照なし）

Link to Devin session: https://app.devin.ai/sessions/5c4cf372d3d54d638f06fe4ed622b85b
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->