### PR TITLE
fix: Table 2/3の列記順をKing→Alonso（時系列順）に変更

### DIFF
--- a/paper/hea_lattice_prediction.tex
+++ b/paper/hea_lattice_prediction.tex
@@ -484,7 +484,7 @@ $N$点のうち1点を抜いて$N-1$点で学習し、
 \paragraph{ベースライン}
 \begin{itemize}
   \item \textbf{King Vegard}:
-    King~\cite{King1966}の原子体積（本研究で41元素に拡張）による
+    King~\cite{King1966}の原子体積（41元素）による
     Vegard予測。Alonsoの体積セットとわずかに異なる。
   \item \textbf{Alonso Vegard}:
     Alonso~\cite{Alonso2021} Table~2記載の純元素原子体積$V_i$による

--- a/paper/hea_lattice_prediction.tex
+++ b/paper/hea_lattice_prediction.tex
@@ -483,6 +483,9 @@ $N$点のうち1点を抜いて$N-1$点で学習し、
 
 \paragraph{ベースライン}
 \begin{itemize}
+  \item \textbf{King Vegard}:
+    King~\cite{King1966}の原子体積（本研究で41元素に拡張）による
+    Vegard予測。Alonsoの体積セットとわずかに異なる。
   \item \textbf{Alonso Vegard}:
     Alonso~\cite{Alonso2021} Table~2記載の純元素原子体積$V_i$による
     Vegard予測$a = (n_\text{auc}\sum c_i V_i)^{1/3}$。
@@ -495,9 +498,6 @@ $N$点のうち1点を抜いて$N-1$点で学習し、
 
 \paragraph{本研究: 物理モデル}
 \begin{itemize}
-  \item \textbf{King Vegard}:
-    King~\cite{King1966}の原子体積（本研究で41元素に拡張）による
-    Vegard予測。Alonsoの体積セットとわずかに異なる。
   \item \textbf{DFT-$\Omega_\text{sf}$}:
     式~\ref{eq:alonso}にDFT由来の構造別$\Omega_\text{sf}$を適用し、
     構造依存スケーリング$q_s$（BCC: $q_\text{BCC} = 0.49$、
@@ -528,11 +528,11 @@ Ridge回帰とGradientBoostingをLOO-CV（64 HEAから1点を抜いて予測を�
    & (\AA) & (\AA) & (\%) & \\
 \midrule
 \multicolumn{5}{l}{\textit{ベースライン}} \\
+King Vegard         & 0.0227 & 0.0139 & 0.42 & 0.990 \\
 Alonso Vegard       & 0.0280 & 0.0167 & 0.50 & 0.985 \\
 Alonsoモデル       & 0.0229 & 0.0141 & 0.42 & 0.990 \\
 \midrule
 \multicolumn{5}{l}{\textit{本研究: 物理モデル}} \\
-King Vegard         & 0.0227 & 0.0139 & 0.42 & 0.990 \\
 DFT-$\Omega_\text{sf}$  & \textbf{0.0214} & \textbf{0.0128} & \textbf{0.39} & \textbf{0.991} \\
 加法$\delta^{(s)}$  & 0.0221 & --- & --- & --- \\
 \midrule
@@ -589,8 +589,8 @@ GradientBoostingは訓練RMSE = 0.0051~\AA だがLOO-CV RMSE = 0.170~\AA と重�
 \toprule
 手法 & BCC ($N\!=\!29$) & FCC ($N\!=\!35$) & 全体 \\
 \midrule
-Alonsoモデル        & 0.0309 & 0.0132 & 0.0229 \\
 King Vegard          & 0.0317 & 0.0104 & 0.0227 \\
+Alonsoモデル        & 0.0309 & 0.0132 & 0.0229 \\
 DFT-$\Omega_\text{sf}$ & 0.0299 & 0.0096 & 0.0214 \\
 \bottomrule
 \end{tabular}


### PR DESCRIPTION
## Summary

Table 2/3の行順をKing (1966) → Alonso (2021)の時系列順に変更。

- **Table 2** (`comparison`): King VegardをベースラインのAlonsoより前に移動。本研究セクションからベースラインに移動。
- **Table 3** (`bcc_fcc`): King Vegard → Alonsoモデル → DFT-Ω_sf の順に変更。
- 手法説明の段落順も同様にKing→Alonso順に変更。

Link to Devin session: https://app.devin.ai/sessions/3fd8fc4791c84687a3daf026214784b6
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->