### PR TITLE
fix: 例題2のΩ_sf値をコード出力（median）に統一

### DIFF
--- a/paper/hea_lattice_prediction.tex
+++ b/paper/hea_lattice_prediction.tex
@@ -1116,11 +1116,11 @@ $\binom{5}{2} = 10$ペアのDFT $\Omega_\text{sf}^\text{B2}$：
 \toprule
 ペア & $\Omega_\text{sf}$ & ペア & $\Omega_\text{sf}$ \\
 \midrule
-Hf--Mo & $-0.036$ & Mo--Zr & $-0.035$ \\
-Hf--Nb & $-0.011$ & Nb--Ti & $-0.025$ \\
-Hf--Ti & $-0.033$ & Nb--Zr & $-0.016$ \\
-Hf--Zr & $-0.017$ & Ti--Zr & $-0.032$ \\
-Mo--Nb & $+0.005$ & Mo--Ti & $-0.051$ \\
+Hf--Mo & $-0.041$ & Mo--Zr & $-0.045$ \\
+Hf--Nb & $-0.013$ & Nb--Ti & $-0.028$ \\
+Hf--Ti & $-0.023$ & Nb--Zr & $-0.018$ \\
+Hf--Zr & $-0.016$ & Ti--Zr & $-0.030$ \\
+Mo--Nb & $+0.008$ & Mo--Ti & $-0.056$ \\
 \bottomrule
 \end{tabular}
 \end{center}
@@ -1128,9 +1128,9 @@ Mo--Nb & $+0.005$ & Mo--Ti & $-0.051$ \\
 \paragraph{Step 4: B2参照での予測（$q_\text{BCC} = 0.49$）}
 \begin{align}
 \text{補正項} &= \sum_i \sum_{j \ne i} c_i\,c_j\,V_j\,\Omega_\text{sf}^\text{B2}(i,j)
-= -0.385~\text{\AA}^3, \nonumber \\
-V &= 2 \times (19.360 + 0.49 \times (-0.385)) = 38.34~\text{\AA}^3, \nonumber \\
-a_\text{pred}^{\text{B2}} &= 38.34^{1/3} = 3.372~\text{\AA}. \label{eq:ex_pred_bcc}
+= -0.401~\text{\AA}^3, \nonumber \\
+V &= 2 \times (19.360 + 0.49 \times (-0.401)) = 38.33~\text{\AA}^3, \nonumber \\
+a_\text{pred}^{\text{B2}} &= 38.33^{1/3} = 3.372~\text{\AA}. \label{eq:ex_pred_bcc}
 \end{align}
 
 \paragraph{Step 5: 実験値との比較}
@@ -1138,7 +1138,7 @@ a_\text{pred}^{\text{B2}} &= 38.34^{1/3} = 3.372~\text{\AA}. \label{eq:ex_pred_b
 $a_\text{exp} = 3.369$~\AA{}（Tseng 2019）。
 誤差 $= |3.372 - 3.369| = 0.003$~\AA。
 Vegard（$a = 3.383$~\AA、誤差0.014~\AA）と比較して78\%の誤差低減であり、$\Omega_\text{sf}$補正の典型的な改善例である。
-Mo--Ti（$-0.051$）やHf--Mo（$-0.036$）など原子サイズ差の大きいペアが負の$\Omega_\text{sf}$を持ち、Vegard則が過大評価する格子定数を収縮方向に補正している。
+Mo--Ti（$-0.056$）やMo--Zr（$-0.045$）など原子サイズ差の大きいペアが負の$\Omega_\text{sf}$を持ち、Vegard則が過大評価する格子定数を収縮方向に補正している。
 
 \paragraph{補足: SQS参照（$q = 1$）の場合}
 SQS $\Omega_\text{sf}$を用いると$a_\text{pred}^{\text{SQS}} \approx 3.367$~\AA{}（誤差0.002~\AA）となり、B2参照よりもさらに改善する。SQSはランダム固溶体の局所環境を直接模擬するため、B2の秩序効果（$\alpha = -1$）による$\Omega_\text{sf}$のバイアスが回避されるためである。


### PR DESCRIPTION
## Summary

例題2（HfMoNbTiZr）のΩ_sf表が`pairwise_omega_sf.csv`（selected source）の値を使用していたが、予測コード`compute_omega_sf_pairwise()`は全ソース（MP+OQMD+VASP）のmedianを使用するため不整合。10ペア中9ペアで値が異なっていた。

`results_omega_sf.csv`（コード出力）のmedian値に修正:
```
Hf-Mo: -0.036→-0.041  Mo-Zr: -0.035→-0.045
Hf-Nb: -0.011→-0.013  Nb-Ti: -0.025→-0.028
Hf-Ti: -0.033→-0.023  Nb-Zr: -0.016→-0.018
Mo-Nb: +0.005→+0.008  Ti-Zr: -0.032→-0.030
Mo-Ti: -0.051→-0.056
```
補正項: -0.385→-0.401、V: 38.34→38.33。最終a_pred=3.372・誤差0.003は変更なし（3dp丸めで同一）。

例題1（CoCrFeNi L1₂）は元々median値と一致しており修正不要。

Link to Devin session: https://app.devin.ai/sessions/3fd8fc4791c84687a3daf026214784b6
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->