### PR TITLE
fix: 独立テスト引用をCSV実出典14文献に同期

### DIFF
--- a/paper/hea_lattice_prediction.bbl
+++ b/paper/hea_lattice_prediction.bbl
@@ -61,24 +61,6 @@ J.~A. Alonso, Estimation of the lattice parameters of {HEAs}, J. Phase Equilib.
 \newblock \href {https://doi.org/10.1007/s11669-022-00988-z}
   {\path{doi:10.1007/s11669-022-00988-z}}.
 
-\bibitem{Zhang2008}
-Y.~Zhang, et~al., Solid-solution phase formation rules for multi-component
-  alloys, Adv. Eng. Mater. 10 (2008) 534--538.
-\newblock \href {https://doi.org/10.1002/adem.200700240}
-  {\path{doi:10.1002/adem.200700240}}.
-
-\bibitem{Guo2011}
-S.~Guo, C.~T. Liu, Phase stability in high entropy alloys: Formation of
-  solid-solution phase or amorphous phase, Prog. Nat. Sci. 21 (2011) 433--446.
-\newblock \href {https://doi.org/10.1016/S1002-0071(12)60080-X}
-  {\path{doi:10.1016/S1002-0071(12)60080-X}}.
-
-\bibitem{Yang2012}
-X.~Yang, Y.~Zhang, Prediction of high-entropy stabilized solid-solution in
-  multi-component alloys, Mater. Chem. Phys. 132 (2012) 233--238.
-\newblock \href {https://doi.org/10.1016/j.matchemphys.2011.11.021}
-  {\path{doi:10.1016/j.matchemphys.2011.11.021}}.
-
 \bibitem{Jain2013}
 A.~Jain, et~al., Commentary: {The Materials Project}: A materials genome
   approach to accelerating materials innovation, APL Mater. 1 (2013) 011002.
@@ -105,11 +87,38 @@ F.~Tian, et~al., Structural stability of {NiCoFeCrAl}$_x$ high-entropy alloy
 \newblock \href {https://doi.org/10.1038/srep12334}
   {\path{doi:10.1038/srep12334}}.
 
-\bibitem{Senkov2013}
-O.~N. Senkov, et~al., Refractory high-entropy alloys, Intermetallics 19 (2011)
-  698--706.
-\newblock \href {https://doi.org/10.1016/j.intermet.2011.01.004}
-  {\path{doi:10.1016/j.intermet.2011.01.004}}.
+\bibitem{Tandoc2023}
+C.~Tandoc, et~al., Mining of lattice distortion, strength, and intrinsic
+  ductility of refractory high entropy alloys, npj Comput. Mater. 9 (2023) 53.
+\newblock \href {https://doi.org/10.1038/s41524-023-00993-x}
+  {\path{doi:10.1038/s41524-023-00993-x}}.
+
+\bibitem{San2021}
+S.~San, C.~Basak, W.~Y. Ching, Lattice distortion in {FCC} high entropy alloys:
+  A first-principles study of {NiFeCoCr-X} (x = mn, cu, pd), Mater. Des. 210
+  (2021) 110071.
+\newblock \href {https://doi.org/10.1016/j.matdes.2021.110071}
+  {\path{doi:10.1016/j.matdes.2021.110071}}.
+
+\bibitem{Zhang2022}
+J.~Zhang, C.~Tandoc, Y.~Ou, V.~Shastri, M.~Todai, T.~Nakano, A.~Hu,
+  C.~Wolverton, Composition design of high-entropy alloys with deep sets
+  learning, npj Comput. Mater. 8 (2022) 89.
+\newblock \href {https://doi.org/10.1038/s41524-022-00779-7}
+  {\path{doi:10.1038/s41524-022-00779-7}}.
+
+\bibitem{Chen2023}
+Z.~Chen, J.~Wen, F.~Grasselli, M.~Bronstein, G.~Hautier, A map of single-phase
+  high-entropy alloys, Nat. Commun. 14 (2023) 2856.
+\newblock \href {https://doi.org/10.1038/s41467-023-38423-7}
+  {\path{doi:10.1038/s41467-023-38423-7}}.
+
+\bibitem{Senkov2012}
+O.~N. Senkov, J.~M. Scott, S.~V. Senkova, F.~Meisenkothen, D.~B. Miracle, C.~F.
+  Woodward, Microstructure and elevated temperature properties of a refractory
+  {TaNbHfZrTi} alloy, J. Mater. Sci. 47 (2012) 4062--4074.
+\newblock \href {https://doi.org/10.1007/s10853-012-6260-2}
+  {\path{doi:10.1007/s10853-012-6260-2}}.
 
 \bibitem{Senkov2013_ActaMat}
 O.~N. Senkov, S.~V. Senkova, C.~Woodward, D.~B. Miracle, Low-density,
@@ -131,11 +140,12 @@ F.~Otto, et~al., The influences of temperature and microstructure on the
 \newblock \href {https://doi.org/10.1016/j.actamat.2013.06.018}
   {\path{doi:10.1016/j.actamat.2013.06.018}}.
 
-\bibitem{Leong2017}
-Z.~Leong, et~al., The effect of electronic structure on the phases present in
-  high entropy alloys, Sci. Rep. 7 (2017) 39803.
-\newblock \href {https://doi.org/10.1038/srep39803}
-  {\path{doi:10.1038/srep39803}}.
+\bibitem{Stepanov2015}
+N.~D. Stepanov, et~al., Effect of {V} content on microstructure and mechanical
+  properties of the {CoCrFeMnNiV}$_x$ high entropy alloys, Mater. Lett. 142
+  (2015) 153--155.
+\newblock \href {https://doi.org/10.1016/j.matlet.2014.11.162}
+  {\path{doi:10.1016/j.matlet.2014.11.162}}.
 
 \bibitem{Tseng2019}
 K.-K. Tseng, C.-C. Juan, S.~Tso, H.-C. Chen, C.-W. Tsai, J.-W. Yeh, Effects of
@@ -145,6 +155,14 @@ K.-K. Tseng, C.-C. Juan, S.~Tso, H.-C. Chen, C.-W. Tsai, J.-W. Yeh, Effects of
 \newblock \href {https://doi.org/10.3390/e21010015}
   {\path{doi:10.3390/e21010015}}.
 
+\bibitem{Dirras2016}
+G.~Dirras, et~al., Microstructural investigation of plastically deformed
+  {Ti$_{20}$Zr$_{20}$Hf$_{20}$Nb$_{20}$Ta$_{20}$} high entropy alloy by {X}-ray
+  diffraction and transmission electron microscopy, Mater. Charact. 108 (2015)
+  1--7.
+\newblock \href {https://doi.org/10.1016/j.matchar.2015.08.007}
+  {\path{doi:10.1016/j.matchar.2015.08.007}}.
+
 \bibitem{Freudenberger2017}
 J.~Freudenberger, D.~Rafaja, D.~Geissler, L.~Giebeler, C.~L.~H. de~Oliveira,
   J.~Eckert, Face-centred cubic multi-component equiatomic solid solutions in
@@ -152,6 +170,19 @@ J.~Freudenberger, D.~Rafaja, D.~Geissler, L.~Giebeler, C.~L.~H. de~Oliveira,
   lattice parameters for 5 quaternary + 1 quinary FCC alloys.
 \newblock \href {https://doi.org/10.3390/met7040135}
   {\path{doi:10.3390/met7040135}}.
+
+\bibitem{Niu2017}
+C.~Niu, A.~J. Zaddach, C.~C. Koch, D.~L. Irving, First principles exploration
+  of near-equiatomic {NiFeCrCo} high entropy alloys, J. Alloys Compd. 672
+  (2016) 510--520, coCrFeNi--Pd/V lattice parameters.
+\newblock \href {https://doi.org/10.1016/j.jallcom.2016.02.108}
+  {\path{doi:10.1016/j.jallcom.2016.02.108}}.
+
+\bibitem{Wang2019}
+Z.~Wang, et~al., Atomic-size effect and solid solubility of multicomponent
+  alloys, Scr. Mater. 94 (2015) 28--31.
+\newblock \href {https://doi.org/10.1016/j.scriptamat.2014.09.010}
+  {\path{doi:10.1016/j.scriptamat.2014.09.010}}.
 
 \bibitem{Reget2020}
 F.~Reget, M.~Maa{\ss}, J.~Haas, J.~Fiehn, N.~Seifried, T.~G. Bley, L.~Pichl,
@@ -161,6 +192,12 @@ F.~Reget, M.~Maa{\ss}, J.~Haas, J.~Fiehn, N.~Seifried, T.~G. Bley, L.~Pichl,
 \newblock \href {https://doi.org/10.3390/met10111530}
   {\path{doi:10.3390/met10111530}}.
 
+\bibitem{Kantelis2025}
+K.~Kantelis, et~al., Lattice distortions in high-entropy alloys, AIP Adv. 15
+  (2025) 015030.
+\newblock \href {https://doi.org/10.1063/5.0245966}
+  {\path{doi:10.1063/5.0245966}}.
+
 \bibitem{Chen2022}
 S.~Chen, Z.~H. Aitken, S.~Pattamatta, Z.~Wu, Z.~G. Yu, D.~J. Srolovitz, P.~K.
   Liaw, Y.-W. Zhang, Phase decomposition and strengthening in {HfNbTaTiZr} high
@@ -168,18 +205,6 @@ S.~Chen, Z.~H. Aitken, S.~Pattamatta, Z.~Wu, Z.~G. Yu, D.~J. Srolovitz, P.~K.
   117582.
 \newblock \href {https://doi.org/10.1016/j.actamat.2021.117582}
   {\path{doi:10.1016/j.actamat.2021.117582}}.
-
-\bibitem{TodaCaraballo2016}
-I.~Toda-Caraballo, P.~E. J. R.-D. del Castillo, Modelling solid solution
-  hardening in high entropy alloys, Intermetallics 71 (2016) 76--87.
-\newblock \href {https://doi.org/10.1016/j.intermet.2015.12.011}
-  {\path{doi:10.1016/j.intermet.2015.12.011}}.
-
-\bibitem{Ye2015}
-Y.~F. Ye, C.~T. Liu, Y.~Yang, A geometric model for intrinsic residual strain
-  and phase stability in high entropy alloys, Acta Mater. 94 (2015) 152--161.
-\newblock \href {https://doi.org/10.1016/j.actamat.2015.04.051}
-  {\path{doi:10.1016/j.actamat.2015.04.051}}.
 
 \bibitem{Wang2004lattice}
 Y.~Wang, S.~Curtarolo, C.~Jiang, R.~Arroyave, T.~Wang, G.~Ceder, L.-Q. Chen,

--- a/paper/hea_lattice_prediction.bbl
+++ b/paper/hea_lattice_prediction.bbl
@@ -95,8 +95,8 @@ C.~Tandoc, et~al., Mining of lattice distortion, strength, and intrinsic
 
 \bibitem{San2021}
 S.~San, C.~Basak, W.~Y. Ching, Lattice distortion in {FCC} high entropy alloys:
-  A first-principles study of {NiFeCoCr-X} (x = mn, cu, pd), Mater. Des. 210
-  (2021) 110071.
+  {A} first-principles study of {NiFeCoCr-X} ({X} = {Mn}, {Cu}, {Pd}), Mater.
+  Des. 210 (2021) 110071.
 \newblock \href {https://doi.org/10.1016/j.matdes.2021.110071}
   {\path{doi:10.1016/j.matdes.2021.110071}}.
 
@@ -174,7 +174,7 @@ J.~Freudenberger, D.~Rafaja, D.~Geissler, L.~Giebeler, C.~L.~H. de~Oliveira,
 \bibitem{Niu2017}
 C.~Niu, A.~J. Zaddach, C.~C. Koch, D.~L. Irving, First principles exploration
   of near-equiatomic {NiFeCrCo} high entropy alloys, J. Alloys Compd. 672
-  (2016) 510--520, coCrFeNi--Pd/V lattice parameters.
+  (2016) 510--520, {CoCrFeNi}--{Pd}/{V} lattice parameters.
 \newblock \href {https://doi.org/10.1016/j.jallcom.2016.02.108}
   {\path{doi:10.1016/j.jallcom.2016.02.108}}.
 

--- a/paper/hea_lattice_prediction.tex
+++ b/paper/hea_lattice_prediction.tex
@@ -144,7 +144,7 @@ King以来の体積サイズファクター研究は実験値（King体積、実
 \node[box, fill=blue!10] (dft) {DFTデータ\\{\scriptsize B2/L1$_2$: 5,152件\\SQS: 860件}};
 \node[box, fill=green!10, right=of dft] (omega) {$\Omega_\text{sf}$導出\\{\scriptsize B2: 465\\L1$_2$: 441}};
 \node[box, fill=red!10, right=of omega] (pred) {格子定数予測\\{\scriptsize 式(\ref{eq:alonso})\\元素対モデル}};
-\node[box, fill=purple!10, right=of pred] (test) {独立検証\\{\scriptsize 31 HEA\\15文献}};
+\node[box, fill=purple!10, right=of pred] (test) {独立検証\\{\scriptsize 31 HEA\\14文献}};
 \node[box, fill=orange!10, below=0.6cm of pred] (add) {加法分解\\{\scriptsize $\delta_i^{(s)}$: 31元素\\式(\ref{eq:a_from_veff})}};
 \draw[arr] (dft) -- (omega);
 \draw[arr] (omega) -- (pred);
@@ -207,7 +207,7 @@ VASP（本研究） & 2,200 & 2,810 & 5,010 \\
 収束判定と物理的格子定数範囲（2.0--8.0~\AA）でのフィルタリング後、B2で465・L1$_2$で441のユニーク元素ペアを得た。同一ペアに複数データソースがある場合は中央値を採用し外れ値の影響を緩和した。3ソース間の$\Omega_\text{sf}$は高い整合性を示し（B2 $r = 0.990$、L1$_2$ $r = 0.990$）、統合前後の平均変化量は$|\Delta\Omega| < 0.006$であった。
 
 \subsubsection{HEA検証データ}
-主検証セットはAlonso~\cite{Alonso2021} Table~2の64個の立方晶HEA（BCC 29、FCC 35、$a = 2.883$--$3.856$~\AA、22元素）である。独立テストセットとしてAlonsoデータ外の31 HEA（BCC 17、FCC 14）を15文献~\cite{Senkov2013,Senkov2013_ActaMat,Yao2016,Otto2013,Leong2017,Tseng2019,Freudenberger2017,Reget2020,Chen2022,Chen2023}から収集した。20元素をカバーし、耐火金属系BCC（Tseng 2019、Reget 2020）、貴金属系FCC（Freudenberger 2017）、三元系BCC（Chen 2022: HfNbZr）、CALPHAD予測＋合成検証（Chen 2023: AlCoMnNiV, CoFeMnNiZn）を含む。ただしBCC 17合金はHf-Mo-Nb-Ta-Ti-Zrの系統的サブセットが主体であり、FCC 14合金もAu-Cu-Ni-Pd-Pt系とCoCrFeMnNi派生に偏る。実効的な化学多様性は合金数より限定的である点に留意が必要である。
+主検証セットはAlonso~\cite{Alonso2021} Table~2の64個の立方晶HEA（BCC 29、FCC 35、$a = 2.883$--$3.856$~\AA、22元素）である。独立テストセットとしてAlonsoデータ外の31 HEA（BCC 17、FCC 14）を14文献~\cite{Senkov2012,Senkov2013_ActaMat,Yao2016,Otto2013,Stepanov2015,Tseng2019,Dirras2016,Freudenberger2017,Niu2017,Wang2019,Reget2020,Kantelis2025,Chen2022,Chen2023}から収集した。20元素をカバーし、耐火金属系BCC（Tseng 2019、Reget 2020）、貴金属系FCC（Freudenberger 2017）、三元系BCC（Chen 2022: HfNbZr）、CALPHAD予測＋合成検証（Chen 2023: AlCoMnNiV, CoFeMnNiZn）を含む。ただしBCC 17合金はHf-Mo-Nb-Ta-Ti-Zrの系統的サブセットが主体であり、FCC 14合金もAu-Cu-Ni-Pd-Pt系とCoCrFeMnNi派生に偏る。実効的な化学多様性は合金数より限定的である点に留意が必要である。
 
 \subsection{体積サイズファクターのDFT導出}
 \label{sec:omega}
@@ -449,11 +449,11 @@ FCC HEAはRMSE = 0.0096~\AA{}と推定$\sigma$以下の精度を示す。構成�
 \subsection{独立テスト検証}
 \label{sec:indep_test}
 
-従来の20点テストセット（実質10種の合金組成、HfNbTaTiZr$\times$3重複）の組成多様性の制約を解消するため、15文献から31個のHEA（BCC 17、FCC 14）を新たに収集した（表~\ref{tab:indep_test}）。20元素をカバーし、Tseng (2019)の耐火金属系BCCバリアント（HfMoNbTaTiZrの系統的元素除去）、Reget (2020)のMo--Nb--V--W--Ti系BCC、Freudenberger (2017)の貴金属系FCC（Au-Cu-Ni-Pd-Pt四元・五元系）、Chen (2022)のHfNbZr三元系BCC、Chen~\cite{Chen2023}のCALPHAD予測に基づく合成検証（AlCoMnNiV, CoFeMnNiZn）を含む。
+従来の20点テストセット（実質10種の合金組成、HfNbTaTiZr$\times$3重複）の組成多様性の制約を解消するため、14文献から31個のHEA（BCC 17、FCC 14）を新たに収集した（表~\ref{tab:indep_test}）。20元素をカバーし、Tseng (2019)の耐火金属系BCCバリアント（HfMoNbTaTiZrの系統的元素除去）、Reget (2020)のMo--Nb--V--W--Ti系BCC、Freudenberger (2017)の貴金属系FCC（Au-Cu-Ni-Pd-Pt四元・五元系）、Chen (2022)のHfNbZr三元系BCC、Chen~\cite{Chen2023}のCALPHAD予測に基づく合成検証（AlCoMnNiV, CoFeMnNiZn）を含む。
 
 \begin{table}[H]
 \centering
-\caption{独立テスト31 HEA（BCC 17 + FCC 14）の予測精度（RMSE / \AA）。訓練と非重複の15文献20元素。}
+\caption{独立テスト31 HEA（BCC 17 + FCC 14）の予測精度（RMSE / \AA）。訓練と非重複の14文献20元素。}
 \label{tab:indep_test}
 \footnotesize
 \begin{tabular}{@{}lccc@{}}
@@ -476,7 +476,7 @@ DFT-$\Omega_\text{sf}$モデルが全カテゴリで最良である。全体RMSE
 \begin{figure*}[!t]
 \centering
 \includegraphics[width=\textwidth]{fig_indep_test.png}
-\caption{独立テストセット（31 HEA、15文献20元素）の予測性能。
+\caption{独立テストセット（31 HEA、14文献20元素）の予測性能。
   (a)~合金別絶対誤差。(b)~構造別RMSE（灰: Vegard、青: DFT-$\Omega_\text{sf}$）。
   (c)~パリティプロット（$q_\text{BCC} = 0.49$、$q_\text{FCC} = 0.13$）。
   BCC 17合金（青四角）とFCC 14合金（赤丸）。}

--- a/paper/references.bib
+++ b/paper/references.bib
@@ -455,7 +455,7 @@
   pages   = {510--520},
   year    = {2016},
   doi     = {10.1016/j.jallcom.2016.02.108},
-  note    = {CoCrFeNi--Pd/V lattice parameters},
+  note    = {{CoCrFeNi}--{Pd}/{V} lattice parameters},
 }
 
 @article{vandeWalle2013,
@@ -550,7 +550,7 @@
 
 @article{San2021,
   author  = {S. San and C. Basak and W. Y. Ching},
-  title   = {Lattice distortion in {FCC} high entropy alloys: A first-principles study of {NiFeCoCr-X} (X = Mn, Cu, Pd)},
+  title   = {Lattice distortion in {FCC} high entropy alloys: {A} first-principles study of {NiFeCoCr-X} ({X} = {Mn}, {Cu}, {Pd})},
   journal = {Mater. Des.},
   volume  = {210},
   pages   = {110071},

--- a/paper/references.bib
+++ b/paper/references.bib
@@ -437,6 +437,27 @@
   doi     = {10.1016/j.actamat.2012.11.032},
 }
 
+@article{Senkov2012,
+  author  = {O. N. Senkov and J. M. Scott and S. V. Senkova and F. Meisenkothen and D. B. Miracle and C. F. Woodward},
+  title   = {Microstructure and elevated temperature properties of a refractory {TaNbHfZrTi} alloy},
+  journal = {J. Mater. Sci.},
+  volume  = {47},
+  pages   = {4062--4074},
+  year    = {2012},
+  doi     = {10.1007/s10853-012-6260-2},
+}
+
+@article{Niu2017,
+  author  = {C. Niu and A. J. Zaddach and C. C. Koch and D. L. Irving},
+  title   = {First principles exploration of near-equiatomic {NiFeCrCo} high entropy alloys},
+  journal = {J. Alloys Compd.},
+  volume  = {672},
+  pages   = {510--520},
+  year    = {2016},
+  doi     = {10.1016/j.jallcom.2016.02.108},
+  note    = {CoCrFeNi--Pd/V lattice parameters},
+}
+
 @article{vandeWalle2013,
   author  = {A. {van de Walle} and P. Tiwary and M. {de Jong} and D. L. Olmsted and M. Asta and A. Dick and D. Shin and Y. Wang and L.-Q. Chen and Z.-K. Liu},
   title   = {Efficient stochastic generation of special quasirandom structures},


### PR DESCRIPTION
## Summary

独立テストセット31 HEAの引用リストが `results_independent_test.csv` の `ref` 列と不整合だった。

**不整合の内容:**
- 本文「15文献」→ CSV実データは **14文献**
- `\cite{}` に10キーしかなく、うち2件（`Senkov2013`, `Leong2017`）はCSVに出典として存在しない
- CSVの実出典6件（`Senkov2012`, `Stepanov2015`, `Dirras2016`, `Niu2017`, `Wang2019`, `Kantelis2025`）が引用漏れ

**修正:**
- `15文献` → `14文献`（5箇所: パイプライン図・本文・表キャプション・図キャプション・セクション冒頭）
- `\cite{}` を14実出典に差し替え: `-Senkov2013,-Leong2017,+Senkov2012,+Stepanov2015,+Dirras2016,+Niu2017,+Wang2019,+Kantelis2025`
- `references.bib` に `Senkov2012`（J. Mater. Sci. 47, 2012）と `Niu2017`（J. Alloys Compd. 672, 2016）を追加
- `bibtex` 再実行で `.bbl` 再生成 → 未定義引用 `[?]` ゼロ確認

**注意:** `Niu2017` の書誌はCrossref検索で最も近い Niu/Zaddach/Koch/Irving (2016) J. Alloys Compd. を採用したが、CSVのキー `Niu2017_SciRep`（Scientific Reports 2017）と年・誌名が一致しない。正確な書誌の確認をお願いします。

Link to Devin session: https://app.devin.ai/sessions/3fd8fc4791c84687a3daf026214784b6
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->