### PR TITLE
fix: Fig 12（二元系Vegard吸収）を付録に移動

### DIFF
--- a/paper/hea_lattice_prediction.tex
+++ b/paper/hea_lattice_prediction.tex
@@ -871,10 +871,10 @@ $r_\text{eff}$が非自明な組成依存性を持つことがわかる。
 \label{fig:reff_comp}
 \end{figure*}
 
-構造依存有効体積$V_\text{eff}$の効果を二元系レベルで検証した結果を
-図~\ref{fig:vegard_absorbed}に示す。
+構造依存有効体積$V_\text{eff}$の効果を二元系レベルで検証すると、
 二元系ペア（B2: 465、L1$_2$: 441）に対するRMSE改善は
-0.222~\AA{}$\to$0.209~\AA（5.9\%）にとどまる。
+0.222~\AA{}$\to$0.209~\AA（5.9\%）にとどまる
+（付録~\ref{sec:appendix_vegard_binary}、図~\ref{fig:vegard_absorbed}）。
 これは組成が$c = 25\%, 50\%, 75\%$に限定されるため、
 Vegard則からの偏差の大部分が線形補間の精度内に収まることによる。
 一方、多成分HEAでは$n(n-1)/2$ペアの$\Omega_\text{sf}$が
@@ -882,18 +882,6 @@ Vegard則からの偏差の大部分が線形補間の精度内に収まるこ�
 独立テスト29 HEAでは11.4\%改善（0.0175~\AA{}$\to$0.0155~\AA）を達成した。
 すなわち$V_\text{eff}$の有用性は成分数の増加に伴い増大し、
 二元系での限定的改善はHEAへの適用を否定するものではない。
-
-\begin{figure*}[!t]
-\centering
-\includegraphics[width=\textwidth]{fig_vegard_structure_absorbed.png}
-\caption{構造情報吸収によるVegard則の改善（全二元系ペア）。
-  左: King純元素体積によるVegard予測（RMSE = 0.222~\AA）。
-  右: 構造依存有効体積$V_\text{eff}$による予測（RMSE = 0.209~\AA）。
-  改善幅は5.9\%にとどまり、二元系レベルでは
-  大部分の分散が組成効果で説明されることを示す。
-  ただし多成分HEAでは10.3\%改善に拡大する（本文参照）。}
-\label{fig:vegard_absorbed}
-\end{figure*}
 
 
 \subsection{機械学習残差解析}
@@ -1988,6 +1976,30 @@ Vegard則の補正に不可欠であることを裏付ける。
 \label{fig:vegard_vs_radius_l12}
 \end{figure*}
 
+
+
+\subsection{二元系における構造情報吸収の効果}
+\label{sec:appendix_vegard_binary}
+
+構造依存有効体積$V_\text{eff}$の効果を二元系レベルで検証した結果を
+図~\ref{fig:vegard_absorbed}に示す。
+King純元素体積によるVegard予測（RMSE = 0.222~\AA）に対し、
+$V_\text{eff}$による予測（RMSE = 0.209~\AA）は5.9\%の改善にとどまる。
+二元系では組成が$c = 25\%, 50\%, 75\%$に限定されるため、
+分散の大部分が組成効果で説明され、構造情報の寄与は小さい。
+多成分HEAでは複数ペアの$\Omega_\text{sf}$が非線形に寄与するため
+改善が拡大する（本文§\ref{sec:veff_results}参照）。
+
+\begin{figure*}[!t]
+\centering
+\includegraphics[width=\textwidth]{fig_vegard_structure_absorbed.png}
+\caption{二元系における構造情報吸収の効果。
+  左: King純元素体積によるVegard予測（RMSE = 0.222~\AA）。
+  右: 構造依存有効体積$V_\text{eff}$による予測（RMSE = 0.209~\AA）。
+  改善幅は5.9\%にとどまる。分散が大きくRMSE差が視覚的に識別しにくいのは、
+  二元系レベルでは大部分の分散が組成効果で説明されるためである。}
+\label{fig:vegard_absorbed}
+\end{figure*}
 
 
 \section{構造間$\Omega_\text{sf}$の相関}


### PR DESCRIPTION
## Summary

本文のFig 12（`fig_vegard_structure_absorbed`）を付録§全元素ペアVegard則の新subsection「二元系における構造情報吸収の効果」に移動。

- 本文: 図を削除、付録参照（`付録~\ref{sec:appendix_vegard_binary}`）に置換
- 付録: 図+説明テキストを追加。キャプションに「分散が大きくRMSE差が視覚的に識別しにくい理由」を明記
- 二元系では改善5.9%にとどまるが多成分HEAでは拡大する、という論旨は本文に残存

Link to Devin session: https://app.devin.ai/sessions/3fd8fc4791c84687a3daf026214784b6
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->