### PR TITLE
fix: Devin Review指摘3件修正（文献数・丸め・cite整合性）

### DIFF
--- a/hea_lattice_xgboost.py
+++ b/hea_lattice_xgboost.py
@@ -272,12 +272,12 @@ INDEPENDENT_TEST = [
     # Otto 2013: CoCrFeMnNi (Cantor alloy)
     {"comp":{"Co":0.20,"Cr":0.20,"Fe":0.20,"Mn":0.20,"Ni":0.20},"struct":"FCC","a_exp":3.5988,
      "ref":"Otto2013_ActaMat","note":"Cantor alloy standard"},
-    # Wang2019 Scripta Mater: CoCrFeNi FCC (precision measurement)
+    # Wang2015 Scripta Mater: CoCrFeNi FCC (precision measurement)
     {"comp":{"Co":0.25,"Cr":0.25,"Fe":0.25,"Ni":0.25},"struct":"FCC","a_exp":3.5723,
-     "ref":"Wang2019_ScriptaMat","note":"equiatomic 4-element precision XRD"},
-    # Wang2019: Co0.5CrFeNi FCC
+     "ref":"Wang2015_ScriptaMat","note":"equiatomic 4-element precision XRD"},
+    # Wang2015: Co0.5CrFeNi FCC
     {"comp":{"Co":0.143,"Cr":0.286,"Fe":0.286,"Ni":0.286},"struct":"FCC","a_exp":3.5805,
-     "ref":"Wang2019_ScriptaMat","note":"Co-lean non-equiatomic"},
+     "ref":"Wang2015_ScriptaMat","note":"Co-lean non-equiatomic"},
     # Niu 2017 Sci Rep: (CoCrFeNi)0.89Pd0.11 single FCC
     {"comp":{"Co":0.2225,"Cr":0.2225,"Fe":0.2225,"Ni":0.2225,"Pd":0.11},"struct":"FCC","a_exp":3.620,
      "ref":"Niu2017_SciRep","note":"11% Pd addition to CoCrFeNi"},

--- a/paper/hea_lattice_prediction.tex
+++ b/paper/hea_lattice_prediction.tex
@@ -144,7 +144,7 @@ King以来の体積サイズファクター研究は実験値（King体積、実
 \node[box, fill=blue!10] (dft) {DFTデータ\\{\scriptsize B2/L1$_2$: 5,152件\\SQS: 860件}};
 \node[box, fill=green!10, right=of dft] (omega) {$\Omega_\text{sf}$導出\\{\scriptsize B2: 465\\L1$_2$: 441}};
 \node[box, fill=red!10, right=of omega] (pred) {格子定数予測\\{\scriptsize 式(\ref{eq:alonso})\\元素対モデル}};
-\node[box, fill=purple!10, right=of pred] (test) {独立検証\\{\scriptsize 31 HEA\\15文献}};
+\node[box, fill=purple!10, right=of pred] (test) {独立検証\\{\scriptsize 31 HEA\\14文献}};
 \node[box, fill=orange!10, below=0.6cm of pred] (add) {加法分解\\{\scriptsize $\delta_i^{(s)}$: 31元素\\式(\ref{eq:a_from_veff})}};
 \draw[arr] (dft) -- (omega);
 \draw[arr] (omega) -- (pred);
@@ -207,7 +207,7 @@ VASP（本研究） & 2,200 & 2,810 & 5,010 \\
 収束判定と物理的格子定数範囲（2.0--8.0~\AA）でのフィルタリング後、B2で465・L1$_2$で441のユニーク元素ペアを得た。同一ペアに複数データソースがある場合は中央値を採用し外れ値の影響を緩和した。3ソース間の$\Omega_\text{sf}$は高い整合性を示し（B2 $r = 0.990$、L1$_2$ $r = 0.990$）、統合前後の平均変化量は$|\Delta\Omega| < 0.006$であった。
 
 \subsubsection{HEA検証データ}
