### PR TITLE
fix: W POTCAR variant W_pv → W_sv（全スクリプト統一）

### DIFF
--- a/vasp_inputs/generate_all_b2.py
+++ b/vasp_inputs/generate_all_b2.py
@@ -107,7 +107,7 @@ POTCAR_VARIANTS = {
     "Y": "Y_sv",   "Zr": "Zr_sv", "Nb": "Nb_pv", "Mo": "Mo_pv",
     "Ru": "Ru_pv", "Rh": "Rh_pv", "Pd": "Pd",    "Ag": "Ag",
     # 5d
-    "La": "La",    "Hf": "Hf_pv", "Ta": "Ta_pv", "W": "W_pv",
+    "La": "La",    "Hf": "Hf_pv", "Ta": "Ta_pv", "W": "W_sv",
     "Re": "Re_pv", "Os": "Os_pv", "Ir": "Ir",    "Pt": "Pt",
     "Au": "Au",
     # Rare earths

--- a/vasp_inputs/generate_magnetic_b2_recalc.py
+++ b/vasp_inputs/generate_magnetic_b2_recalc.py
@@ -77,7 +77,7 @@ POTCAR_VARIANTS = {
     "Cu": "Cu_pv", "Zn": "Zn",
     "Zr": "Zr_sv", "Nb": "Nb_pv", "Mo": "Mo_pv",
     "Ru": "Ru_pv", "Rh": "Rh_pv", "Pd": "Pd", "Ag": "Ag",
-    "Hf": "Hf_pv", "Ta": "Ta_pv", "W": "W_pv",
+    "Hf": "Hf_pv", "Ta": "Ta_pv", "W": "W_sv",
     "Re": "Re_pv", "Os": "Os_pv", "Ir": "Ir", "Pt": "Pt", "Au": "Au",
     "Ca": "Ca_sv", "Mg": "Mg_pv", "Be": "Be",
     "Al": "Al", "Si": "Si", "Ge": "Ge_d", "Sn": "Sn_d", "Pb": "Pb_d",

--- a/vasp_inputs/generate_refractory_b2.py
+++ b/vasp_inputs/generate_refractory_b2.py
@@ -55,7 +55,7 @@ POTCAR_VARIANTS = {
     "Ta": "Ta_pv",
     "Ti": "Ti_pv",
     "V":  "V_sv",
-    "W":  "W_pv",
+    "W":  "W_sv",
     "Zr": "Zr_sv",
 }
 

--- a/vasp_inputs/generate_table6_missing.py
+++ b/vasp_inputs/generate_table6_missing.py
@@ -106,7 +106,7 @@ POTCAR_VARIANTS = {
     "Ta": "Ta_pv",
     "Ti": "Ti_pv",
     "V":  "V_sv",
-    "W":  "W_pv",
+    "W":  "W_sv",
     "Zr": "Zr_sv",
 }
 

--- a/vasp_inputs/generate_vasp_inputs.py
+++ b/vasp_inputs/generate_vasp_inputs.py
@@ -169,7 +169,7 @@ POTCAR_VARIANTS = {
     "Ti": "Ti_pv",
     "Nb": "Nb_pv",
     "Ta": "Ta_pv",
-    "W":  "W_pv",
+    "W":  "W_sv",
     "Hf": "Hf_pv",
     "Zr": "Zr_sv",
     "Zn": "Zn",


### PR DESCRIPTION
## Summary

`POTCAR_VARIANTS` の W を `W_pv` → `W_sv` に修正。`potpaw_PBE` に `W_pv` が存在しない環境で W 含有ペア（Co-W, Cr-W, Fe-W, Mn-W, Ni-W）の POTCAR 生成が失敗していた。

全5スクリプトを統一修正:\n- `generate_magnetic_b2_recalc.py`\n- `generate_all_b2.py`\n- `generate_refractory_b2.py`\n- `generate_vasp_inputs.py`\n- `generate_table6_missing.py`

Link to Devin session: https://app.devin.ai/sessions/3fd8fc4791c84687a3daf026214784b6
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->