### PR TITLE
fix: generate_all_figures.py 冒頭コメントのデータパスを実際の読み込み先に修正

### DIFF
--- a/paper/generate_all_figures.py
+++ b/paper/generate_all_figures.py
@@ -7,8 +7,7 @@ Usage:
     cd paper/ && python generate_all_figures.py
 
 Input data (relative to repo root):
-    four_case_output/figures/compounds_{MP,OQMD}_{B2,L12}.csv
-    data/compounds_VASP_{B2,L12}.csv
+    data/compounds_{MP,OQMD,VASP}_{B2,L12}.csv
 
 Output:
     paper/fig_*.png          — all paper figures


### PR DESCRIPTION
## Summary

冒頭docstringの入力データパスが古いまま残っていた。実際のコード(`load_compounds()` line 83-87)は `data/compounds_{MP,OQMD,VASP}_{B2,L12}.csv` を読むが、コメントには `four_case_output/figures/compounds_{MP,OQMD}_{B2,L12}.csv` と記載されていた。

```diff
-    four_case_output/figures/compounds_{MP,OQMD}_{B2,L12}.csv
-    data/compounds_VASP_{B2,L12}.csv
+    data/compounds_{MP,OQMD,VASP}_{B2,L12}.csv
```

Link to Devin session: https://app.devin.ai/sessions/3fd8fc4791c84687a3daf026214784b6
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->