### PR TITLE
paper: 考察に構造整合Vegard検証の意義を追加

### DIFF
--- a/paper/hea_lattice_prediction.tex
+++ b/paper/hea_lattice_prediction.tex
@@ -994,6 +994,40 @@ $\Omega_\text{sf}$は偏差の比として定義されるためGGA誤差が
 元素ごとのばらつきがそのまま影響する。
 
 
+\subsection{構造整合Vegard検証の意義}
+\label{sec:vegard_structure}
+
+図~\ref{fig:composition_b2}・\ref{fig:composition_l12}で
+構造ファミリーごとにVegard則の成立を検証した。
+この分離には本質的な理由がある。
+純元素の平衡体積は構造依存であり（$V_X^\text{BCC} \neq V_X^\text{FCC}$）、
+King原子体積のような構造非依存の単一値をB2とL1$_2$の両方に
+当てると、Vegardからの偏差（＝$\Omega_\text{sf}$）の中に
+合金化由来ではない純元素の構造体積差というアーティファクトが混入する。
+
+構造整合の端点（B2同種体積$V^\text{BCC}$、L1$_2$同種体積$V^\text{FCC}$）を
+用いることで、同一汎関数・同一セルタイプで端点と化合物が揃い、
+GGA系統誤差が偏差比の中でキャンセルする。
+残る偏差が構造体積差を含まない純粋な$\Omega_\text{sf}$となり、
+Vegard則がどこまで成立し、どこから$\Omega_\text{sf}$が効くかを
+クリーンに判定できる。
+
+ここで\ref{sec:self_consistency}節の「DFT体積はKingに劣る」との
+整合性を確認しておく。目的が異なる。
+Vegard成立の検証は相対量でありDFT内で完結するため
+構造整合DFT端点が正しい。
+一方、実合金の格子定数の絶対予測では元素依存GGA誤差が
+直接影響するためKing実験値が優る。
+両者は相補的であり矛盾しない。
+
+なお、この検証は体積空間で行うべきである。
+半径に変換すると、同じ原子体積でもBCCとFCCで最近接距離が
+異なるという別の構造ジオメトリが入り込む。
+剛体球接触モデルの単一半径セットが
+RMSE = 0.162~\AA{}と破綻したこと（\ref{sec:packing_results}節）は
+この問題を裏付ける。
+
+
 \subsection{DFT自己整合Ω$_\text{sf}$によるq$\approx$1の達成}
 \label{sec:dft_self_consistent}
 


### PR DESCRIPTION
## Summary

§4（考察）に「構造整合Vegard検証の意義」サブセクションを追加。Fig7のB2/L1₂分離（PR #335）の物理的根拠を考察として記述。

- 純元素体積の構造依存性（V_BCC ≠ V_FCC）→ King単一値使用時のアーティファクト混入問題
- DFT同種端点による偏差比のGGA誤差キャンセル機構
- Vegard検証（相対量、DFT端点）vs 絶対予測（King値）の目的の違い → §4.4との整合性を明記
- 体積空間で検証すべき理由（半径変換の構造ジオメトリ問題、§3.7 RMSE=0.162との接続）

Link to Devin session: https://app.devin.ai/sessions/3fd8fc4791c84687a3daf026214784b6
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->