-主検証セットはAlonso~\cite{Alonso2021} Table~2の64個の立方晶HEA（BCC 29、FCC 35、$a = 2.883$--$3.856$~\AA、22元素）である。独立テストセットとしてAlonsoデータ外の31 HEA（BCC 17、FCC 14）を15文献~\cite{Senkov2013,Senkov2013_ActaMat,Yao2016,Otto2013,Leong2017,Tseng2019,Freudenberger2017,Reget2020,Chen2022,Chen2023}から収集した。20元素をカバーし、耐火金属系BCC（Tseng 2019、Reget 2020）、貴金属系FCC（Freudenberger 2017）、三元系BCC（Chen 2022: HfNbZr）、CALPHAD予測＋合成検証（Chen 2023: AlCoMnNiV, CoFeMnNiZn）を含む。ただしBCC 17合金はHf-Mo-Nb-Ta-Ti-Zrの系統的サブセットが主体であり、FCC 14合金もAu-Cu-Ni-Pd-Pt系とCoCrFeMnNi派生に偏る。実効的な化学多様性は合金数より限定的である点に留意が必要である。
+主検証セットはAlonso~\cite{Alonso2021} Table~2の64個の立方晶HEA（BCC 29、FCC 35、$a = 2.883$--$3.856$~\AA、22元素）である。独立テストセットとしてAlonsoデータ外の31 HEA（BCC 17、FCC 14）を14文献~\cite{Senkov2012,Senkov2013_ActaMat,Yao2016,Otto2013,Stepanov2015,Tseng2019,Freudenberger2017,Reget2020,Dirras2016,Kantelis2025,Niu2017,Wang2019,Chen2022,Chen2023}から収集した。19元素をカバーし、耐火金属系BCC（Tseng 2019、Reget 2020）、貴金属系FCC（Freudenberger 2017）、三元系BCC（Chen 2022: HfNbZr）、CALPHAD予測＋合成検証（Chen 2023: AlCoMnNiV, CoFeMnNiZn）を含む。ただしBCC 17合金はHf-Mo-Nb-Ta-Ti-Zrの系統的サブセットが主体であり、FCC 14合金もAu-Cu-Ni-Pd-Pt系とCoCrFeMnNi派生に偏る。実効的な化学多様性は合金数より限定的である点に留意が必要である。
 
 \subsection{体積サイズファクターのDFT導出}
 \label{sec:omega}
@@ -449,11 +449,11 @@ FCC HEAはRMSE = 0.0096~\AA{}と推定$\sigma$以下の精度を示す。構成�
 \subsection{独立テスト検証}
 \label{sec:indep_test}
 
-従来の20点テストセット（実質10種の合金組成、HfNbTaTiZr$\times$3重複）の組成多様性の制約を解消するため、15文献から31個のHEA（BCC 17、FCC 14）を新たに収集した（表~\ref{tab:indep_test}）。20元素をカバーし、Tseng (2019)の耐火金属系BCCバリアント（HfMoNbTaTiZrの系統的元素除去）、Reget (2020)のMo--Nb--V--W--Ti系BCC、Freudenberger (2017)の貴金属系FCC（Au-Cu-Ni-Pd-Pt四元・五元系）、Chen (2022)のHfNbZr三元系BCC、Chen~\cite{Chen2023}のCALPHAD予測に基づく合成検証（AlCoMnNiV, CoFeMnNiZn）を含む。
+従来の20点テストセット（実質10種の合金組成、HfNbTaTiZr$\times$3重複）の組成多様性の制約を解消するため、14文献から31個のHEA（BCC 17、FCC 14）を新たに収集した（表~\ref{tab:indep_test}）。19元素をカバーし、Tseng (2019)の耐火金属系BCCバリアント（HfMoNbTaTiZrの系統的元素除去）、Reget (2020)のMo--Nb--V--W--Ti系BCC、Freudenberger (2017)の貴金属系FCC（Au-Cu-Ni-Pd-Pt四元・五元系）、Chen (2022)のHfNbZr三元系BCC、Chen~\cite{Chen2023}のCALPHAD予測に基づく合成検証（AlCoMnNiV, CoFeMnNiZn）を含む。
 
 \begin{table}[H]
 \centering
-\caption{独立テスト31 HEA（BCC 17 + FCC 14）の予測精度（RMSE / \AA）。訓練と非重複の15文献20元素。}
+\caption{独立テスト31 HEA（BCC 17 + FCC 14）の予測精度（RMSE / \AA）。訓練と非重複の14文献19元素。}
 \label{tab:indep_test}
 \footnotesize
 \begin{tabular}{@{}lccc@{}}
@@ -476,14 +476,14 @@ DFT-$\Omega_\text{sf}$モデルが全カテゴリで最良である。全体RMSE
 \begin{figure*}[!t]
 \centering
 \includegraphics[width=\textwidth]{fig_indep_test.png}
