### PR TITLE
fix: run_all.sh を mpirun -np 8 に変更

### DIFF
--- a/vasp_inputs/generate_magnetic_b2_recalc.py
+++ b/vasp_inputs/generate_magnetic_b2_recalc.py
@@ -272,12 +272,15 @@ def generate_run_script(base_dir, calculations):
         "#!/bin/bash",
         "# Batch execution for magnetic B2 recalculations",
         "# Usage: bash run_all.sh",
+        "# Runs: mpirun -np $NP $VASPBIN (default NP=8)",
         "",
         'if [ -z "$VASPBIN" ]; then',
         '    echo "Error: VASPBIN not set"',
         '    echo "  export VASPBIN=/path/to/vasp_std"',
         '    exit 1',
         'fi',
+        '',
+        'NP=${NP:-8}',
         "",
         'BASE=$(cd "$(dirname "$0")" && pwd)',
         'LOG="$BASE/run_status.log"',
@@ -293,7 +296,7 @@ def generate_run_script(base_dir, calculations):
         lines.append('if [ ! -f POTCAR ]; then')
         lines.append('    echo "  SKIP (no POTCAR)" | tee -a "$LOG"')
         lines.append('else')
-        lines.append('    $VASPBIN > vasp.out 2>&1')
+        lines.append('    mpirun -np $NP $VASPBIN > vasp.out 2>&1')
         lines.append('    if grep -q "reached required accuracy" OUTCAR 2>/dev/null; then')
         lines.append('        echo "  CONVERGED" | tee -a "$LOG"')
         lines.append('    else')


### PR DESCRIPTION
## Summary

`run_all.sh` の VASP 実行コマンドを `$VASPBIN` → `mpirun -np $NP $VASPBIN` に変更（デフォルト NP=8）。`NP` 環境変数でコア数を変更可能（例: `NP=16 bash run_all.sh`）。

Link to Devin session: https://app.devin.ai/sessions/3fd8fc4791c84687a3daf026214784b6
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->