### PR TITLE
fix: Devin Review #373 — no_dictレイテンシ・結論CTE記述・CTE表メトリック注釈

### DIFF
--- a/l12-schema-graph-text2sql/paper/main.tex
+++ b/l12-schema-graph-text2sql/paper/main.tex
@@ -918,7 +918,7 @@ $n$-best = 1への変更はレイテンシを70\%低減するが精度差は非�
 \midrule
 full & 27.7 \\
 no\_fewshot & 64.1 \\
-no\_dict & 56.5 \\
+no\_dict & 32.2 \\
 no\_reranker & 20.2 \\
 no\_guard & 39.4 \\
 no\_nbest & 8.3 \\
@@ -1613,12 +1613,13 @@ few-shot例・SQLGuardの除去により全件不正解となった。
 \midrule
 full          & 100\% (5/5) \\
 no\_fewshot   & 0\% (0/5) \\
-no\_dict      & 80\% (4/5) \\
+no\_dict      & 80\% (4/5)$^\dagger$ \\
 no\_reranker  & 100\% (5/5) \\
 no\_guard     & 0\% (0/5) \\
 no\_nbest     & 100\% (5/5) \\
 no\_graph     & 100\% (5/5) \\
 \bottomrule
+\multicolumn{2}{l}{\scriptsize $^\dagger$精度$\geq$0.8を正解と判定。平均精度は92.0\%。}
 \end{tabular}
 \end{table}
 
@@ -1752,9 +1753,10 @@ $\gamma'$相候補ランキング、安定・準安定候補162件の抽出を�
 
 CTE（Common Table Expression）を用いた多段計算クエリ
 （生成エンタルピー計算等）5件の評価では、
-few-shot例と辞書の両方が揃った条件で100\%の精度を達成し、
+few-shot例とSQLGuardの両方が揃った条件で100\%の精度を達成し、
 いずれかの除去で全件不正解となった（\ref{sec:cte_evaluation}節）。
-これは材料研究固有の導出量計算に対するfew-shot例の決定的重要性を示す。
+辞書の除去では4/5件が正解を維持（80\%）し、
+few-shot例からの語彙学習が大部分のCTEパターンで有効であることを示した。
 
 本研究を通じて得られたもう一つの重要な知見は、
 RDBスキーマの正規化度とテーブル構造が


### PR DESCRIPTION
## Summary

Devin Review #373 の3件を修正:

1. **レイテンシ表** `no_dict`: `56.5→32.2s` — `paper_data.json:72` の `avg_latency_s: 32.2` と一致
2. **結論** lines 1755-1757: 「few-shot+辞書→全件不正解」→「few-shot+SQLGuard→全件不正解、辞書除去は4/5維持(80%)」— §6.8の記述と整合
3. **CTE表** `no_dict 80% (4/5)` に `†` 注釈追加: 「平均精度は92.0%」— `paper_data.json:143` の `no_dict_cte_accuracy_pct: 92.0` との関係を明示

Link to Devin session: https://app.devin.ai/sessions/5c4cf372d3d54d638f06fe4ed622b85b
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/374" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->