-\caption{独立テストセット（31 HEA、15文献20元素）の予測性能。
+\caption{独立テストセット（31 HEA、14文献19元素）の予測性能。
   (a)~合金別絶対誤差。(b)~構造別RMSE（灰: Vegard、青: DFT-$\Omega_\text{sf}$）。
   (c)~パリティプロット（$q_\text{BCC} = 0.49$、$q_\text{FCC} = 0.13$）。
   BCC 17合金（青四角）とFCC 14合金（赤丸）。}
 \label{fig:indep_test}
 \end{figure*}
 
-テストセット中で最大の誤差を示すAlCoMnNiV（BCC）について補足する。この合金の実験格子定数$a = 2.900$~\AA{}に対し、Vegard予測は$a = 2.957$~\AA（誤差$+0.057$~\AA）、$\Omega_\text{sf}$予測は$a = 2.930$~\AA（誤差$+0.030$~\AA）であり、$\Omega_\text{sf}$補正が誤差を約半分に縮小する。Vegard誤差が大きい主因はAlのKing原子体積（$V_\text{Al} = 16.60$~\AA$^3$、等価BCC格子定数3.21~\AA）が本来のFCC構造から換算した値であり、BCC環境でのAlの実効体積を過大評価するためである。全10ペアの$\Omega_\text{sf}^\text{B2}$は$-0.021$\textasciitilde$-0.129$と全て負値（体積収縮側）であり、特にAl--Co（$-0.129$）、Al--Mn（$-0.115$）が補正に寄与している。Chen~\cite{Chen2023}によるCALPHAD予測と実験の整合性は高いが、$a = 2.900$~\AA{}は3$d$遷移金属5元素としては異例に小さく、本モデルの二元系線形外挿の限界を示す事例である。
+テストセット中で最大の誤差を示すAlCoMnNiV（BCC）について補足する。この合金の実験格子定数$a = 2.900$~\AA{}に対し、Vegard予測は$a = 2.957$~\AA（誤差$+0.057$~\AA）、$\Omega_\text{sf}$予測は$a = 2.931$~\AA（誤差$+0.031$~\AA）であり、$\Omega_\text{sf}$補正が誤差を約半分に縮小する。Vegard誤差が大きい主因はAlのKing原子体積（$V_\text{Al} = 16.60$~\AA$^3$、等価BCC格子定数3.21~\AA）が本来のFCC構造から換算した値であり、BCC環境でのAlの実効体積を過大評価するためである。全10ペアの$\Omega_\text{sf}^\text{B2}$は$-0.021$\textasciitilde$-0.129$と全て負値（体積収縮側）であり、特にAl--Co（$-0.129$）、Al--Mn（$-0.115$）が補正に寄与している。Chen~\cite{Chen2023}によるCALPHAD予測と実験の整合性は高いが、$a = 2.900$~\AA{}は3$d$遷移金属5元素としては異例に小さく、本モデルの二元系線形外挿の限界を示す事例である。
 
 \subsection{元素別加法分解パラメータ}
 \label{sec:delta_results}

--- a/paper/hea_lattice_prediction.tex
+++ b/paper/hea_lattice_prediction.tex
@@ -207,7 +207,7 @@ VASP（本研究） & 2,200 & 2,810 & 5,010 \\
 収束判定と物理的格子定数範囲（2.0--8.0~\AA）でのフィルタリング後、B2で465・L1$_2$で441のユニーク元素ペアを得た。同一ペアに複数データソースがある場合は中央値を採用し外れ値の影響を緩和した。3ソース間の$\Omega_\text{sf}$は高い整合性を示し（B2 $r = 0.990$、L1$_2$ $r = 0.990$）、統合前後の平均変化量は$|\Delta\Omega| < 0.006$であった。
 
 \subsubsection{HEA検証データ}
-主検証セットはAlonso~\cite{Alonso2021} Table~2の64個の立方晶HEA（BCC 29、FCC 35、$a = 2.883$--$3.856$~\AA、22元素）である。独立テストセットとしてAlonsoデータ外の31 HEA（BCC 17、FCC 14）を14文献~\cite{Senkov2012,Senkov2013_ActaMat,Yao2016,Otto2013,Stepanov2015,Tseng2019,Freudenberger2017,Reget2020,Dirras2016,Kantelis2025,Niu2017,Wang2019,Chen2022,Chen2023}から収集した。19元素をカバーし、耐火金属系BCC（Tseng 2019、Reget 2020）、貴金属系FCC（Freudenberger 2017）、三元系BCC（Chen 2022: HfNbZr）、CALPHAD予測＋合成検証（Chen 2023: AlCoMnNiV, CoFeMnNiZn）を含む。ただしBCC 17合金はHf-Mo-Nb-Ta-Ti-Zrの系統的サブセットが主体であり、FCC 14合金もAu-Cu-Ni-Pd-Pt系とCoCrFeMnNi派生に偏る。実効的な化学多様性は合金数より限定的である点に留意が必要である。
+主検証セットはAlonso~\cite{Alonso2021} Table~2の64個の立方晶HEA（BCC 29、FCC 35、$a = 2.883$--$3.856$~\AA、22元素）である。独立テストセットとしてAlonsoデータ外の31 HEA（BCC 17、FCC 14）を14文献~\cite{Senkov2012,Senkov2013_ActaMat,Yao2016,Otto2013,Stepanov2015,Tseng2019,Freudenberger2017,Reget2020,Dirras2016,Kantelis2025,Niu2017,Wang2015,Chen2022,Chen2023}から収集した。19元素をカバーし、耐火金属系BCC（Tseng 2019、Reget 2020）、貴金属系FCC（Freudenberger 2017）、三元系BCC（Chen 2022: HfNbZr）、CALPHAD予測＋合成検証（Chen 2023: AlCoMnNiV, CoFeMnNiZn）を含む。ただしBCC 17合金はHf-Mo-Nb-Ta-Ti-Zrの系統的サブセットが主体であり、FCC 14合金もAu-Cu-Ni-Pd-Pt系とCoCrFeMnNi派生に偏る。実効的な化学多様性は合金数より限定的である点に留意が必要である。
 
 \subsection{体積サイズファクターのDFT導出}
 \label{sec:omega}

--- a/paper/references.bib
+++ b/paper/references.bib
@@ -556,3 +556,23 @@
   year    = {2023},
   doi     = {10.1038/s41467-023-38423-7},
 }
