### PR TITLE
fix: AUC_delta_sf 0.745→0.710（paper_metrics.json再計算値に統一）

### DIFF
--- a/paper/hea_lattice_prediction.tex
+++ b/paper/hea_lattice_prediction.tex
@@ -940,20 +940,20 @@ $\bar{\Omega}_i = \sum_{j \ne i} c_j \Omega_\text{sf}(i,j)$。
 基準 & AUC & 精度 & F1 \\
 \midrule
 $\delta r$ (閾値4.73\%) & \textbf{0.869} & \textbf{0.815} & \textbf{0.833} \\
-$\delta_\text{sf}$ (閾値0.017) & 0.745 & 0.722 & 0.795 \\
+$\delta_\text{sf}$ (閾値0.017) & 0.710 & 0.722 & 0.795 \\
 Yang--Zhang & --- & 0.648 & 0.725 \\
 \bottomrule
 \end{tabular}
 \end{table}
 
-$\delta r$は$\delta_\text{sf}$より相分類に優れる（AUC 0.869 vs 0.745）。
+$\delta r$は$\delta_\text{sf}$より相分類に優れる（AUC 0.869 vs 0.710）。
 固溶体安定性が主に幾何学的サイズ適合性で支配されることを示す。
 
 \begin{figure}[H]
 \centering
 \includegraphics[width=0.7\columnwidth]{fig_roc.png}
 \caption{SS vs 非SS分類のROC曲線（54 HEA）。
-  $\delta r$（AUC = 0.869）が$\delta_\text{sf}$（AUC = 0.745）を上回る。}
+  $\delta r$（AUC = 0.869）が$\delta_\text{sf}$（AUC = 0.710）を上回る。}
 \label{fig:roc}
 \end{figure}
 
@@ -1143,7 +1143,7 @@ $q \neq 1$の主因はΩ$_\text{sf}$参照体積の不整合に
 第一に、7種のMLモデルがDFT-$\Omega_\text{sf}$モデルを
 実質的に改善できないことは、残差が測定ノイズに支配されていることを示す。
 第二に、DFT由来$\delta_\text{sf}$が$\delta r$より
-相分類で劣ること（AUC 0.745 vs 0.869）は、
+相分類で劣ること（AUC 0.710 vs 0.869）は、
 固溶体安定性が幾何学的サイズ適合性で支配されることの証拠であり、
 $\Omega_\text{sf}$の価値は格子定数の定量予測にある。
 第三に、DFT自己整合体積がKing実験値を超えられないことは、


### PR DESCRIPTION
## Summary

`generate_all_figures.py` 再実行で確認された `AUC_delta_sf = 0.710` に LaTeX 4箇所を統一。旧値 0.745 は4f+Y除外前の残存値。

変更箇所: 表5, 本文AUC比較, ROCキャプション, 考察（否定的結果）

Link to Devin session: https://app.devin.ai/sessions/3fd8fc4791c84687a3daf026214784b6
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->