### PR TITLE
docs: 純元素原子体積の出典明確化 + King/Alonso検証スクリプト修正（PR#442 Review対応）

### DIFF
--- a/hea_lattice_xgboost.py
+++ b/hea_lattice_xgboost.py
@@ -144,7 +144,10 @@ ATOMIC_MASS = {
     "Th":232.04,"U":238.03,"Pu":244.06,"Np":237.05,
 }
 
-# King1966 pure-element atomic volumes (Å³)
+# Pure-element atomic volumes (Å³) from room-temperature lattice constants
+# (a³/n_auc; hcp: √3·a²·c/4). Agree with King 1966 Table III within ±0.1%
+# for most elements; Co/Hf/Sn/Sc/Tb use modern crystallographic values
+# (King's entries for these are based on older measurements, up to 6% off).
 KING_ATOMIC_VOLUMES = {
     "Al":16.602,"Cu":11.810,"Ni":10.941,"Pd":14.716,"Pt":15.095,
     "Au":16.966,"Ag":17.061,"Ir":14.155,"Rh":13.754,

--- a/paper/hea_lattice_prediction.tex
+++ b/paper/hea_lattice_prediction.tex
@@ -218,7 +218,7 @@ VASP（本研究） & 1,483 & 2,808 & 4,291 \\
   \frac{V_\text{DFT} - V_\text{Vegard}}{V_\text{Vegard}},
   \label{eq:omega_def}
 \end{equation}
-ここで$V_\text{DFT} = a_\text{DFT}^3 / n_\text{auc}$、$V_\text{Vegard} = \sum_i x_i V_i$はKing原子体積~\cite{King1966}を使用する。B2とL1$_2$の構造特異性を保持し独立に扱う：
+ここで$V_\text{DFT} = a_\text{DFT}^3 / n_\text{auc}$、$V_\text{Vegard} = \sum_i x_i V_i$はKing原子体積~\cite{King1966}を使用する\footnote{本研究の「King原子体積」は室温格子定数から$V_i = a^3/n_\text{auc}$（hcpは$V_i = \sqrt{3}a^2c/4$）で算出した値であり、King (1966) Table~IIIと大半の元素で$\pm 0.1$\%以内で一致する。ただしCo（$+0.5$\%）、Hf（$-0.7$\%）、Sn（$+2.2$\%）、Sc（$-6.3$\%）、Tb（$-3.0$\%）はKing表の値が古い測定に基づくとみられ、本研究では現代の結晶学データ由来の値を採用している。}。B2とL1$_2$の構造特異性を保持し独立に扱う：
 \begin{align}
   \Omega_\text{sf}^\text{B2}(A\text{-}B) &= \text{median}\left\{
     \Omega_\text{sf} \mid \text{B2} \right\}, \label{eq:omega_b2} \\

--- a/paper/verify_king_alonso_model.py
+++ b/paper/verify_king_alonso_model.py
@@ -8,8 +8,10 @@ item B1 / verification item 7) using digitized experimental data:
   data/alonso_table3_volume_size_factors.csv (Alonso 2022 Table 3 supplement)
 
 Duplicate directional (solvent, solute) entries in King Table II (different
-Cmax concentration ranges) are averaged. Alonso Table 3 values are used only
-for pairs absent from King Table II.
+Cmax concentration ranges) are averaged. Rows whose lsf is inconsistent with
+Dsf (|lsf - ((1+Dsf)^(1/3)-1)| > 0.5%) are excluded as suspected digitization
+errors. Alonso Table 3 values supplement directional pairs absent from King
+Table II (both directions kept).
 
 Model: Alonso Eq.10 with directional experimental Omega_sf,j/i = Dsf/100
 (solute j in solvent i); missing pairs fall back to the reversed direction,
@@ -93,6 +95,9 @@ def main():
             print(f"  {r.Solvent}-{r.Solute}: Dsf={r.Dsf_percent} "
                   f"lsf={r.lsf_percent} (expected "
                   f"{lsf_pred[r.Index]:.2f})")
+        print("  -> these rows are EXCLUDED from the model "
+              "(pending re-check against the original table)")
+        t2 = t2.drop(bad.index)
         print()
 
     # average duplicate directional entries (different Cmax ranges)
@@ -113,7 +118,7 @@ def main():
     n_added = 0
     for r in ta.itertuples():
         key = (r.Solvent, r.Solute)
