### PR TITLE
paper: 先行研究調査にTandoc/San/Zhang/Chen追加（格子歪み・ML予測）

### DIFF
--- a/paper/hea_lattice_prediction.tex
+++ b/paper/hea_lattice_prediction.tex
@@ -96,6 +96,12 @@ Alonsoら~\cite{Alonso2021}はKingの$\Omega_\text{sf}$を多成分HEAに拡張�
 \paragraph{DFTによるHEA格子定数研究}
 DFTデータベース（Materials Project~\cite{Jain2013}、OQMD~\cite{Saal2013}）は数千の二元系化合物の格子定数を提供しており、$\Omega_\text{sf}$のDFT再導出が可能である。第一原理計算によるHEA格子定数研究としてはTian~\emph{et al.}~\cite{Tian2013}のKKR-CPA法やTian~\emph{et al.}~\cite{Tian2015}のEMTO-CPA法があるが、いずれも特定組成のDFT直接計算であり、任意組成への外挿には新たなDFT計算が必要となる。
 
+\paragraph{格子歪みの予測モデル}
+Tandoc~\emph{et al.}~\cite{Tandoc2023}は10元素BCC耐火合金空間（Ti, V, Cr, Zr, Nb, Mo, Hf, Ta, W, Re）において、二元系B2結合長から構成した記述子（結合長標準偏差$\sigma^L_{\text{B2/bcc}}$、双極子不変量$u^{\text{dip}}_{\text{B2/bcc}}$）にVECを組み合わせた3パラメータ回帰モデルでRMSAD（root mean square atomic displacement）を予測した（テストRMSE = 0.012~\AA{}）。「純元素サイズではなく二元系化合物の結合情報を使う」発想は本研究と共通するが、予測対象は格子歪みであり格子定数にはVegard則をそのまま使用している。San~\emph{et al.}~\cite{San2021}は500原子SQS＋VASPで4種のFCC HEA（NiFeCoCr, NiFeCoCrMn, NiFeCoCrCu, NiFeCoCrPd）の局所格子歪みを解析し、元素対に依存した原子間距離の変動を報告した。いずれも格子歪みの理解に資するが、格子定数の汎用予測手法は提案していない。
+
+\paragraph{機械学習による格子定数予測}
+Zhang~\emph{et al.}~\cite{Zhang2022}はEMTO-CPA法で計算した7,086件の四元系HEAデータからDeep Setsモデルを訓練し、Wigner--Seitz半径を含む複数物性を同時予測した（$s_{\text{ws}}$のMAE = 0.004~Bohr）。大規模なDFTデータと深層学習の組合せにより高い内挿精度を達成しているが、(1)~EMTO-CPA値の予測であり実験格子定数との系統誤差（$\sim$1.1\%）を内包する、(2)~学習に用いた10元素空間外への外挿は保証されない、(3)~DFT→DFTの内挿であるためVegard則からの改善量を実験値ベースで評価することが困難、という制約がある。Chen~\emph{et al.}~\cite{Chen2023}は40元素の二元系・三元系DFT形成エネルギーから熱力学モデルを構築し、66万通りの五元系HEAの相安定性マップを作成した。BCC AlCoMnNiV（$a = 2.9$~\AA{}）およびFCC CoFeMnNiZn（$a = 3.635$~\AA{}）を予測・合成し実験格子定数を報告しており、本研究の独立テストデータとして利用可能である。
+
 \subsection{本研究の新規性}
 
 King以来の体積サイズファクター研究は実験値（King体積、実験格子定数）に依拠してきた。本研究は$\Omega_\text{sf}$の導出をDFT計算に置換し（純元素体積$V_i$はKing実験値を保持）、以下の3つの進展を得た。

--- a/paper/references.bib
+++ b/paper/references.bib
@@ -526,3 +526,33 @@
   year    = {2022},
   doi     = {10.1016/j.actamat.2021.117582},
 }
+
+@article{San2021,
+  author  = {S. San and C. Basak and W. Y. Ching},
+  title   = {Lattice distortion in {FCC} high entropy alloys: A first-principles study of {NiFeCoCr-X} (X = Mn, Cu, Pd)},
+  journal = {Mater. Des.},
+  volume  = {210},
+  pages   = {110071},
+  year    = {2021},
+  doi     = {10.1016/j.matdes.2021.110071},
+}
+
+@article{Zhang2022,
+  author  = {J. Zhang and C. Tandoc and Y. Ou and V. Shastri and M. Todai and T. Nakano and A. Hu and C. Wolverton},
+  title   = {Composition design of high-entropy alloys with deep sets learning},
+  journal = {npj Comput. Mater.},
+  volume  = {8},
+  pages   = {89},
+  year    = {2022},
+  doi     = {10.1038/s41524-022-00779-7},
+}
+
+@article{Chen2023,
+  author  = {Z. Chen and J. Wen and F. Grasselli and M. Bronstein and G. Hautier},
+  title   = {A map of single-phase high-entropy alloys},
+  journal = {Nat. Commun.},
+  volume  = {14},
+  pages   = {2856},
+  year    = {2023},
+  doi     = {10.1038/s41467-023-38423-7},
+}


### PR DESCRIPTION
## Summary

`\subsection{体積サイズファクター研究の系譜}` に2段落を追加。

**格子歪みの予測モデル** — Tandoc et al. (2023): B2結合長記述子によるRMSAD予測（10元素BCC耐火合金、テストRMSE=0.012 Å）。San et al. (2021): 500原子SQSによるFCC局所歪み解析（4系）。いずれも格子定数予測手法は提案していない旨を明記。

**機械学習による格子定数予測** — Zhang et al. (2022): EMTO-CPA 7,086件 + Deep Setsによる$s_\text{ws}$予測（MAE=0.004 Bohr）。実験値との系統誤差（~1.1%）・10元素空間限定を制約として記載。Chen et al. (2023): DFT熱力学モデルからの66万通りHEA相マップ。AlCoMnNiV/CoFeMnNiZnの実験格子定数を独立テストデータとして利用可能と位置づけ。

`references.bib` に `San2021`, `Zhang2022`, `Chen2023` の3エントリを追加（`Tandoc2023`は既存）。lualatex+bibtexコンパイル確認済み（26ページ、未定義参照なし）。

Link to Devin session: https://app.devin.ai/sessions/3fd8fc4791c84687a3daf026214784b6
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->