### PR TITLE
fix: 独立テスト引用をCSV実出典14文献に同期 + 全数値検証

### DIFF
--- a/paper/hea_lattice_prediction.bbl
+++ b/paper/hea_lattice_prediction.bbl
@@ -113,11 +113,12 @@ Z.~Chen, J.~Wen, F.~Grasselli, M.~Bronstein, G.~Hautier, A map of single-phase
 \newblock \href {https://doi.org/10.1038/s41467-023-38423-7}
   {\path{doi:10.1038/s41467-023-38423-7}}.
 
-\bibitem{Senkov2013}
-O.~N. Senkov, et~al., Refractory high-entropy alloys, Intermetallics 19 (2011)
-  698--706.
-\newblock \href {https://doi.org/10.1016/j.intermet.2011.01.004}
-  {\path{doi:10.1016/j.intermet.2011.01.004}}.
+\bibitem{Senkov2012}
+O.~N. Senkov, J.~M. Scott, S.~V. Senkova, D.~B. Miracle, C.~F. Woodward,
+  Microstructure and room temperature properties of a high-entropy {TaNbHfZrTi}
+  alloy, J. Alloys Compd. 509 (2011) 6043--6048.
+\newblock \href {https://doi.org/10.1016/j.jallcom.2011.02.171}
+  {\path{doi:10.1016/j.jallcom.2011.02.171}}.
 
 \bibitem{Senkov2013_ActaMat}
 O.~N. Senkov, S.~V. Senkova, C.~Woodward, D.~B. Miracle, Low-density,
@@ -126,12 +127,6 @@ O.~N. Senkov, S.~V. Senkova, C.~Woodward, D.~B. Miracle, Low-density,
 \newblock \href {https://doi.org/10.1016/j.actamat.2012.11.032}
   {\path{doi:10.1016/j.actamat.2012.11.032}}.
 
-\bibitem{Yao2016}
-H.~W. Yao, et~al., {NbTaV-(Ti,W)} refractory high-entropy alloys, Entropy 18
-  (2016) 189.
-\newblock \href {https://doi.org/10.3390/e18050189}
-  {\path{doi:10.3390/e18050189}}.
-
 \bibitem{Otto2013}
 F.~Otto, et~al., The influences of temperature and microstructure on the
   tensile properties of a {CoCrFeMnNi} high-entropy alloy, Acta Mater. 61
@@ -139,19 +134,33 @@ F.~Otto, et~al., The influences of temperature and microstructure on the
 \newblock \href {https://doi.org/10.1016/j.actamat.2013.06.018}
   {\path{doi:10.1016/j.actamat.2013.06.018}}.
 
-\bibitem{Leong2017}
-Z.~Leong, et~al., The effect of electronic structure on the phases present in
-  high entropy alloys, Sci. Rep. 7 (2017) 39803.
-\newblock \href {https://doi.org/10.1038/srep39803}
-  {\path{doi:10.1038/srep39803}}.
+\bibitem{Niu2017}
+C.~Niu, A.~J. Zaddach, A.~A. Oni, X.~Sang, J.~W.~H. III, J.~M. LeBeau, C.~C.
+  Koch, D.~L. Irving, Spin-driven ordering of {Cr} in the equiatomic high
+  entropy alloy {NiFeCrCo}, Appl. Phys. Lett. 106 (2015) 161906.
+\newblock \href {https://doi.org/10.1063/1.4918996}
+  {\path{doi:10.1063/1.4918996}}.
 
-\bibitem{Tseng2019}
-K.-K. Tseng, C.-C. Juan, S.~Tso, H.-C. Chen, C.-W. Tsai, J.-W. Yeh, Effects of
-  {Mo}, {Nb}, {Ta}, {Ti}, and {Zr} on mechanical properties of equiatomic
-  {Hf-Mo-Nb-Ta-Ti-Zr} alloys, Entropy 21 (2019) 15, table~2: HfMoNbTaTiZr and 5
-  equiatomic BCC subsets with XRD lattice parameters.
-\newblock \href {https://doi.org/10.3390/e21010015}
-  {\path{doi:10.3390/e21010015}}.
+\bibitem{Stepanov2015}
+N.~D. Stepanov, et~al., Effect of {V} content on microstructure and mechanical
+  properties of the {CoCrFeMnNiV}$_x$ high entropy alloys, Mater. Lett. 142
+  (2015) 153--155.
+\newblock \href {https://doi.org/10.1016/j.matlet.2014.11.162}
+  {\path{doi:10.1016/j.matlet.2014.11.162}}.
+
+\bibitem{Dirras2016}
+G.~Dirras, et~al., Microstructural investigation of plastically deformed
+  {Ti$_{20}$Zr$_{20}$Hf$_{20}$Nb$_{20}$Ta$_{20}$} high entropy alloy by {X}-ray
+  diffraction and transmission electron microscopy, Mater. Charact. 108 (2015)
+  1--7.
+\newblock \href {https://doi.org/10.1016/j.matchar.2015.08.007}
+  {\path{doi:10.1016/j.matchar.2015.08.007}}.
+
+\bibitem{Yao2016}
+H.~W. Yao, et~al., {NbTaV-(Ti,W)} refractory high-entropy alloys, Entropy 18
+  (2016) 189.
+\newblock \href {https://doi.org/10.3390/e18050189}
+  {\path{doi:10.3390/e18050189}}.
 
 \bibitem{Freudenberger2017}
 J.~Freudenberger, D.~Rafaja, D.~Geissler, L.~Giebeler, C.~L.~H. de~Oliveira,
@@ -160,6 +169,20 @@ J.~Freudenberger, D.~Rafaja, D.~Geissler, L.~Giebeler, C.~L.~H. de~Oliveira,
   lattice parameters for 5 quaternary + 1 quinary FCC alloys.
 \newblock \href {https://doi.org/10.3390/met7040135}
   {\path{doi:10.3390/met7040135}}.
+
+\bibitem{Wang2019}
+Z.~Wang, et~al., Atomic-size effect and solid solubility of multicomponent
+  alloys, Scr. Mater. 94 (2015) 28--31.
+\newblock \href {https://doi.org/10.1016/j.scriptamat.2014.09.010}
+  {\path{doi:10.1016/j.scriptamat.2014.09.010}}.
+
+\bibitem{Tseng2019}
+K.-K. Tseng, C.-C. Juan, S.~Tso, H.-C. Chen, C.-W. Tsai, J.-W. Yeh, Effects of
+  {Mo}, {Nb}, {Ta}, {Ti}, and {Zr} on mechanical properties of equiatomic
+  {Hf-Mo-Nb-Ta-Ti-Zr} alloys, Entropy 21 (2019) 15, table~2: HfMoNbTaTiZr and 5
+  equiatomic BCC subsets with XRD lattice parameters.
+\newblock \href {https://doi.org/10.3390/e21010015}
+  {\path{doi:10.3390/e21010015}}.
 
 \bibitem{Reget2020}
 F.~Reget, M.~Maa{\ss}, J.~Haas, J.~Fiehn, N.~Seifried, T.~G. Bley, L.~Pichl,
@@ -176,6 +199,12 @@ S.~Chen, Z.~H. Aitken, S.~Pattamatta, Z.~Wu, Z.~G. Yu, D.~J. Srolovitz, P.~K.
   117582.
 \newblock \href {https://doi.org/10.1016/j.actamat.2021.117582}
   {\path{doi:10.1016/j.actamat.2021.117582}}.
+
+\bibitem{Kantelis2025}
+K.~Kantelis, et~al., Lattice distortions in high-entropy alloys, AIP Adv. 15
+  (2025) 015030.
+\newblock \href {https://doi.org/10.1063/5.0245966}
+  {\path{doi:10.1063/5.0245966}}.
 
 \bibitem{Wang2004lattice}
 Y.~Wang, S.~Curtarolo, C.~Jiang, R.~Arroyave, T.~Wang, G.~Ceder, L.-Q. Chen,

--- a/paper/hea_lattice_prediction.tex
+++ b/paper/hea_lattice_prediction.tex
@@ -144,7 +144,7 @@ King以来の体積サイズファクター研究は実験値（King体積、実
 \node[box, fill=blue!10] (dft) {DFTデータ\\{\scriptsize B2/L1$_2$: 5,152件\\SQS: 860件}};
 \node[box, fill=green!10, right=of dft] (omega) {$\Omega_\text{sf}$導出\\{\scriptsize B2: 465\\L1$_2$: 441}};
 \node[box, fill=red!10, right=of omega] (pred) {格子定数予測\\{\scriptsize 式(\ref{eq:alonso})\\元素対モデル}};
-\node[box, fill=purple!10, right=of pred] (test) {独立検証\\{\scriptsize 31 HEA\\15文献}};
+\node[box, fill=purple!10, right=of pred] (test) {独立検証\\{\scriptsize 31 HEA\\14文献}};
 \node[box, fill=orange!10, below=0.6cm of pred] (add) {加法分解\\{\scriptsize $\delta_i^{(s)}$: 31元素\\式(\ref{eq:a_from_veff})}};
 \draw[arr] (dft) -- (omega);
 \draw[arr] (omega) -- (pred);
@@ -207,7 +207,7 @@ VASP（本研究） & 2,200 & 2,810 & 5,010 \\
 収束判定と物理的格子定数範囲（2.0--8.0~\AA）でのフィルタリング後、B2で465・L1$_2$で441のユニーク元素ペアを得た。同一ペアに複数データソースがある場合は中央値を採用し外れ値の影響を緩和した。3ソース間の$\Omega_\text{sf}$は高い整合性を示し（B2 $r = 0.990$、L1$_2$ $r = 0.990$）、統合前後の平均変化量は$|\Delta\Omega| < 0.006$であった。
 
 \subsubsection{HEA検証データ}
-主検証セットはAlonso~\cite{Alonso2021} Table~2の64個の立方晶HEA（BCC 29、FCC 35、$a = 2.883$--$3.856$~\AA、22元素）である。独立テストセットとしてAlonsoデータ外の31 HEA（BCC 17、FCC 14）を15文献~\cite{Senkov2013,Senkov2013_ActaMat,Yao2016,Otto2013,Leong2017,Tseng2019,Freudenberger2017,Reget2020,Chen2022,Chen2023}から収集した。20元素をカバーし、耐火金属系BCC（Tseng 2019、Reget 2020）、貴金属系FCC（Freudenberger 2017）、三元系BCC（Chen 2022: HfNbZr）、CALPHAD予測＋合成検証（Chen 2023: AlCoMnNiV, CoFeMnNiZn）を含む。ただしBCC 17合金はHf-Mo-Nb-Ta-Ti-Zrの系統的サブセットが主体であり、FCC 14合金もAu-Cu-Ni-Pd-Pt系とCoCrFeMnNi派生に偏る。実効的な化学多様性は合金数より限定的である点に留意が必要である。
+主検証セットはAlonso~\cite{Alonso2021} Table~2の64個の立方晶HEA（BCC 29、FCC 35、$a = 2.883$--$3.856$~\AA、22元素）である。独立テストセットとしてAlonsoデータ外の31 HEA（BCC 17、FCC 14）を14文献~\cite{Senkov2012,Senkov2013_ActaMat,Otto2013,Niu2017,Stepanov2015,Dirras2016,Yao2016,Freudenberger2017,Wang2019,Tseng2019,Reget2020,Chen2022,Kantelis2025,Chen2023}から収集した。20元素をカバーし、耐火金属系BCC（Tseng 2019、Reget 2020）、貴金属系FCC（Freudenberger 2017）、三元系BCC（Chen 2022: HfNbZr）、CALPHAD予測＋合成検証（Chen 2023: AlCoMnNiV, CoFeMnNiZn）を含む。ただしBCC 17合金はHf-Mo-Nb-Ta-Ti-Zrの系統的サブセットが主体であり、FCC 14合金もAu-Cu-Ni-Pd-Pt系とCoCrFeMnNi派生に偏る。実効的な化学多様性は合金数より限定的である点に留意が必要である。
 
 \subsection{体積サイズファクターのDFT導出}
 \label{sec:omega}
@@ -449,11 +449,11 @@ FCC HEAはRMSE = 0.0096~\AA{}と推定$\sigma$以下の精度を示す。構成�
 \subsection{独立テスト検証}
 \label{sec:indep_test}
 
-従来の20点テストセット（実質10種の合金組成、HfNbTaTiZr$\times$3重複）の組成多様性の制約を解消するため、15文献から31個のHEA（BCC 17、FCC 14）を新たに収集した（表~\ref{tab:indep_test}）。20元素をカバーし、Tseng (2019)の耐火金属系BCCバリアント（HfMoNbTaTiZrの系統的元素除去）、Reget (2020)のMo--Nb--V--W--Ti系BCC、Freudenberger (2017)の貴金属系FCC（Au-Cu-Ni-Pd-Pt四元・五元系）、Chen (2022)のHfNbZr三元系BCC、Chen~\cite{Chen2023}のCALPHAD予測に基づく合成検証（AlCoMnNiV, CoFeMnNiZn）を含む。
+従来の20点テストセット（実質10種の合金組成、HfNbTaTiZr$\times$3重複）の組成多様性の制約を解消するため、14文献から31個のHEA（BCC 17、FCC 14）を新たに収集した（表~\ref{tab:indep_test}）。20元素をカバーし、Tseng (2019)の耐火金属系BCCバリアント（HfMoNbTaTiZrの系統的元素除去）、Reget (2020)のMo--Nb--V--W--Ti系BCC、Freudenberger (2017)の貴金属系FCC（Au-Cu-Ni-Pd-Pt四元・五元系）、Chen (2022)のHfNbZr三元系BCC、Chen~\cite{Chen2023}のCALPHAD予測に基づく合成検証（AlCoMnNiV, CoFeMnNiZn）を含む。
 
 \begin{table}[H]
 \centering
-\caption{独立テスト31 HEA（BCC 17 + FCC 14）の予測精度（RMSE / \AA）。訓練と非重複の15文献20元素。}
+\caption{独立テスト31 HEA（BCC 17 + FCC 14）の予測精度（RMSE / \AA）。訓練と非重複の14文献20元素。}
 \label{tab:indep_test}
 \footnotesize
 \begin{tabular}{@{}lccc@{}}
@@ -476,7 +476,7 @@ DFT-$\Omega_\text{sf}$モデルが全カテゴリで最良である。全体RMSE
 \begin{figure*}[!t]
 \centering
 \includegraphics[width=\textwidth]{fig_indep_test.png}
-\caption{独立テストセット（31 HEA、15文献20元素）の予測性能。
+\caption{独立テストセット（31 HEA、14文献20元素）の予測性能。
   (a)~合金別絶対誤差。(b)~構造別RMSE（灰: Vegard、青: DFT-$\Omega_\text{sf}$）。
   (c)~パリティプロット（$q_\text{BCC} = 0.49$、$q_\text{FCC} = 0.13$）。
   BCC 17合金（青四角）とFCC 14合金（赤丸）。}

--- a/paper/references.bib
+++ b/paper/references.bib
@@ -556,3 +556,23 @@
   year    = {2023},
   doi     = {10.1038/s41467-023-38423-7},
 }
+
+@article{Senkov2012,
+  author  = {O. N. Senkov and J. M. Scott and S. V. Senkova and D. B. Miracle and C. F. Woodward},
+  title   = {Microstructure and room temperature properties of a high-entropy {TaNbHfZrTi} alloy},
+  journal = {J. Alloys Compd.},
+  volume  = {509},
+  pages   = {6043--6048},
+  year    = {2011},
+  doi     = {10.1016/j.jallcom.2011.02.171},
+}
+
+@article{Niu2017,
+  author  = {C. Niu and A. J. Zaddach and A. A. Oni and X. Sang and J. W. Hurt III and J. M. LeBeau and C. C. Koch and D. L. Irving},
+  title   = {Spin-driven ordering of {Cr} in the equiatomic high entropy alloy {NiFeCrCo}},
+  journal = {Appl. Phys. Lett.},
+  volume  = {106},
+  pages   = {161906},
+  year    = {2015},
+  doi     = {10.1063/1.4918996},
+}


### PR DESCRIPTION
## Summary

`generate_all_figures.py`を再実行し全図表・`paper_metrics.json`を再生成後、LaTeX本文の全数値・図キャプション・引用を機械的に検証。

**修正:**
- `15文献` → `14文献`（5箇所）: CSV `ref`列の実出典数に統一
- `\cite{}`リストをCSV実出典14件に差し替え:
  - 削除: `Senkov2013`（データなし）, `Leong2017`（データなし）
  - 追加: `Senkov2012`, `Niu2017`, `Stepanov2015`, `Dirras2016`, `Wang2019`, `Kantelis2025`
- `references.bib`に`Senkov2012`, `Niu2017`の書誌追加
- `bibtex`再実行で`.bbl`再生成 → 未定義引用ゼロ

**検証結果（`verify_all.py`）:**
- 223チェックOK、エラー0、警告9件（全て許容: per-source件数は本文未使用、孤立図4件は.gitignore済み）
- 全39引用キーがbibに存在、全53 `\ref`に対応`\label`あり

Link to Devin session: https://app.devin.ai/sessions/3fd8fc4791c84687a3daf026214784b6
Requested by: @minimumtone