### PR TITLE
fix: Appendix B「King値を下回った」の曖昧表現を明確化

### DIFF
--- a/paper/hea_lattice_prediction.tex
+++ b/paper/hea_lattice_prediction.tex
@@ -1037,7 +1037,7 @@ Vegard則自体の精度が高いためFCCでの$q$感度が低いことを反�
 $\Omega_\text{sf}$との自己整合性が確保されるが、
 3つの代替案（VASP B2同種体積、Wang~\cite{Wang2004lattice}の
 ab initio体積、741ペア直接予測）のいずれも
-King実験値を下回ることを確認した
+HEA予測精度（RMSE）でKing実験値を上回れないことを確認した
 （表~\ref{tab:vi_comparison}、\ref{sec:appendix_volumes}節）。
 GGA-PBEの元素依存系統誤差（Au: $+7.1$\%, Fe: $-4.6$\%等）が
 Vegardベースラインを直接劣化させるためである。
@@ -1417,7 +1417,7 @@ RMSE = 0.162~\AA{}と大きく、剛体球仮定の破綻を示す。
 \label{sec:appendix_volumes}
 
 King体積をDFT計算値に置き換える3つの試みを検証したが、
-いずれもKing値を下回った。
+いずれもHEA格子定数の予測精度（RMSE）はKing値使用時を上回れなかった。
 
 \subsection{VASP B2同種ペア体積}
 \label{sec:appendix_vasp_homo}


### PR DESCRIPTION
## Summary

「King値を下回った」が何（精度？誤差？）を指すか曖昧だった表現を2箇所修正:

- §4.4: `いずれもKing実験値を下回ることを確認した` → `いずれもHEA予測精度（RMSE）でKing実験値を上回れないことを確認した`
- Appendix B冒頭: `いずれもKing値を下回った` → `いずれもHEA格子定数の予測精度（RMSE）はKing値使用時を上回れなかった`

Link to Devin session: https://app.devin.ai/sessions/3fd8fc4791c84687a3daf026214784b6
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->