### PR TITLE
fix: 相分類の4f希土類除外漏れ + phase map VEC正規化（codexデバッグ検出）

### DIFF
--- a/paper/generate_all_figures.py
+++ b/paper/generate_all_figures.py
@@ -74,6 +74,12 @@ EXCLUDE_ELEMENTS = {
     "Y",  # similar RE behavior
 }
 
+# Phase-classification DB with the same element exclusion as all other analyses
+# (entries containing 4f RE / Y would otherwise contribute artificially small
+#  delta_sf because their Omega_sf pairs are absent from the compound data).
+HEA_PHASE_DB = [h for h in MULTIPHASE_HEA_DB
+               if not set(h["comp"]) & EXCLUDE_ELEMENTS]
+
 
 # ---------------------------------------------------------------------------
 # Helper: lattice constant → atomic volume conversion
@@ -2365,7 +2371,8 @@ def fig16_phase_map(heas_mp, ob2, ol12):
         comp = h["comp"]
         phase = h.get("phase", "SS")
         dr = compute_delta_r(comp)
-        vec = sum(c * VEC.get(e, 5) for e, c in comp.items())
+        ctot = sum(comp.values())
+        vec = sum(c * VEC.get(e, 5) for e, c in comp.items()) / ctot
         if phase == "SS":
             dr_ss.append(dr)
             vec_ss.append(vec)
@@ -2559,8 +2566,8 @@ def main():
     fig12_hea_additive(y_train, a_add_tr, ALONSO_TABLE2, y_test, a_add_te, INDEPENDENT_TEST)
     fig13_composition_reff(decomp, gb_add, gf_add)
     fig14_vegard_absorbed(all_df, radii)
-    fig15_roc(MULTIPHASE_HEA_DB, ob2, ol12)
-    fig16_phase_map(MULTIPHASE_HEA_DB, ob2, ol12)
+    fig15_roc(HEA_PHASE_DB, ob2, ol12)
+    fig16_phase_map(HEA_PHASE_DB, ob2, ol12)
 
     # 9. Save data
     print("\n[8] Saving data files...")
@@ -2938,7 +2945,7 @@ def main():
     # Aligned with fig15_roc labeling and standard HEA literature.
     from sklearn.metrics import roc_auc_score, f1_score
     dr_vals, dsf_vals, labels = [], [], []
-    for h in MULTIPHASE_HEA_DB:
+    for h in HEA_PHASE_DB:
         dr = compute_delta_r(h["comp"])
         dsf = compute_delta_sf(h["comp"], ob2)
         if np.isnan(dr) or np.isnan(dsf):
@@ -3234,7 +3241,7 @@ def main():
             "additive_mode_A_RMSE_test": round(float(rmse_addA_te), 4),
         },
         "phase_classification": {
-            "n_HEA": int(len(MULTIPHASE_HEA_DB)),
+            "n_HEA": int(len(HEA_PHASE_DB)),
             "AUC_delta_r": round(float(auc_dr), 3),
             "AUC_delta_sf": round(float(auc_dsf), 3),
             "accuracy_delta_r": round(float(np.mean(

--- a/paper/paper_metrics.json
+++ b/paper/paper_metrics.json
@@ -74,13 +74,13 @@
     "additive_mode_A_RMSE_test": 0.0175
   },
   "phase_classification": {
-    "n_HEA": 54,
-    "AUC_delta_r": 0.869,
-    "AUC_delta_sf": 0.71,
-    "accuracy_delta_r": 0.815,
-    "accuracy_delta_sf": 0.722,
-    "F1_delta_r": 0.833,
-    "F1_delta_sf": 0.795,
+    "n_HEA": 53,
+    "AUC_delta_r": 0.864,
+    "AUC_delta_sf": 0.717,
+    "accuracy_delta_r": 0.811,
+    "accuracy_delta_sf": 0.717,
+    "F1_delta_r": 0.828,
+    "F1_delta_sf": 0.789,
     "threshold_delta_r_pct": 4.73,
     "threshold_delta_sf": 0.0179,
     "convention": "non-SS (IM+AM) = positive class"


### PR DESCRIPTION
## Summary
openai-codexによるパイプラインデバッグで検出されたバグ2件を修正します。

1. **相分類への4f希土類混入**: ファイル冒頭で「4f希土類とYは全解析から除外」と宣言している一方、`fig15_roc()` / `fig16_phase_map()` / JSONの分類指標計算は `MULTIPHASE_HEA_DB` を無フィルタで使用していました。Er/Tb/Dyを含む `Guo2011_AM4` は、Ω_sfペアの大半が除外済みB2辞書に存在せず `compute_delta_sf` が欠損ペアを0扱いするため、人工的に小さいδ_sfを持つ正例としてAUC/F1に混入していました。`EXCLUDE_ELEMENTS` を適用した `HEA_PHASE_DB`（53件）に統一しました。
2. **phase mapのVEC非正規化**: `fig16_phase_map()` のVECが組成和で割られておらず、組成和≠1の4レコード（Shun2012_Mo05/Mo085, He2014_Nb05/Nb10）でVECが17〜18%過小にプロットされていました。`/ ctot` で正規化しました。

`paper_metrics.json` の変化は `phase_classification` ブロックのみ（AUC_δr 0.869→0.864、AUC_δsf 0.710→0.717、n_HEA 54→53 等）。本文texはPR #406で相安定性の議論を削除済みのためこれらの値を参照しておらず、tex変更は不要です。主結果（RMSE・q値）は不変であることをパイプライン全再実行で確認済みです。

codexが報告したその他の指摘（独立テスト組成重複、SQS統計の再現不能性など）は既知事項または設計判断を要するため本PRには含めず、別途報告します。

Link to Devin session: https://app.devin.ai/sessions/3fd8fc4791c84687a3daf026214784b6
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->