+
+@article{Senkov2012,
+  author  = {O. N. Senkov and J. M. Scott and S. V. Senkova and F. Meisenkothen and D. B. Miracle and C. F. Woodward},
+  title   = {Microstructure and elevated temperature properties of a refractory {TaNbHfZrTi} alloy},
+  journal = {J. Mater. Sci.},
+  volume  = {47},
+  pages   = {4062--4074},
+  year    = {2012},
+  doi     = {10.1007/s10853-012-6260-2},
+}
+
+@article{Niu2017,
+  author  = {C. Niu and A. J. Zaddach and A. A. Oni and X. Sang and J. W. Hurt III and J. M. LeBeau and C. C. Koch and D. L. Irving},
+  title   = {Spin-driven ordering of {Cr} in the equiatomic high entropy alloy {NiFeCrCo}},
+  journal = {Sci. Rep.},
+  volume  = {7},
+  pages   = {7043},
+  year    = {2017},
+  doi     = {10.1038/s41598-017-07289-1},
+}

--- a/paper/references.bib
+++ b/paper/references.bib
@@ -185,7 +185,7 @@
   doi     = {10.1038/srep39803},
 }
 
-@article{Wang2019,
+@article{Wang2015,
   author  = {Z. Wang and others},
   title   = {Atomic-size effect and solid solubility of multicomponent alloys},
   journal = {Scr. Mater.},


### PR DESCRIPTION
## Summary

PR#419のDevin Review指摘3件を修正。

1. **文献数・元素数の過大カウント**: `INDEPENDENT_TEST`の実データから数えると14文献・19元素。`15文献20元素`→`14文献19元素`に修正（4箇所: L147, L210, L456, L479）
2. **AlCoMnNiV予測値の丸め誤り**: CSV値`2.9312`の四捨五入は`2.931`。`2.930`→`2.931`、誤差`0.030`→`0.031`に修正
3. **`\cite{}`の整合性**: データに存在しない`Leong2017`を削除、実データに対応する6件（`Senkov2012`, `Stepanov2015`, `Kantelis2025`, `Dirras2016`, `Niu2017`, `Wang2019`）を追加。`references.bib`に`Senkov2012`と`Niu2017`のエントリを新規追加

Link to Devin session: https://app.devin.ai/sessions/3fd8fc4791c84687a3daf026214784b6
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->