-        if key not in omega_dir and key[::-1] not in omega_dir:
+        if key not in omega_dir:
             omega_dir[key] = r.Omega_f_percent / 100.0
             n_added += 1
     print(f"King Table II: {len(t2)} rows, {n_king} directional pairs; "

--- a/paper/verify_king_alonso_model_report.txt
+++ b/paper/verify_king_alonso_model_report.txt
@@ -21,27 +21,27 @@ WARNING: 17 rows with lsf inconsistent with Dsf (possible digitization errors):
   Tc-Ir: Dsf=-2.43 lsf=-2.19 (expected -0.82)
   Th-Zr: Dsf=-7.68 lsf=-10.25 (expected -2.63)
   Ti-Mn: Dsf=51.17 lsf=-21.25 (expected 14.77)
+  -> these rows are EXCLUDED from the model (pending re-check against the original table)
 
 Duplicate (solvent, solute) entries averaged:
   Co-Mn: [+7.33, +4.89] -> +6.11
   Cr-Ni: [+4.65, -4.80] -> -0.07
   Mg-Mn: [-17.43, +23.20] -> +2.88
   Mn-Cr: [-4.78, -17.87] -> -11.33
-  Pd-Pt: [+15.35, +1.52] -> +8.44
   Pd-Ru: [-9.02, -8.27] -> -8.64
   Pt-Re: [+7.29, +2.02] -> +4.66
   Pt-Rh: [-0.37, -8.86] -> -4.61
 
-King Table II: 462 rows, 454 directional pairs; Alonso Table 3: 75 rows, 31 new pairs added; total 485 directional, 381 unique pairs
-HEA-required pairs: 99, covered: 96 (97%)
-missing: [('Al', 'Zr'), ('Mn', 'V'), ('V', 'Zr')]
+King Table II: 445 rows, 438 directional pairs; Alonso Table 3: 75 rows, 70 new pairs added; total 508 directional, 373 unique pairs
+HEA-required pairs: 99, covered: 95 (96%)
+missing: [('Al', 'Zr'), ('Mn', 'V'), ('Ni', 'Zn'), ('V', 'Zr')]
 
-calibrated q_BCC=+0.016, q_FCC=-0.004
+calibrated q_BCC=-0.036, q_FCC=+0.022
 
   model                           all(31)  BCC(17)  FCC(14)
   Vegard (King volumes)            0.0202   0.0226   0.0170
-  Alonso-King+T3 Omega_sf, q=1     0.0553   0.0424   0.0677
-  Alonso-King+T3, q calib          0.0203   0.0226   0.0171
+  Alonso-King+T3 Omega_sf, q=1     0.0513   0.0385   0.0635
+  Alonso-King+T3, q calib          0.0197   0.0223   0.0160
 
 Table III atomic volumes vs KING_ATOMIC_VOLUMES in code:
   Co : code  11.073  TableIII  11.130 (+0.5%)


### PR DESCRIPTION
## Summary

- **原子体積の出典明確化**（ユーザー確認済み方針）: コードの `KING_ATOMIC_VOLUMES` は室温格子定数から a³/n_auc（hcp: √3a²c/4）で算出した値であり、King 1966 Table IIIと大半±0.1%一致するが、Co/Hf/Sn/Sc/Tb はKing表が古い測定に基づくため現代結晶学値を採用している。この旨をコードコメントとLaTeX脚注（式 eq:omega_def 直後）に明記。**数値パイプラインは一切変更なし**
- **PR #442 Review指摘の修正**（`paper/verify_king_alonso_model.py`）:
  - Alonso Table 3補完時の `key[::-1]` チェックを削除し両方向を保持（追加ペア31→70。例: (Ta,Fe)=−38.9% / (Fe,Ta)=+38.06% を両方使用）
  - lsf vs Dsf 不整合17行（Nb-W Dsf=−98.22等）をデジタル化エラーの疑いとしてモデルから除外（原表照合までの暫定措置）

## 結果（結論は不変）

| モデル | 全31 | BCC17 | FCC14 |
|---|---|---|---|
| Vegard | 0.0202 | 0.0226 | 0.0170 |
| Alonso-King+T3, q=1 | 0.0513 | 0.0385 | 0.0635 |
| 同・q校正 | 0.0197 | 0.0223 | 0.0160（q_BCC=−0.036 → Vegard縮退） |


Link to Devin session: https://app.devin.ai/sessions/3fd8fc4791c84687a3daf026214784b6
Requested by: @minimumtone