### PR TITLE
fix: EXISTS/subquery二重カウント防止（Devin Review #328）

### DIFF
--- a/l12-schema-graph-text2sql/scripts/compute_paper_figures.py
+++ b/l12-schema-graph-text2sql/scripts/compute_paper_figures.py
@@ -302,7 +302,7 @@ def main():
         c = _count_where_conditions(sql)
         g = 1 if re.search(r'\bGROUP\s+BY\b', sql.upper()) else 0
         e = 1 if re.search(r'\bEXISTS\b', sql.upper()) else 0
-        s = 1 if sql.upper().count('SELECT') > 1 else 0
+        s = 1 if (sql.upper().count('SELECT') > 1 and e == 0) else 0
         return t * 3 + c + g * 2 + e * 3 + s * 3
 
     def _unified_difficulty_label(score: int) -> str:


### PR DESCRIPTION
## Summary

`_unified_complexity_score()` で EXISTS句を含むSQLが `exists*3 + subquery*3 = 6` と二重カウントされるバグを修正。EXISTS句は必ずsub-SELECTを含むため、`e==1`の場合は`s=0`とする。

```diff
- s = 1 if sql.upper().count('SELECT') > 1 else 0
+ s = 1 if (sql.upper().count('SELECT') > 1 and e == 0) else 0
```

現時点では著者gold SQLにEXISTS 0件、独立1件のみのため出力に変化なし。将来のクエリ追加時に分類が正しくなる。

Devin Review #328 指摘対応。126テスト PASS、59論文値 PASS。

Link to Devin session: https://app.devin.ai/sessions/5c4cf372d3d54d638f06fe4ed622b85b
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->