### PR TITLE
feat: MI-HUB2 pinax2.0-pilot 状態駆動研究エージェント環境（mi_hub2）

### DIFF
--- a/mi_hub2/README.md
+++ b/mi_hub2/README.md
@@ -1,0 +1,116 @@
+# mi_hub2 — MI 統合環境(runcell / OptiMat / MLflow / Feast / AutoML) + 研究エージェント
+
+「Jupyter(runcell)を操縦席、MLflow を記録層、parquet + provenance を連携層」とする
+疎結合アーキテクチャの実装一式。全モジュールはコンテナ内でエンドツーエンド検証済み
+(TC-Python 実接続部と OptiMat 実イメージ部を除く)。
+
+```
+[知識]   既存 GraphRAG + ExtractBib(ローカル。Bohrium は設計参考のみ)
+[操縦席] JupyterLab + runcell 0.2.0 + pygwalker 0.5.0.1
+   ├→ [計算]   OptiMat Alloys(Docker) → optimat_bridge で living DB を吸い上げ
+   ├→ [計算]   TC-Python パイプライン  → notebooks/02 の定型 8 行で記録
+   ├→ [記録]   MLflow(sqlite)         → tracking.track() / mi_hub.run_id タグ
+   ├→ [特徴量] Feast(registry+offline のみの最小構成)
+   ├→ [AutoML] FLAML                    → automl.fit_baseline()
+   └→ [事例]   case_template(1 事例 = 1 ディレクトリ規約。実行者非依存)
+[研究エージェント] mi_hub.agent(状態駆動の仮説・反証検証ループ + Human-in-the-loop)
+```
+
+## 構成
+
+| パス | 内容 | フェーズ |
+|---|---|---|
+| `setup/phase1_setup.sh` | conda 環境 + runcell/pygwalker/MLflow/mi_hub 一括導入 | 1 |
+| `src/mi_hub/datastore.py` | parquet + provenance(run_id/created_at/source/code_ver)共通層 | 1 |
+| `src/mi_hub/tracking.py` | MLflow ヘルパー(track/log_table/log_metrics/runs) | 1 |
+| `notebooks/02_ternary_ingest_demo.py` | TC-Python 三元断面 → 記録の定型(ドライラン可) | 1 |
+| `setup/phase2_optimat/` | OptiMat の docker-compose + living DB マウント手順 | 2 |
+| `src/mi_hub/optimat_bridge.py` | living DB(SQLite/JSON)スナップショット取得 | 2 |
+| `case_template/` | 事例テンプレート(README/run.py/env.yml。runcell/手動どちらでも実行可) | 3 |
+| `feast_repo/` | Feast 最小構成(hea_features の FeatureView 例) | 4 |
+| `src/mi_hub/automl.py` | FLAML ベースライン + MLflow 一元記録 | 4 |
+| `notebooks/01_eda_and_automl_demo.py` | pygwalker EDA + FLAML デモ | 1/4 |
+| `src/mi_hub/agent/` | 状態駆動研究エージェント(下記参照) | 5 |
+| `tests/` | 受入試験(指示書 §19 準拠) | 5 |
+
+## 研究エージェント(Phase 5, 指示書「研究エージェント機能追加改訂版」準拠)
+
+Devin/OpenHands 型の状態駆動実行ループを Human-in-the-loop 制御下で実装:
+
+```
+Goal → Observe → Plan → Human Check → Act → Observe Result → Evaluate → Replan
+```
+
+| モジュール | 内容 | 指示書 |
+|---|---|---|
+| `agent/states.py` | エージェント/タスク/仮説/エラー状態 | §6, §9.1 |
+| `agent/models.py` | Goal/Plan/Task/Hypothesis/Budget/StopConditions 等 | §4, §8, §15 |
+| `agent/roles.py` | Evidence/Hypothesis/ModelSelection/VerificationPlanning/Execution/Evaluation/SafetyApproval の論理エージェント | §5 |
+| `agent/loop.py` | Research Manager(実行ループ・計画版管理・停止条件・HITL・永続化) | §4, §5.1, §8, §12 |
+| `agent/errors.py` | エラー分類・自動修正(単位変換等)・再試行上限 | §9 |
+| `agent/tools.py` | t2X/MCP ゲートウェイのモック(MInt レジストリ・文献検索・推論) | §3 |
+| `agent/llm.py` | LLM 補助(構造化・仮説候補・要約のみ。判定には不使用) | §16 |
+| `agent/api.py` | FastAPI 研究エージェント API | §14 |
+| `agent/ui_streamlit.py` | チャット UI + Agent 状態ペイン | §13 |
+
+### 起動
+
+```bash
+pip install -e ".[agent]"            # または: pip install pydantic fastapi uvicorn streamlit
+PYTHONPATH=src streamlit run src/mi_hub/agent/ui_streamlit.py   # チャットUI
+PYTHONPATH=src uvicorn mi_hub.agent.api:app --port 8800          # REST API
+PYTHONPATH=src python -m pytest tests/ -q                        # 受入試験
+```
+
+- セッション状態は `$MI_HUB_DATA/agent_sessions/*.json` に永続化され、再開可能。
+- `OPENAI_API_KEY` 設定時は目標構造化・仮説候補生成に LLM を使用(未設定時は決定論的フォールバック)。
+- 高コスト操作(モデル一括実行・DFT 提案等)は承認されるまで実行されない(§11)。
+- 反証条件の変更・仮説の正式採用/反証は人間のみが行える(§5.8, §10)。
+- MVP 制限: 自動反復 5 回・モデル実行 30 件・DFT/実験は提案のみ(§18)。
+- 実 MInt/GraphRAG 接続時は `agent/tools.py` の `ToolGateway` を同一インターフェイスで差し替える。
+
+## クイックスタート(Phase 1)
+
+```bash
+bash setup/phase1_setup.sh hub
+export MI_HUB_DATA=$HOME/mi_hub_data
+export MI_HUB_MLFLOW=sqlite:///$HOME/mi_hub_data/mlflow.db
+conda activate hub
+python notebooks/02_ternary_ingest_demo.py     # 記録層の動作確認
+mlflow ui --backend-store-uri $MI_HUB_MLFLOW -p 5000
+jupyter lab                                     # runcell から自然言語で操作
+```
+
+既存 TC-Python パイプラインへの組み込みは `notebooks/02` の
+「計算 → 記録」8 行を計算ループの外側に被せるだけ。
+
+## 全パイプライン共通の定型
+
+```python
+from mi_hub import datastore as ds, tracking as tr
+
+rid = ds.new_run_id()
+with tr.track("<experiment>", run_id=rid, params={...}):
+    df = <計算本体>
+    ds.save(df, "<kind>", run_id=rid, source="<tc_python|optimat|dft|...>")
+    tr.log_table(df)
+    tr.log_metrics({...})
+```
+
+## 既知の注意点
+
+- **runcell のデータガバナンス**: クラウド LLM 前提のため、未公開データを
+  ノートブックに載せる前に外部送信範囲とローカルエンドポイント設定可否を確認。
+- **FLAML × MLflow**: FLAML 2.3+ の自動ロギングは skops 直列化で失敗するため
+  `mlflow_logging=False` で無効化済み(記録は mi_hub 側で一元化)。
+- **OptiMat**: イメージ名・コンテナ内 DB パスは配布元の最新 README に合わせて
+  `setup/phase2_optimat/docker-compose.yml` を書き換えること。
+- **Feast**: 依存が重いので Phase 1 環境と分けるか、導入時に pin を確認。
+
+## 検証済み事項(2026-07-06, Python 3.12 / mlflow 3.14 / flaml 2.x)
+
+- datastore 保存・結合ロード・catalog
+- tracking(sqlite バックエンド、artifact、mi_hub.run_id タグ)
+- 三元断面デモのドライラン一式
+- FLAML 回帰ベースライン → モデル/予測/指標の MLflow 記録
+- case_template の run.py スケルトン実行

--- a/mi_hub2/case_template/README.md
+++ b/mi_hub2/case_template/README.md
@@ -1,0 +1,24 @@
+# 解析事例: <事例名>
+
+<!-- 事例管理テンプレート。1 事例 = 1 ディレクトリ(or リポジトリ)。実行者(人間/runcell/任意エージェント)非依存。 -->
+
+## 目的
+(1〜3 行。何を知るための解析か)
+
+## 結論
+(完了後に必ず記入。図表は MLflow artifact を参照)
+
+## 再現
+```bash
+conda env create -f environment.yml -n case_<name>
+conda run -n case_<name> python run.py
+```
+
+## 関連
+- MLflow experiment: `<experiment名>` / mi_hub.run_id: `<uuid>`
+- 入力データ kind: `<datastore kind>`
+- 先行事例: `../<case>/`
+
+## エージェント(runcell 等)への典型指示
+- 「この事例を再実行し、MLflow の run_id を README の関連欄に追記せよ」
+- 「事例 <X> の手法を本事例のデータに適用し、差分を報告せよ」

--- a/mi_hub2/case_template/environment.yml
+++ b/mi_hub2/case_template/environment.yml
@@ -1,0 +1,7 @@
+name: case_template
+channels: [conda-forge]
+dependencies:
+  - python=3.11
+  - pip
+  - pip:
+      - -e ../..          # mi_hub(パスは配置に応じ調整)

--- a/mi_hub2/case_template/run.py
+++ b/mi_hub2/case_template/run.py
@@ -1,0 +1,25 @@
+"""事例実行の定型スケルトン。全事例がこの形に従うとエージェント・人間双方が扱いやすい。"""
+import argparse
+
+from mi_hub import datastore as ds, tracking as tr
+
+CASE_NAME = "case_template"          # 事例名(= experiment 名)
+
+
+def main(dry_run: bool = False):
+    rid = ds.new_run_id()
+    with tr.track(CASE_NAME, run_id=rid, params={"dry_run": dry_run}):
+        # --- ここに解析本体 ---
+        import pandas as pd
+        df = pd.DataFrame({"x": [1, 2, 3]})
+        # ----------------------
+        ds.save(df, CASE_NAME, run_id=rid, source="case", code_ver="v0")
+        tr.log_table(df)
+        tr.log_metrics({"n_rows": len(df)})
+    print(f"done. mi_hub.run_id={rid}")
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--dry-run", action="store_true")
+    main(**vars(p.parse_args()))

--- a/mi_hub2/feast_repo/feature_store.yaml
+++ b/mi_hub2/feast_repo/feature_store.yaml
@@ -1,0 +1,7 @@
+# Phase 4: Feast 最小構成(registry + offline store のみ、オンラインサービング無し)
+project: mi_hub
+registry: data/registry.db
+provider: local
+offline_store:
+  type: file
+entity_key_serialization_version: 3

--- a/mi_hub2/feast_repo/features.py
+++ b/mi_hub2/feast_repo/features.py
@@ -1,0 +1,40 @@
+"""Feast feature 定義(Phase 4)。
+
+前提: datastore の "hea_features" を 1 ファイルに統合した parquet を
+feast_repo/data/hea_features.parquet に置く(下のスクリプト参照)。
+Feast の FileSource は event_timestamp 列を要求するため、
+provenance の created_at をそのまま流用する。
+
+準備:
+    python -c "
+    from mi_hub import datastore as ds
+    import pandas as pd
+    df = ds.load('hea_features')
+    df['created_at'] = pd.to_datetime(df['created_at'])
+    df.to_parquet('feast_repo/data/hea_features.parquet', index=False)"
+    cd feast_repo && feast apply
+"""
+from datetime import timedelta
+
+from feast import Entity, FeatureView, Field, FileSource
+from feast.types import Float64
+
+alloy = Entity(name="alloy_id", join_keys=["alloy_id"])
+
+hea_source = FileSource(
+    path="data/hea_features.parquet",
+    timestamp_field="created_at",
+)
+
+hea_features = FeatureView(
+    name="hea_features",
+    entities=[alloy],
+    ttl=timedelta(days=3650),
+    schema=[
+        Field(name="vec", dtype=Float64),
+        Field(name="delta_r", dtype=Float64),
+        Field(name="dH_mix", dtype=Float64),
+        Field(name="omega_sf_mean", dtype=Float64),
+    ],
+    source=hea_source,
+)

--- a/mi_hub2/notebooks/01_eda_and_automl_demo.py
+++ b/mi_hub2/notebooks/01_eda_and_automl_demo.py
@@ -1,0 +1,43 @@
+# %% [markdown]
+# # EDA(pygwalker) + AutoML(FLAML) デモ
+# datastore に溜めた特徴量テーブルを可視化し、ベースラインモデルを自動構築、
+# 結果は MLflow に自動記録される。
+# runcell への依頼例: 「hea_features を読み込んで yield_strength の
+# ベースラインを FLAML で作り、MLflow の run URL を教えて」
+
+# %% 合成 HEA 特徴量(実運用では MAGPIE/Ωsf テーブルを ds.save しておく)
+import numpy as np
+import pandas as pd
+from mi_hub import datastore as ds
+
+rng = np.random.default_rng(1)
+n = 300
+feat = pd.DataFrame({
+    "alloy_id": [f"HEA{i:04d}" for i in range(n)],
+    "vec": rng.uniform(4.5, 8.5, n),           # 価電子濃度
+    "delta_r": rng.uniform(0.01, 0.08, n),     # 原子半径ミスマッチ
+    "dH_mix": rng.uniform(-20, 5, n),
+    "omega_sf_mean": rng.uniform(-5, 15, n),   # Ωsf 平均(ダミー)
+})
+feat["yield_strength"] = (
+    900 - 60 * feat["vec"] + 4000 * feat["delta_r"]
+    - 8 * feat["dH_mix"] + 6 * feat["omega_sf_mean"]
+    + rng.normal(0, 40, n))
+ds.save(feat, "hea_features", source="manual", code_ver="demo")
+
+# %% pygwalker(Phase 1 環境で)
+# import pygwalker as pyg
+# pyg.walk(ds.load("hea_features"))
+
+# %% FLAML ベースライン(pip install 'flaml[automl]' 後)
+from mi_hub import automl
+res = automl.fit_baseline(
+    ds.load("hea_features"), target="yield_strength",
+    task="regression", time_budget=30,
+    drop=ds.PROVENANCE_COLS + ["alloy_id"])
+print(res["best_estimator"], res["holdout_metrics"])
+
+# %% MLflow の run 一覧を DataFrame で(pygwalker に渡せる)
+from mi_hub import tracking as tr
+print(tr.runs("automl")[["run_id", "metrics.mae", "metrics.r2",
+                         "params.best_estimator"]].head())

--- a/mi_hub2/notebooks/02_ternary_ingest_demo.py
+++ b/mi_hub2/notebooks/02_ternary_ingest_demo.py
@@ -1,0 +1,54 @@
+# %% [markdown]
+# # TC-Python 三元系等温断面 → mi_hub 流し込みデモ
+# 既存の三元断面パイプラインの出力(組成グリッド + 相分類)を
+# datastore + MLflow に記録する最小例。
+# tc_python が無い環境でも動くよう、合成データのドライランを既定とする。
+# 実運用では `compute_section()` を実パイプライン呼び出しに差し替えるだけ。
+
+# %%
+import numpy as np
+import pandas as pd
+from mi_hub import datastore as ds, tracking as tr
+
+SYSTEM = ("Al", "Co", "Cr")
+T_K = 1273
+DATABASE = "TCHEA7"
+
+
+def compute_section(system, T, database) -> pd.DataFrame:
+    """実運用ではここを TC-Python 呼び出しに置換。
+    返り値の規約: x_<el1>, x_<el2>, x_<el3>, phase_label, n_phases
+    """
+    rng = np.random.default_rng(0)
+    n = 500
+    a = rng.dirichlet(np.ones(3), size=n)
+    labels = np.where(a[:, 0] > 0.5, "BCC_B2",
+              np.where(a[:, 1] > 0.5, "FCC_L12", "FCC_A1+BCC_A2"))
+    return pd.DataFrame({
+        f"x_{system[0]}": a[:, 0],
+        f"x_{system[1]}": a[:, 1],
+        f"x_{system[2]}": a[:, 2],
+        "phase_label": labels,
+        "n_phases": np.char.count(labels.astype(str), "+") + 1,
+    })
+
+
+# %% 計算 → 記録(この 8 行が全パイプライン共通の定型)
+rid = ds.new_run_id()
+with tr.track("ternary_sections", run_id=rid,
+              params={"system": "-".join(SYSTEM), "T_K": T_K,
+                      "database": DATABASE}):
+    df = compute_section(SYSTEM, T_K, DATABASE)
+    ds.save(df, "ternary_sections", run_id=rid, source="tc_python",
+            code_ver="demo")
+    tr.log_table(df, "section.parquet")
+    tr.log_metrics({"n_points": len(df),
+                    "n_unique_phases": df["phase_label"].nunique()})
+print("run_id:", rid)
+
+# %% 在庫確認
+print(ds.catalog())
+
+# %% pygwalker で探索(Phase 1 環境で実行)
+# import pygwalker as pyg
+# pyg.walk(ds.load("ternary_sections"))

--- a/mi_hub2/pyproject.toml
+++ b/mi_hub2/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mi-hub"
+version = "0.2.0"
+description = "Integrated MI environment glue: datastore(parquet) + MLflow + OptiMat bridge + FLAML + research agent"
+requires-python = ">=3.10"
+dependencies = ["pandas>=2.0", "pyarrow>=14", "mlflow>=2.14"]
+
+[project.optional-dependencies]
+hub = ["jupyterlab>=4.4", "runcell==0.2.0", "pygwalker==0.5.0.1"]
+automl = ["flaml[automl]>=2.1", "scikit-learn>=1.3"]
+feast = ["feast>=0.40"]
+agent = ["pydantic>=2", "fastapi>=0.110", "uvicorn>=0.29", "streamlit>=1.35"]
+agent-llm = ["openai>=1.30"]
+dev = ["pytest>=8", "httpx>=0.27"]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/mi_hub2/setup/phase1_setup.sh
+++ b/mi_hub2/setup/phase1_setup.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Phase 1: 操縦席(JupyterLab + runcell + pygwalker) + 記録層(MLflow) + mi_hub
+set -euo pipefail
+
+ENV_NAME="${1:-hub}"
+conda create -y -n "$ENV_NAME" python=3.11
+conda run -n "$ENV_NAME" pip install \
+    "jupyterlab>=4.4" runcell==0.2.0 pygwalker==0.5.0.1 \
+    "mlflow>=2.14" "pandas>=2.0" "pyarrow>=14" scikit-learn
+conda run -n "$ENV_NAME" pip install -e "$(dirname "$0")/.."   # mi_hub 本体
+
+echo
+echo "~/.bashrc に追記推奨:"
+echo "  export MI_HUB_DATA=\$HOME/mi_hub_data"
+echo "  export MI_HUB_MLFLOW=sqlite:///\$HOME/mi_hub_data/mlflow.db"
+echo
+echo "起動:"
+echo "  conda activate $ENV_NAME && jupyter lab                # runcell 拡張が現れる"
+echo "  mlflow ui --backend-store-uri \$MI_HUB_MLFLOW -p 5000  # 別ターミナル"

--- a/mi_hub2/setup/phase2_optimat/README.md
+++ b/mi_hub2/setup/phase2_optimat/README.md
@@ -1,0 +1,26 @@
+# Phase 2: OptiMat Alloys 導入メモ
+
+1. `.env` に `OPENROUTER_API_KEY=...`(無料枠可)を記載。
+2. `docker compose up -d` → `http://<GPUサーバ>:8000` で Chainlit UI。
+3. コンテナ内 DB パス(`/app/database` は仮)は配布イメージのドキュメントで確認。
+   `docker exec -it <ctr> find / -name "*.db" 2>/dev/null` 等で実パスを特定し、
+   `volumes:` の右側を合わせる。
+4. Jupyter(Phase 1 環境)側:
+
+   ```bash
+   export MI_HUB_OPTIMAT_DB=/data/optimat_db
+   ```
+
+   ```python
+   from mi_hub import optimat_bridge as ob, datastore as ds
+   snap = ob.snapshot()                     # {name: DataFrame}
+   for name, df in snap.items():
+       ds.save(df, f"optimat_{name}", source="optimat")
+   ```
+
+   以後、他の kind と同様に pygwalker / FLAML / Feast から参照できる。
+
+運用の分業:
+- 4元系以上・CALPHAD 未整備領域の当たり付け → OptiMat(U-MLIP)
+- 有望組成の精査(相平衡・等温断面) → TC-Python(既存三元系パイプライン)
+- 両者の結果は同じ datastore + MLflow に集約

--- a/mi_hub2/setup/phase2_optimat/docker-compose.yml
+++ b/mi_hub2/setup/phase2_optimat/docker-compose.yml
@@ -1,0 +1,15 @@
+# Phase 2: OptiMat Alloys(GPU サーバ推奨)
+# イメージ名・コンテナ内 DB パスは配布元(optimat.chat / 論文付随リポジトリ)の
+# 最新 README に合わせて差し替えること。要点は living DB のホスト側マウントのみ。
+services:
+  optimat:
+    image: OPTIMAT_ALLOYS_IMAGE   # ← 配布イメージ名に置換
+    ports:
+      - "8000:8000"               # Chainlit UI
+    environment:
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:?set in .env}
+      # 完全ローカル運用時は Ollama 設定に切替(A100/H100 級がないと
+      # tool-calling 信頼性が落ちる点に注意)
+    volumes:
+      - /data/optimat_db:/app/database   # ← living DB をホストへ露出
+    restart: unless-stopped

--- a/mi_hub2/src/mi_hub/__init__.py
+++ b/mi_hub2/src/mi_hub/__init__.py
@@ -1,0 +1,13 @@
+"""mi_hub — runcell/OptiMat/MLflow/Feast/AutoML 統合環境 + 研究エージェントの共通ライブラリ。"""
+import importlib
+
+__version__ = "0.2.0"
+
+_LAZY_MODULES = ("datastore", "tracking", "automl", "optimat_bridge", "agent")
+
+
+def __getattr__(name: str):
+    # mlflow 等の重い依存を持つモジュールは初回アクセス時に読み込む
+    if name in _LAZY_MODULES:
+        return importlib.import_module(f".{name}", __name__)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/mi_hub2/src/mi_hub/agent/__init__.py
+++ b/mi_hub2/src/mi_hub/agent/__init__.py
@@ -1,0 +1,2 @@
+"""mi_hub.agent — 状態駆動型研究エージェント（仮説・反証検証）。"""
+__all__ = ["errors", "loop", "models", "roles", "states", "tools"]

--- a/mi_hub2/src/mi_hub/agent/api.py
+++ b/mi_hub2/src/mi_hub/agent/api.py
@@ -1,0 +1,255 @@
+"""研究エージェント API（指示書 §14）。
+
+起動:  uvicorn mi_hub.agent.api:app --port 8800
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from .loop import ResearchManager
+from .models import SessionState, Task
+from .states import HypothesisState
+
+app = FastAPI(title="mi_hub research agent", version="0.1.0")
+_manager = ResearchManager()
+
+
+def get_manager() -> ResearchManager:
+    return _manager
+
+
+def _load(session_id: str) -> SessionState:
+    state = get_manager().store.load(session_id)
+    if state is None:
+        raise HTTPException(404, f"session not found: {session_id}")
+    return state
+
+
+class GoalRequest(BaseModel):
+    statement: str
+    target_material: str | None = None
+    target_phase: str | None = None
+    target_property: str | None = None
+
+
+class PlanPatch(BaseModel):
+    reason: str = ""
+    add_tasks: list[dict[str, Any]] = Field(default_factory=list)
+    remove_task_ids: list[str] = Field(default_factory=list)
+    reorder_task_ids: list[str] = Field(default_factory=list)
+
+
+class ActionRequest(BaseModel):
+    session_id: str
+    task_id: str
+
+
+class ResultRequest(BaseModel):
+    session_id: str
+    result: dict[str, Any] = Field(default_factory=dict)
+
+
+class ApprovalRequestBody(BaseModel):
+    session_id: str
+    approve: bool
+    by: str = "human"
+
+
+class HypothesisPatch(BaseModel):
+    session_id: str
+    status: str | None = None
+    falsification_conditions: list[str] | None = None
+    by: str = "human"
+
+
+# §14.1 研究目標作成
+@app.post("/api/agent/goals")
+def create_goal(req: GoalRequest) -> dict[str, Any]:
+    m = get_manager()
+    state = m.create_session(
+        req.statement,
+        target_material=req.target_material,
+        target_phase=req.target_phase,
+        target_property=req.target_property,
+    )
+    return {"session_id": state.session_id, "goal": state.goal.model_dump()}
+
+
+@app.get("/api/agent/sessions")
+def list_sessions() -> dict[str, Any]:
+    return {"sessions": get_manager().store.list_sessions()}
+
+
+# §14.2 現在状態取得
+@app.get("/api/agent/sessions/{session_id}/state")
+def get_state(session_id: str) -> dict[str, Any]:
+    m = get_manager()
+    state = _load(session_id)
+    obs = m.observe(state)
+    m.store.save(state)
+    return {
+        "session_id": state.session_id,
+        "agent_state": state.agent_state.value,
+        "goal": state.goal.model_dump() if state.goal else None,
+        "observation": obs.model_dump(),
+        "plan": state.plan.model_dump() if state.plan else None,
+        "hypotheses": [h.model_dump() for h in state.hypotheses],
+        "evidence": [e.model_dump() for e in state.evidence],
+        "approvals": [a.model_dump() for a in state.approvals],
+        "errors": [e.model_dump() for e in state.errors],
+        "budget": state.budget.model_dump(),
+        "stop_conditions": state.stop_conditions.model_dump(),
+        "stop_reason": state.stop_reason,
+        "plan_history": [c.model_dump() for c in state.plan_history],
+    }
+
+
+# §14.3 計画生成
+@app.post("/api/agent/sessions/{session_id}/plans")
+def create_plan(session_id: str) -> dict[str, Any]:
+    m = get_manager()
+    state = _load(session_id)
+    plan = m.generate_plan(state)
+    return plan.model_dump()
+
+
+# §14.4 計画更新
+@app.patch("/api/agent/plans/{plan_id}")
+def patch_plan(plan_id: str, req: PlanPatch, session_id: str) -> dict[str, Any]:
+    m = get_manager()
+    state = _load(session_id)
+    if state.plan is None or state.plan.plan_id != plan_id:
+        raise HTTPException(404, f"plan not found: {plan_id}")
+    add = [Task.model_validate(t) for t in req.add_tasks]
+    plan = m.apply_plan_change(
+        state, created_by="human", reason=req.reason, add_tasks=add,
+        remove_task_ids=req.remove_task_ids or None,
+        reorder_task_ids=req.reorder_task_ids or None,
+    )
+    return plan.model_dump()
+
+
+# §14.5 次行動候補取得
+@app.get("/api/agent/sessions/{session_id}/next-actions")
+def next_actions(session_id: str) -> dict[str, Any]:
+    m = get_manager()
+    state = _load(session_id)
+    actions = m.next_actions(state)
+    m.store.save(state)
+    return {"next_actions": actions}
+
+
+# §14.6 行動実行
+@app.post("/api/agent/actions")
+def execute_action(req: ActionRequest) -> dict[str, Any]:
+    m = get_manager()
+    state = _load(req.session_id)
+    try:
+        return m.execute_task(state, req.task_id)
+    except ValueError as exc:
+        raise HTTPException(404, str(exc)) from exc
+
+
+@app.post("/api/agent/sessions/{session_id}/run-auto")
+def run_auto(session_id: str) -> dict[str, Any]:
+    m = get_manager()
+    state = _load(session_id)
+    return m.run_auto(state)
+
+
+# §14.7 実行結果登録（外部計算結果の登録）
+@app.post("/api/agent/actions/{action_id}/results")
+def register_result(action_id: str, req: ResultRequest) -> dict[str, Any]:
+    m = get_manager()
+    state = _load(req.session_id)
+    if state.plan is None:
+        raise HTTPException(404, "plan not found")
+    task = state.plan.task(action_id)
+    if task is None:
+        raise HTTPException(404, f"task not found: {action_id}")
+    task.result = req.result
+    from .states import TaskState
+
+    task.status = TaskState.COMPLETED
+    state.audit("external", "result_registered", task_id=action_id)
+    m.store.save(state)
+    return {"task_id": action_id, "status": task.status.value}
+
+
+# §14.8 再計画
+@app.post("/api/agent/sessions/{session_id}/replan")
+def replan(session_id: str, req: PlanPatch) -> dict[str, Any]:
+    m = get_manager()
+    state = _load(session_id)
+    if state.plan is None:
+        plan = m.generate_plan(state)
+        return plan.model_dump()
+    add = [Task.model_validate(t) for t in req.add_tasks]
+    plan = m.apply_plan_change(
+        state, created_by="agent", reason=req.reason or "replanning",
+        add_tasks=add, remove_task_ids=req.remove_task_ids or None,
+        reorder_task_ids=req.reorder_task_ids or None,
+    )
+    return plan.model_dump()
+
+
+# §14.9 一時停止
+@app.post("/api/agent/sessions/{session_id}/pause")
+def pause(session_id: str) -> dict[str, Any]:
+    m = get_manager()
+    state = _load(session_id)
+    m.pause(state)
+    return {"agent_state": state.agent_state.value}
+
+
+# §14.10 再開
+@app.post("/api/agent/sessions/{session_id}/resume")
+def resume(session_id: str) -> dict[str, Any]:
+    m = get_manager()
+    state = _load(session_id)
+    m.resume(state)
+    return {"agent_state": state.agent_state.value}
+
+
+# §14.11 終了
+@app.post("/api/agent/sessions/{session_id}/complete")
+def complete(session_id: str) -> dict[str, Any]:
+    m = get_manager()
+    state = _load(session_id)
+    m.complete(state)
+    return {"agent_state": state.agent_state.value}
+
+
+# 承認解決（Human-in-the-loop §10）
+@app.post("/api/agent/approvals/{approval_id}")
+def resolve_approval(approval_id: str, req: ApprovalRequestBody) -> dict[str, Any]:
+    m = get_manager()
+    state = _load(req.session_id)
+    try:
+        return m.resolve_approval(state, approval_id, req.approve, by=req.by)
+    except ValueError as exc:
+        raise HTTPException(404, str(exc)) from exc
+
+
+# 仮説の修正（Human-in-the-loop §10）
+@app.patch("/api/agent/hypotheses/{hypothesis_id}")
+def patch_hypothesis(hypothesis_id: str, req: HypothesisPatch) -> dict[str, Any]:
+    m = get_manager()
+    state = _load(req.session_id)
+    try:
+        if req.status:
+            m.set_hypothesis_status(state, hypothesis_id, HypothesisState(req.status),
+                                    by=req.by)
+        if req.falsification_conditions is not None:
+            m.update_falsification_conditions(state, hypothesis_id,
+                                              req.falsification_conditions, by=req.by)
+    except ValueError as exc:
+        raise HTTPException(404, str(exc)) from exc
+    except PermissionError as exc:
+        raise HTTPException(403, str(exc)) from exc
+    h = state.hypothesis(hypothesis_id)
+    return h.model_dump() if h else {}

--- a/mi_hub2/src/mi_hub/agent/errors.py
+++ b/mi_hub2/src/mi_hub/agent/errors.py
@@ -1,0 +1,101 @@
+"""エラー分類と回復（指示書 §9）。
+
+自動修正は事前定義ルールの範囲内に限定し、意味変更を伴う修正は
+人間確認を要求する。自動再試行回数には上限を設ける。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .models import ErrorRecord
+from .states import AUTO_RECOVERABLE_ERRORS, HUMAN_REVIEW_ERRORS, ErrorType
+
+# エラーメッセージからの分類キーワード
+_KEYWORDS: list[tuple[str, ErrorType]] = [
+    ("unit", ErrorType.UNIT_MISMATCH),
+    ("単位", ErrorType.UNIT_MISMATCH),
+    ("schema", ErrorType.SCHEMA_MISMATCH),
+    ("missing input", ErrorType.MISSING_INPUT),
+    ("timeout", ErrorType.TIMEOUT),
+    ("permission", ErrorType.PERMISSION_ERROR),
+    ("network", ErrorType.NETWORK_ERROR),
+    ("connection", ErrorType.NETWORK_ERROR),
+    ("out of domain", ErrorType.OUT_OF_DOMAIN),
+    ("適用範囲外", ErrorType.OUT_OF_DOMAIN),
+    ("memory", ErrorType.OUT_OF_MEMORY),
+    ("validation", ErrorType.VALIDATION_ERROR),
+]
+
+
+def classify_error(message: str) -> ErrorType:
+    low = message.lower()
+    for kw, etype in _KEYWORDS:
+        if kw in low:
+            return etype
+    return ErrorType.UNKNOWN_ERROR
+
+
+def is_auto_recoverable(error_type: ErrorType) -> bool:
+    return error_type in AUTO_RECOVERABLE_ERRORS
+
+
+def requires_human_review(error_type: ErrorType) -> bool:
+    return error_type in HUMAN_REVIEW_ERRORS
+
+
+# 事前定義の単位変換ルール（§9.2 自動修正可能な範囲）
+_UNIT_CONVERSIONS: dict[tuple[str, str], float] = {
+    ("ev/atom", "kj/mol"): 96.485,
+    ("kj/mol", "ev/atom"): 1.0 / 96.485,
+    ("c", "k"): 1.0,  # オフセット変換は convert_unit 内で処理
+}
+
+
+def convert_unit(value: float, from_unit: str, to_unit: str) -> float:
+    """既知の単位ペアのみ変換する。未知ペアは例外を送出し人間確認へ。"""
+    f, t = from_unit.strip().lower(), to_unit.strip().lower()
+    if f == t:
+        return value
+    if (f, t) == ("c", "k"):
+        return value + 273.15
+    if (f, t) == ("k", "c"):
+        return value - 273.15
+    if (f, t) in _UNIT_CONVERSIONS:
+        return value * _UNIT_CONVERSIONS[(f, t)]
+    raise ValueError(f"不確実な単位解釈のため人間確認が必要: {from_unit} -> {to_unit}")
+
+
+def try_auto_fix(
+    error_type: ErrorType, inputs: dict[str, Any]
+) -> dict[str, Any] | None:
+    """自動修正候補を返す。修正できない場合は None（人間確認へ）。"""
+    if error_type == ErrorType.UNIT_MISMATCH:
+        unit = str(inputs.get("temperature_unit", "")).strip().lower()
+        if "temperature" in inputs and unit and unit != "k":
+            try:
+                fixed = dict(inputs)
+                fixed["temperature"] = convert_unit(float(inputs["temperature"]), unit, "K")
+                fixed["temperature_unit"] = "K"
+                return fixed
+            except (ValueError, TypeError):
+                return None
+        return None
+    if error_type == ErrorType.SCHEMA_MISMATCH:
+        # 入力キーの別名変換（事前定義ルール）
+        aliases = {"temp": "temperature", "comp": "composition", "T": "temperature"}
+        fixed = {aliases.get(k, k): v for k, v in inputs.items()}
+        return fixed if fixed != inputs else None
+    if error_type in (ErrorType.NETWORK_ERROR, ErrorType.TIMEOUT):
+        return dict(inputs)  # 入力そのままで再試行
+    return None
+
+
+def record_error(task_id: str | None, message: str) -> ErrorRecord:
+    etype = classify_error(message)
+    return ErrorRecord(
+        task_id=task_id,
+        error_type=etype,
+        message=message,
+        auto_recoverable=is_auto_recoverable(etype),
+    )

--- a/mi_hub2/src/mi_hub/agent/llm.py
+++ b/mi_hub2/src/mi_hub/agent/llm.py
@@ -1,0 +1,112 @@
+"""LLM 補助層（指示書 §16）。
+
+LLM は自然言語の構造化・仮説候補生成・説明生成のみに使用する。
+数値計算・権限判定・承認状態判定・仮説の最終確定には使用しない。
+OPENAI_API_KEY が未設定の場合は決定論的フォールバックで動作する。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+
+def llm_available() -> bool:
+    return bool(os.environ.get("OPENAI_API_KEY"))
+
+
+def _chat_json(system: str, user: str) -> dict[str, Any] | None:
+    """OpenAI へ JSON 応答を要求。失敗時は None（フォールバックへ）。"""
+    if not llm_available():
+        return None
+    try:
+        from openai import OpenAI
+
+        client = OpenAI()
+        resp = client.chat.completions.create(
+            model=os.environ.get("MI_HUB_LLM_MODEL", "gpt-4o-mini"),
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            response_format={"type": "json_object"},
+            temperature=0.2,
+        )
+        return json.loads(resp.choices[0].message.content or "{}")
+    except Exception:
+        return None
+
+
+def structure_goal(statement: str) -> dict[str, Any]:
+    """研究目標文を構造化する。LLM 不可時はルールベース。"""
+    out = _chat_json(
+        "あなたは材料科学の研究目標を構造化するアシスタントです。"
+        "JSON で target_material, target_phase, target_property, success_criteria を返してください。",
+        statement,
+    )
+    if out:
+        return out
+    # フォールバック: 簡易キーワード抽出
+    phase = None
+    for p in ("B2", "L12", "L1_2", "FCC", "BCC", "HCP"):
+        if p in statement:
+            phase = p
+            break
+    material = None
+    for m in ("Ni-Al", "NiAl", "Co-Ni-Ta", "Fe-V"):
+        if m in statement:
+            material = "Ni-Al" if m == "NiAl" else m
+            break
+    prop = "formation_enthalpy"
+    if "格子定数" in statement:
+        prop = "lattice_constant"
+    elif "拡散" in statement:
+        prop = "diffusivity"
+    return {
+        "target_material": material,
+        "target_phase": phase,
+        "target_property": prop,
+        "success_criteria": [
+            "主要仮説と対立仮説が形式化されている",
+            "利用可能なモデル群による数値検証が完了している",
+            "支持・反証・保留・限定支持の判定材料が提示されている",
+        ],
+    }
+
+
+def generate_hypotheses(goal_statement: str, evidence_claims: list[str]) -> list[dict[str, Any]]:
+    """主仮説・対立仮説の候補を生成する（最終採用は人間）。"""
+    out = _chat_json(
+        "材料科学の仮説候補を生成してください。JSON で "
+        '{"hypotheses": [{"statement", "is_counter", "supporting_predictions", '
+        '"falsification_conditions"}]} を返してください。',
+        f"研究目標: {goal_statement}\n証拠: {json.dumps(evidence_claims, ensure_ascii=False)}",
+    )
+    if out and isinstance(out.get("hypotheses"), list):
+        return out["hypotheses"]
+    return [
+        {
+            "statement": f"主仮説: {goal_statement} に対する主要因が成立する",
+            "is_counter": False,
+            "supporting_predictions": ["独立モデル群の予測が同方向の傾向を示す"],
+            "falsification_conditions": ["独立モデル群の過半が逆方向の傾向を示す"],
+        },
+        {
+            "statement": "対立仮説: 別の欠陥・機構が主要因である",
+            "is_counter": True,
+            "supporting_predictions": ["対象因子を除外しても傾向が維持される"],
+            "falsification_conditions": ["対象因子除外時に傾向が消失する"],
+        },
+    ]
+
+
+def summarize_for_human(payload: dict[str, Any]) -> str:
+    """人間向け説明の生成。LLM 不可時は構造化テキスト。"""
+    out = _chat_json(
+        "研究エージェントの状態を日本語で簡潔に要約してください。JSON {\"summary\": str}",
+        json.dumps(payload, ensure_ascii=False, default=str),
+    )
+    if out and out.get("summary"):
+        return str(out["summary"])
+    return json.dumps(payload, ensure_ascii=False, indent=2, default=str)

--- a/mi_hub2/src/mi_hub/agent/loop.py
+++ b/mi_hub2/src/mi_hub/agent/loop.py
@@ -1,0 +1,423 @@
+"""Research Manager Agent — 状態駆動実行ループ（指示書 §4, §5.1, §8, §12）。
+
+Goal → Observe → Plan → Human Check → Act → Observe Result → Evaluate → Replan
+の反復を、承認範囲・予算・反復回数の制約下で実行する。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from . import llm
+from .models import (
+    Observation,
+    Plan,
+    PlanChange,
+    ResearchGoal,
+    SessionState,
+    Task,
+)
+from .roles import (
+    APPROVAL_REQUIRED_ACTIONS,
+    EvaluationAgent,
+    EvidenceAgent,
+    ExecutionAgent,
+    HypothesisAgent,
+    ModelSelectionAgent,
+    SafetyApprovalAgent,
+    VerificationPlanningAgent,
+)
+from .states import AgentState, HypothesisState, TaskState
+from .tools import ToolGateway
+
+_DEFAULT_DIR = os.path.join(
+    os.environ.get("MI_HUB_DATA", os.path.expanduser("~/mi_hub_data")), "agent_sessions"
+)
+
+
+class SessionStore:
+    """作業記憶の永続化（§7.1: セッション再開可能にする）。"""
+
+    def __init__(self, base_dir: str | None = None):
+        self.base_dir = Path(base_dir or _DEFAULT_DIR)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    def path(self, session_id: str) -> Path:
+        return self.base_dir / f"{session_id}.json"
+
+    def save(self, state: SessionState) -> None:
+        self.path(state.session_id).write_text(
+            json.dumps(state.model_dump(), ensure_ascii=False, indent=1, default=str),
+            encoding="utf-8",
+        )
+
+    def load(self, session_id: str) -> SessionState | None:
+        p = self.path(session_id)
+        if not p.exists():
+            return None
+        return SessionState.model_validate(json.loads(p.read_text(encoding="utf-8")))
+
+    def list_sessions(self) -> list[str]:
+        return sorted(p.stem for p in self.base_dir.glob("*.json"))
+
+
+class ResearchManager:
+    """研究セッション全体を統括する（§5.1）。"""
+
+    def __init__(self, gateway: ToolGateway | None = None,
+                 store: SessionStore | None = None):
+        self.gateway = gateway or ToolGateway()
+        self.store = store or SessionStore()
+        self.safety = SafetyApprovalAgent()
+        self._roles = {
+            "EvidenceAgent": EvidenceAgent(),
+            "HypothesisAgent": HypothesisAgent(),
+            "ModelSelectionAgent": ModelSelectionAgent(),
+            "VerificationPlanningAgent": VerificationPlanningAgent(),
+            "ExecutionAgent": ExecutionAgent(),
+            "EvaluationAgent": EvaluationAgent(),
+        }
+
+    # ---------- Goal ----------
+    def create_session(self, goal_statement: str, **goal_kwargs: Any) -> SessionState:
+        structured = llm.structure_goal(goal_statement)
+        structured.update({k: v for k, v in goal_kwargs.items() if v is not None})
+        goal = ResearchGoal(statement=goal_statement, **{
+            k: structured.get(k) for k in
+            ("target_material", "target_phase", "target_property", "success_criteria")
+            if structured.get(k) is not None
+        })
+        state = SessionState(goal=goal, agent_state=AgentState.IDLE)
+        state.audit("ResearchManager", "session_created", goal_id=goal.goal_id)
+        self.store.save(state)
+        return state
+
+    # ---------- Observe (§4.1 Step 2) ----------
+    def observe(self, state: SessionState) -> Observation:
+        state.agent_state = AgentState.OBSERVING
+        plan = state.plan
+        completed = [t.task_id for t in plan.tasks if t.status == TaskState.COMPLETED] if plan else []
+        failed = [t.task_id for t in plan.tasks if t.status == TaskState.FAILED] if plan else []
+        total = len(plan.tasks) if plan and plan.tasks else 0
+        obs = Observation(
+            goal_progress=(len(completed) / total) if total else 0.0,
+            active_hypotheses=[h.hypothesis_id for h in state.hypotheses
+                               if h.status not in (HypothesisState.ARCHIVED,
+                                                   HypothesisState.REJECTED_BY_HUMAN)],
+            available_models=len(self.gateway.models),
+            applicable_models=len(self._applicable_models(state)),
+            completed_tasks=completed,
+            failed_tasks=failed,
+            pending_approvals=[a.approval_id for a in state.approvals if a.status == "pending"],
+            unresolved_issues=[e.message for e in state.errors if not e.resolved],
+            evidence_count=len(state.evidence),
+            budget_remaining_runs=max(0, state.budget.max_model_runs - state.budget.used_model_runs),
+            iterations_remaining=max(0, state.stop_conditions.max_iterations
+                                     - state.stop_conditions.current_iteration),
+        )
+        state.last_observation = obs
+        return obs
+
+    def _applicable_models(self, state: SessionState) -> list[Any]:
+        goal = state.goal
+        if not goal or not goal.target_property:
+            return []
+        elements = []
+        if goal.target_material:
+            elements = [e for e in goal.target_material.replace("-", " ").split() if e]
+        try:
+            return self.gateway.search_models(goal.target_property, elements,
+                                              goal.target_phase)
+        except Exception:
+            return []  # 観察はベストエフォート（失敗はタスク実行側で扱う）
+
+    # ---------- Plan (§4.1 Step 3) ----------
+    def generate_plan(self, state: SessionState) -> Plan:
+        state.agent_state = AgentState.PLANNING
+        goal = state.goal
+        t1 = Task(agent="EvidenceAgent", action="search_literature",
+                  description="関連論文・証拠を検索する",
+                  inputs={"query": goal.statement if goal else ""})
+        t2 = Task(agent="HypothesisAgent", action="generate_hypotheses",
+                  description="主仮説と対立仮説を生成する", depends_on=[t1.task_id])
+        t3 = Task(agent="ModelSelectionAgent", action="search_models",
+                  description="適用可能なMIntモデルを検索する", depends_on=[t2.task_id])
+        t4 = Task(agent="VerificationPlanningAgent", action="plan_verification",
+                  description="検証ジョブ（入力条件）を生成する", depends_on=[t3.task_id])
+        t5 = Task(agent="ExecutionAgent", action="run_models_bulk",
+                  description="適用可能なモデルを一括実行する", depends_on=[t4.task_id],
+                  requires_approval=True)
+        t6 = Task(agent="EvaluationAgent", action="evaluate_hypothesis",
+                  description="傾きと不確実性から仮説の判定材料を整理する",
+                  depends_on=[t5.task_id])
+        plan = Plan(goal_id=goal.goal_id if goal else "", tasks=[t1, t2, t3, t4, t5, t6])
+        state.plan = plan
+        state.plan_history.append(PlanChange(
+            plan_id=plan.plan_id, version=plan.version,
+            reason_for_change="initial plan",
+            added_tasks=[t.task_id for t in plan.tasks],
+        ))
+        state.audit("ResearchManager", "plan_generated", plan_id=plan.plan_id,
+                    version=plan.version)
+        self.store.save(state)
+        return plan
+
+    def apply_plan_change(self, state: SessionState, *, created_by: str = "human",
+                          reason: str = "", add_tasks: list[Task] | None = None,
+                          remove_task_ids: list[str] | None = None,
+                          reorder_task_ids: list[str] | None = None) -> Plan:
+        """計画の編集（人間介入 §10 / 再計画 §8）。版管理される。"""
+        plan = state.plan
+        if plan is None:
+            raise ValueError("計画が存在しません")
+        prev_version = plan.version
+        added, removed = [], []
+        if remove_task_ids:
+            plan.tasks = [t for t in plan.tasks if t.task_id not in remove_task_ids]
+            removed = list(remove_task_ids)
+        for t in add_tasks or []:
+            plan.tasks.append(t)
+            added.append(t.task_id)
+        reordered = []
+        if reorder_task_ids:
+            by_id = {t.task_id: t for t in plan.tasks}
+            ordered = [by_id[i] for i in reorder_task_ids if i in by_id]
+            rest = [t for t in plan.tasks if t.task_id not in set(reorder_task_ids)]
+            plan.tasks = ordered + rest
+            reordered = list(reorder_task_ids)
+        plan.version += 1
+        plan.reason_for_change = reason
+        plan.previous_plan_version = prev_version
+        plan.created_by = created_by
+        state.plan_history.append(PlanChange(
+            plan_id=plan.plan_id, version=plan.version, created_by=created_by,
+            reason_for_change=reason, previous_plan_version=prev_version,
+            added_tasks=added, removed_tasks=removed, reordered_tasks=reordered,
+            human_approval=(created_by == "human"),
+        ))
+        state.audit(created_by, "plan_changed", version=plan.version, reason=reason)
+        self.store.save(state)
+        return plan
+
+    # ---------- Next actions (§14.5) ----------
+    def next_actions(self, state: SessionState) -> list[dict[str, Any]]:
+        plan = state.plan
+        if plan is None:
+            return [{"action": "generate_plan", "reason": "計画が未生成"}]
+        out = []
+        for t in plan.ready_tasks():
+            needs = t.requires_approval or t.action in APPROVAL_REQUIRED_ACTIONS
+            approved = False
+            if t.approval_id:
+                a = state.approval(t.approval_id)
+                approved = bool(a and a.status == "approved")
+            out.append({
+                "task_id": t.task_id, "action": t.action, "agent": t.agent,
+                "description": t.description,
+                "requires_approval": needs, "approved": approved,
+            })
+        state.next_action_candidates = [o["task_id"] for o in out]
+        return out
+
+    # ---------- Act (§4.1 Step 4-6) ----------
+    def execute_task(self, state: SessionState, task_id: str) -> dict[str, Any]:
+        plan = state.plan
+        if plan is None:
+            raise ValueError("計画が存在しません")
+        task = plan.task(task_id)
+        if task is None:
+            raise ValueError(f"タスクが存在しません: {task_id}")
+        if state.agent_state == AgentState.PAUSED:
+            return {"status": "paused", "detail": "セッションは一時停止中です"}
+        ok, reason = self.safety.check(state, task)
+        if not ok:
+            if "承認" in reason and task.approval_id is None:
+                self.safety.request_approval(state, task)
+                state.agent_state = AgentState.AWAITING_APPROVAL
+                self.store.save(state)
+                return {"status": "awaiting_approval", "approval_id": task.approval_id,
+                        "detail": reason}
+            state.agent_state = AgentState.BLOCKED
+            self.store.save(state)
+            return {"status": "blocked", "detail": reason}
+
+        # 依存タスクの結果を入力へ引き継ぐ
+        self._wire_inputs(state, task)
+        state.agent_state = AgentState.EXECUTING
+        task.status = TaskState.RUNNING
+        role = self._roles.get(task.agent)
+        try:
+            result = role.run(state, self.gateway, task) if role else {}
+            task.result = result
+            failures = result.get("failures") or []
+            successes = result.get("results")
+            if failures and successes:
+                task.status = TaskState.PARTIALLY_COMPLETED
+            elif failures and not successes and task.agent == "ExecutionAgent":
+                task.status = TaskState.FAILED
+            else:
+                task.status = TaskState.COMPLETED
+            state.audit(task.agent, "task_executed", task_id=task.task_id,
+                        status=task.status.value)
+            status = "completed" if task.status != TaskState.FAILED else "failed"
+        except Exception as exc:  # ツール層以外の予期しない失敗
+            from .errors import record_error
+
+            err = record_error(task.task_id, str(exc))
+            state.errors.append(err)
+            task.status = TaskState.FAILED
+            task.error = {"message": str(exc), "error_type": err.error_type.value}
+            status = "failed"
+        state.agent_state = AgentState.EVALUATING
+        self._after_step(state)
+        self.store.save(state)
+        return {"status": status, "task_id": task.task_id,
+                "result": task.result, "error": task.error}
+
+    def _wire_inputs(self, state: SessionState, task: Task) -> None:
+        plan = state.plan
+        assert plan is not None
+        for dep_id in task.depends_on:
+            dep = plan.task(dep_id)
+            if not dep or not dep.result:
+                continue
+            if task.action == "plan_verification" and "recommended_models" in dep.result:
+                task.inputs.setdefault("model_ids", dep.result["recommended_models"])
+            if task.action == "run_models_bulk" and "jobs" in dep.result:
+                task.inputs.setdefault("jobs", dep.result["jobs"])
+            if task.action == "evaluate_hypothesis" and "results" in dep.result:
+                task.inputs.setdefault("results", dep.result["results"])
+
+    def _after_step(self, state: SessionState) -> None:
+        """Observe Result → Evaluate → Replan 判定（§4.1 Step 5-7）。"""
+        state.stop_conditions.current_iteration += 1
+        self.observe(state)
+        stop = self.check_stop_conditions(state)
+        if stop:
+            state.stop_reason = stop
+            if "承認待ち" in stop or "人間判断" in stop:
+                state.agent_state = AgentState.AWAITING_APPROVAL
+            elif "完了" in stop:
+                state.agent_state = AgentState.COMPLETED
+            else:
+                state.agent_state = AgentState.BLOCKED
+        else:
+            state.agent_state = AgentState.REPLANNING
+
+    # ---------- Stop conditions (§12) ----------
+    def check_stop_conditions(self, state: SessionState) -> str | None:
+        sc = state.stop_conditions
+        plan = state.plan
+        if plan and plan.tasks and all(
+            t.status in (TaskState.COMPLETED, TaskState.SKIPPED,
+                         TaskState.PARTIALLY_COMPLETED)
+            for t in plan.tasks
+        ):
+            return "正常終了: 承認済み検証計画が完了"
+        if sc.current_iteration >= sc.max_iterations:
+            return "資源制約: 反復回数上限に到達"
+        if state.budget.exceeded():
+            return "資源制約: 計算予算上限に到達"
+        if any(a.status == "pending" for a in state.approvals):
+            return None  # 承認待ちは execute 時に個別処理
+        return None
+
+    # ---------- Human-in-the-loop (§10) ----------
+    def resolve_approval(self, state: SessionState, approval_id: str,
+                         approve: bool, by: str = "human") -> dict[str, Any]:
+        import time as _time
+
+        req = state.approval(approval_id)
+        if req is None:
+            raise ValueError(f"承認要求が存在しません: {approval_id}")
+        req.status = "approved" if approve else "rejected"
+        req.resolved_at = _time.time()
+        req.resolved_by = by
+        state.audit(by, "approval_resolved", approval_id=approval_id, approved=approve)
+        if not approve and req.task_id and state.plan:
+            task = state.plan.task(req.task_id)
+            if task:
+                task.status = TaskState.REJECTED
+        elif approve and req.task_id and state.plan:
+            task = state.plan.task(req.task_id)
+            if task and task.status == TaskState.AWAITING_APPROVAL:
+                task.status = TaskState.READY
+        self.store.save(state)
+        return {"approval_id": approval_id, "status": req.status}
+
+    def set_hypothesis_status(self, state: SessionState, hypothesis_id: str,
+                              status: HypothesisState, by: str = "human") -> None:
+        """仮説の正式採用・反証等は人間のみが確定できる。"""
+        h = state.hypothesis(hypothesis_id)
+        if h is None:
+            raise ValueError(f"仮説が存在しません: {hypothesis_id}")
+        h.status = status
+        if status == HypothesisState.APPROVED_FOR_TESTING:
+            h.falsification_approved = True  # 反証条件の固定
+        state.audit(by, "hypothesis_status_changed",
+                    hypothesis_id=hypothesis_id, status=status.value)
+        self.store.save(state)
+
+    def update_falsification_conditions(self, state: SessionState, hypothesis_id: str,
+                                        conditions: list[str], by: str = "human") -> None:
+        """反証条件の変更は人間承認必須（§4.1 Step 7）。変更前後を保存する。"""
+        if by != "human":
+            raise PermissionError("反証条件の変更には研究者の承認が必要です")
+        h = state.hypothesis(hypothesis_id)
+        if h is None:
+            raise ValueError(f"仮説が存在しません: {hypothesis_id}")
+        before = list(h.falsification_conditions)
+        h.falsification_conditions = conditions
+        state.audit(by, "falsification_conditions_changed",
+                    hypothesis_id=hypothesis_id, before=before, after=conditions)
+        self.store.save(state)
+
+    # ---------- Pause / Resume / Complete (§14.9-11) ----------
+    def pause(self, state: SessionState) -> None:
+        state.agent_state = AgentState.PAUSED
+        state.audit("human", "session_paused")
+        self.store.save(state)
+
+    def resume(self, state: SessionState) -> None:
+        state.agent_state = AgentState.REPLANNING
+        state.stop_reason = None
+        state.audit("human", "session_resumed")
+        self.store.save(state)
+
+    def complete(self, state: SessionState) -> None:
+        state.agent_state = AgentState.COMPLETED
+        state.stop_reason = "研究者が終了を承認"
+        state.audit("human", "session_completed")
+        self.store.save(state)
+
+    # ---------- Auto loop ----------
+    def run_auto(self, state: SessionState, max_steps: int | None = None) -> dict[str, Any]:
+        """承認不要タスクを自動で連続実行する。承認要タスクで一時停止する。"""
+        executed = []
+        steps = 0
+        limit = max_steps or state.stop_conditions.max_iterations
+        while steps < limit:
+            if state.agent_state in (AgentState.PAUSED, AgentState.COMPLETED,
+                                     AgentState.CANCELLED, AgentState.FAILED):
+                break
+            actions = self.next_actions(state)
+            runnable = [a for a in actions
+                        if not a["requires_approval"] or a["approved"]]
+            if not runnable:
+                if actions:
+                    # 承認待ちを生成して停止
+                    res = self.execute_task(state, actions[0]["task_id"])
+                    executed.append(res)
+                break
+            res = self.execute_task(state, runnable[0]["task_id"])
+            executed.append(res)
+            steps += 1
+            if res["status"] in ("awaiting_approval", "blocked", "paused"):
+                break
+            if state.stop_reason:
+                break
+        return {"executed": executed, "agent_state": state.agent_state.value,
+                "stop_reason": state.stop_reason}

--- a/mi_hub2/src/mi_hub/agent/models.py
+++ b/mi_hub2/src/mi_hub/agent/models.py
@@ -1,0 +1,229 @@
+"""データモデル（指示書 §4, §8, §15）。"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .states import AgentState, ErrorType, HypothesisState, TaskState
+
+
+def _uid(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+class ResearchGoal(BaseModel):
+    goal_id: str = Field(default_factory=lambda: _uid("GOAL"))
+    statement: str
+    target_material: str | None = None
+    target_phase: str | None = None
+    target_property: str | None = None
+    success_criteria: list[str] = Field(default_factory=list)
+
+
+class Evidence(BaseModel):
+    evidence_id: str = Field(default_factory=lambda: _uid("E"))
+    source_type: str = "journal_article"
+    claim: str = ""
+    conditions: dict[str, Any] = Field(default_factory=dict)
+    evidence_type: str = "experiment"
+    independence_group: str | None = None
+    limitations: list[str] = Field(default_factory=list)
+
+
+class Hypothesis(BaseModel):
+    hypothesis_id: str = Field(default_factory=lambda: _uid("H"))
+    statement: str
+    counter_to: str | None = None  # 対立仮説の場合、主仮説ID
+    supporting_predictions: list[str] = Field(default_factory=list)
+    falsification_conditions: list[str] = Field(default_factory=list)
+    falsification_approved: bool = False  # 反証条件は研究者承認後に固定（§5.3）
+    hold_conditions: list[str] = Field(default_factory=list)
+    required_inputs: list[str] = Field(default_factory=list)
+    required_outputs: list[str] = Field(default_factory=list)
+    applicability: dict[str, Any] = Field(default_factory=dict)
+    status: HypothesisState = HypothesisState.DRAFT
+
+
+class Task(BaseModel):
+    task_id: str = Field(default_factory=lambda: _uid("TASK"))
+    agent: str = "ResearchManagerAgent"
+    action: str = ""
+    description: str = ""
+    status: TaskState = TaskState.PROPOSED
+    depends_on: list[str] = Field(default_factory=list)
+    requires_approval: bool = False
+    approval_id: str | None = None
+    inputs: dict[str, Any] = Field(default_factory=dict)
+    result_ids: list[str] = Field(default_factory=list)
+    result: dict[str, Any] | None = None
+    error: dict[str, Any] | None = None
+    retry_count: int = 0
+    estimated_cost: float = 0.0
+    tool: str | None = None
+    reason: str = ""
+
+
+class Plan(BaseModel):
+    plan_id: str = Field(default_factory=lambda: _uid("PLAN"))
+    goal_id: str = ""
+    version: int = 1
+    created_at: float = Field(default_factory=time.time)
+    created_by: str = "agent"
+    reason_for_change: str = "initial plan"
+    previous_plan_version: int | None = None
+    tasks: list[Task] = Field(default_factory=list)
+
+    def task(self, task_id: str) -> Task | None:
+        for t in self.tasks:
+            if t.task_id == task_id:
+                return t
+        return None
+
+    def ready_tasks(self) -> list[Task]:
+        """依存タスクが完了し実行可能なタスクを返す。"""
+        done = {
+            t.task_id
+            for t in self.tasks
+            if t.status in (TaskState.COMPLETED, TaskState.PARTIALLY_COMPLETED, TaskState.SKIPPED)
+        }
+        out = []
+        for t in self.tasks:
+            if t.status in (
+                TaskState.PROPOSED,
+                TaskState.PENDING,
+                TaskState.READY,
+                TaskState.AWAITING_APPROVAL,
+            ) and all(d in done for d in t.depends_on):
+                out.append(t)
+        return out
+
+
+class PlanChange(BaseModel):
+    """計画変更履歴（§8.1）。"""
+
+    plan_id: str
+    version: int
+    created_at: float = Field(default_factory=time.time)
+    created_by: str = "agent"
+    reason_for_change: str = ""
+    previous_plan_version: int | None = None
+    added_tasks: list[str] = Field(default_factory=list)
+    removed_tasks: list[str] = Field(default_factory=list)
+    reordered_tasks: list[str] = Field(default_factory=list)
+    human_approval: bool = False
+
+
+class ApprovalRequest(BaseModel):
+    approval_id: str = Field(default_factory=lambda: _uid("APPROVAL"))
+    task_id: str | None = None
+    kind: str = "task_execution"
+    description: str = ""
+    status: str = "pending"  # pending / approved / rejected
+    requested_at: float = Field(default_factory=time.time)
+    resolved_at: float | None = None
+    resolved_by: str | None = None
+
+
+class Budget(BaseModel):
+    max_model_runs: int = 30  # MVP制限（§18）
+    used_model_runs: int = 0
+    max_gpu_hours: float = 10.0
+    used_gpu_hours: float = 0.0
+
+    def exceeded(self) -> bool:
+        return (
+            self.used_model_runs >= self.max_model_runs
+            or self.used_gpu_hours >= self.max_gpu_hours
+        )
+
+
+class StopConditions(BaseModel):
+    max_iterations: int = 5  # MVP: 自動反復回数は3〜5回（§18）
+    current_iteration: int = 0
+    minimum_information_gain: float = 0.01
+    max_retries_per_task: int = 3
+
+
+class StepEvaluation(BaseModel):
+    step_result: str = "completed"
+    goal_progress_before: float = 0.0
+    goal_progress_after: float = 0.0
+    evidence_added: list[str] = Field(default_factory=list)
+    hypotheses_affected: list[str] = Field(default_factory=list)
+    new_conflicts: list[str] = Field(default_factory=list)
+    result_quality: str = "acceptable"
+    requires_replanning: bool = False
+
+
+class ErrorRecord(BaseModel):
+    error_id: str = Field(default_factory=lambda: _uid("ERR"))
+    task_id: str | None = None
+    error_type: ErrorType = ErrorType.UNKNOWN_ERROR
+    message: str = ""
+    auto_recoverable: bool = False
+    resolved: bool = False
+    created_at: float = Field(default_factory=time.time)
+
+
+class AuditLogEntry(BaseModel):
+    timestamp: float = Field(default_factory=time.time)
+    actor: str = ""
+    action: str = ""
+    detail: dict[str, Any] = Field(default_factory=dict)
+
+
+class Observation(BaseModel):
+    """現在状態の観察結果（§4.1 Step 2）。"""
+
+    goal_progress: float = 0.0
+    active_hypotheses: list[str] = Field(default_factory=list)
+    available_models: int = 0
+    applicable_models: int = 0
+    completed_tasks: list[str] = Field(default_factory=list)
+    failed_tasks: list[str] = Field(default_factory=list)
+    pending_approvals: list[str] = Field(default_factory=list)
+    unresolved_issues: list[str] = Field(default_factory=list)
+    evidence_count: int = 0
+    budget_remaining_runs: int = 0
+    iterations_remaining: int = 0
+
+
+class SessionState(BaseModel):
+    """研究セッションの作業記憶（§7.1、§15）。"""
+
+    session_id: str = Field(default_factory=lambda: _uid("SESSION"))
+    goal: ResearchGoal | None = None
+    agent_state: AgentState = AgentState.IDLE
+    plan: Plan | None = None
+    plan_history: list[PlanChange] = Field(default_factory=list)
+    hypotheses: list[Hypothesis] = Field(default_factory=list)
+    evidence: list[Evidence] = Field(default_factory=list)
+    approvals: list[ApprovalRequest] = Field(default_factory=list)
+    errors: list[ErrorRecord] = Field(default_factory=list)
+    evaluations: list[StepEvaluation] = Field(default_factory=list)
+    audit_log: list[AuditLogEntry] = Field(default_factory=list)
+    budget: Budget = Field(default_factory=Budget)
+    stop_conditions: StopConditions = Field(default_factory=StopConditions)
+    last_observation: Observation | None = None
+    next_action_candidates: list[str] = Field(default_factory=list)
+    stop_reason: str | None = None
+    chat_history: list[dict[str, str]] = Field(default_factory=list)
+
+    def hypothesis(self, hid: str) -> Hypothesis | None:
+        for h in self.hypotheses:
+            if h.hypothesis_id == hid:
+                return h
+        return None
+
+    def approval(self, aid: str) -> ApprovalRequest | None:
+        for a in self.approvals:
+            if a.approval_id == aid:
+                return a
+        return None
+
+    def audit(self, actor: str, action: str, **detail: Any) -> None:
+        self.audit_log.append(AuditLogEntry(actor=actor, action=action, detail=detail))

--- a/mi_hub2/src/mi_hub/agent/roles.py
+++ b/mi_hub2/src/mi_hub/agent/roles.py
@@ -1,0 +1,270 @@
+"""専門エージェント群（指示書 §5）。
+
+MVP では物理的なマルチエージェント並列実行は行わず、論理的役割として分離する（§18）。
+各役割は SessionState と ToolGateway を受け取り、決定論的に動作する。
+LLM は候補生成にのみ使用される（llm モジュール経由）。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from . import llm
+from .errors import record_error, requires_human_review, try_auto_fix
+from .models import (
+    ApprovalRequest,
+    Evidence,
+    Hypothesis,
+    SessionState,
+    StepEvaluation,
+    Task,
+)
+from .states import HypothesisState, TaskState
+from .tools import ToolError, ToolGateway
+
+# 人間承認が必要な操作（§11.2）
+APPROVAL_REQUIRED_ACTIONS = {
+    "run_models_bulk",
+    "run_high_cost_model",
+    "submit_dft_job",
+    "calphad_large_search",
+    "external_api_call",
+    "send_confidential_data",
+    "register_model",
+    "update_model",
+    "adopt_hypothesis",
+    "falsify_hypothesis",
+    "register_knowledge_graph",
+    "operate_experiment_equipment",
+    "change_verification_conditions",
+    "change_falsification_conditions",
+}
+
+# 自動実行可能な操作（§11.1）
+AUTO_ALLOWED_ACTIONS = {
+    "search_literature",
+    "search_models",
+    "get_model_metadata",
+    "run_low_cost_model",
+    "validate_inputs",
+    "normalize_units",
+    "make_plots",
+    "aggregate_results",
+    "analyze_error",
+    "generate_next_actions",
+    "reuse_results",
+    "generate_hypotheses",
+    "evaluate_hypothesis",
+}
+
+
+class SafetyApprovalAgent:
+    """権限・コスト・承認状態の確認と禁止操作の遮断（§5.8）。
+
+    この判定は決定論的ルールで行い、他エージェントは上書きできない。
+    """
+
+    def check(self, state: SessionState, task: Task) -> tuple[bool, str]:
+        """(実行可, 理由) を返す。"""
+        if state.budget.exceeded():
+            return False, "計算予算上限に到達"
+        if task.action in APPROVAL_REQUIRED_ACTIONS or task.requires_approval:
+            approval = state.approval(task.approval_id) if task.approval_id else None
+            if approval is None or approval.status != "approved":
+                return False, "人間承認が必要（未承認）"
+        return True, "ok"
+
+    def request_approval(self, state: SessionState, task: Task, kind: str = "task_execution") -> ApprovalRequest:
+        req = ApprovalRequest(task_id=task.task_id, kind=kind, description=task.description)
+        state.approvals.append(req)
+        task.approval_id = req.approval_id
+        task.status = TaskState.AWAITING_APPROVAL
+        state.audit("SafetyApprovalAgent", "approval_requested",
+                    approval_id=req.approval_id, task_id=task.task_id)
+        return req
+
+
+class EvidenceAgent:
+    """文献・データベース検索と証拠抽出（§5.2）。"""
+
+    def run(self, state: SessionState, gateway: ToolGateway, task: Task) -> dict[str, Any]:
+        query = task.inputs.get("query") or (state.goal.statement if state.goal else "")
+        docs = gateway.search_literature(query)
+        added = []
+        for doc in docs:
+            ev = Evidence(
+                source_type=doc.get("source_type", "journal_article"),
+                claim=doc.get("claim", ""),
+                conditions=doc.get("conditions", {}),
+                evidence_type=doc.get("evidence_type", "experiment"),
+                limitations=doc.get("limitations", []),
+            )
+            state.evidence.append(ev)
+            added.append(ev.evidence_id)
+        task.result_ids = added
+        return {"evidence_ids": added, "count": len(added)}
+
+
+class HypothesisAgent:
+    """主仮説・対立仮説・反証条件案の生成（§5.3）。
+
+    反証条件は研究者承認後に固定される。
+    """
+
+    def run(self, state: SessionState, gateway: ToolGateway, task: Task) -> dict[str, Any]:
+        goal = state.goal.statement if state.goal else ""
+        claims = [e.claim for e in state.evidence]
+        candidates = llm.generate_hypotheses(goal, claims)
+        added = []
+        main_id: str | None = None
+        for c in candidates:
+            h = Hypothesis(
+                statement=c.get("statement", ""),
+                counter_to=main_id if c.get("is_counter") else None,
+                supporting_predictions=c.get("supporting_predictions", []),
+                falsification_conditions=c.get("falsification_conditions", []),
+                status=HypothesisState.PROPOSED,
+            )
+            state.hypotheses.append(h)
+            if not c.get("is_counter"):
+                main_id = h.hypothesis_id
+            added.append(h.hypothesis_id)
+        task.result_ids = added
+        return {"hypothesis_ids": added}
+
+
+class ModelSelectionAgent:
+    """MInt 登録モデルの検索と適用範囲確認（§5.4）。"""
+
+    def run(self, state: SessionState, gateway: ToolGateway, task: Task) -> dict[str, Any]:
+        goal = state.goal
+        prop = task.inputs.get("target_property") or (goal.target_property if goal else "")
+        elements = task.inputs.get("elements")
+        if not elements and goal and goal.target_material:
+            elements = [e for e in goal.target_material.replace("-", " ").split() if e]
+        phase = task.inputs.get("phase") or (goal.target_phase if goal else None)
+        models = gateway.search_models(prop or "", elements or [], phase)
+        recommended = [m.model_id for m in models]
+        excluded = [
+            {"model_id": m.model_id, "reason": "対象物性が不一致"}
+            for m in gateway.models
+            if m.model_id not in recommended
+        ]
+        groups = {m.independence_group for m in models}
+        result = {
+            "recommended_models": recommended,
+            "excluded_models": excluded,
+            "independent_series": len(groups),
+            "missing_model_types": [] if recommended else [prop],
+        }
+        task.result_ids = recommended
+        return result
+
+
+class VerificationPlanningAgent:
+    """検証タスクの分解と入力条件生成（§5.5）。"""
+
+    def run(self, state: SessionState, gateway: ToolGateway, task: Task) -> dict[str, Any]:
+        model_ids = task.inputs.get("model_ids", [])
+        compositions = task.inputs.get(
+            "compositions",
+            [{"Ni": 1 - x, "Al": x} for x in (0.48, 0.50, 0.52, 0.54)],
+        )
+        temperature = task.inputs.get("temperature", 800.0)
+        jobs = [
+            {"model_id": mid, "inputs": {"composition": c, "temperature": temperature,
+                                         "temperature_unit": "K"}}
+            for mid in model_ids
+            for c in compositions
+        ]
+        return {"jobs": jobs, "estimated_cost": len(jobs)}
+
+
+class ExecutionAgent:
+    """承認済みタスクの実行・再試行・エラー構造化（§5.6）。"""
+
+    def run(self, state: SessionState, gateway: ToolGateway, task: Task) -> dict[str, Any]:
+        jobs = task.inputs.get("jobs", [])
+        results: list[dict[str, Any]] = []
+        failures: list[dict[str, Any]] = []
+        max_retries = state.stop_conditions.max_retries_per_task
+        for job in jobs:
+            if state.budget.used_model_runs >= state.budget.max_model_runs:
+                failures.append({"job": job, "error": "budget exceeded"})
+                break
+            inputs = dict(job["inputs"])
+            attempt = 0
+            while True:
+                try:
+                    res = gateway.run_model(job["model_id"], inputs)
+                    state.budget.used_model_runs += 1
+                    results.append({"job": job, "result": res})
+                    break
+                except ToolError as exc:
+                    err = record_error(task.task_id, exc.message)
+                    state.errors.append(err)
+                    if requires_human_review(err.error_type):
+                        failures.append({"job": job, "error": exc.message,
+                                         "needs_human": True})
+                        break
+                    fixed = try_auto_fix(err.error_type, inputs)
+                    attempt += 1
+                    if fixed is None or attempt > max_retries:
+                        failures.append({"job": job, "error": exc.message,
+                                         "needs_human": fixed is None})
+                        break
+                    inputs = fixed
+                    err.resolved = True
+                    state.audit("ExecutionAgent", "auto_fix_retry",
+                                task_id=task.task_id, attempt=attempt,
+                                error_type=err.error_type.value)
+        task.retry_count = max(task.retry_count, 0)
+        return {"results": results, "failures": failures,
+                "n_success": len(results), "n_failed": len(failures)}
+
+
+class EvaluationAgent:
+    """モデル出力比較と仮説支持候補の整理（§5.7）。
+
+    最終的な科学的結論は自動確定しない（判定材料の整理まで）。
+    """
+
+    def run(self, state: SessionState, gateway: ToolGateway, task: Task) -> dict[str, Any]:
+        exec_results = task.inputs.get("results", [])
+        by_comp: dict[float, list[float]] = {}
+        for r in exec_results:
+            x_al = float(r["job"]["inputs"]["composition"].get("Al", 0.5))
+            by_comp.setdefault(x_al, []).append(float(r["result"]["prediction"]))
+        xs = sorted(by_comp)
+        means = [gateway.analyze(by_comp[x])["mean"] for x in xs]
+        slope = 0.0
+        if len(xs) >= 2:
+            n = len(xs)
+            mx, my = sum(xs) / n, sum(means) / n
+            denom = sum((x - mx) ** 2 for x in xs)
+            if denom > 0:
+                slope = sum((x - mx) * (y - my) for x, y in zip(xs, means)) / denom
+        stds = [gateway.analyze(by_comp[x])["std"] for x in xs]
+        mean_std = sum(stds) / len(stds) if stds else 0.0
+        verdict_candidate = "inconclusive"
+        if xs and abs(slope) > 3 * (mean_std + 1e-9):
+            verdict_candidate = "supported" if slope > 0 else "falsification_candidate"
+        for h in state.hypotheses:
+            if h.status == HypothesisState.APPROVED_FOR_TESTING:
+                h.status = HypothesisState.UNDER_EVALUATION
+        evaluation = StepEvaluation(
+            step_result="completed",
+            goal_progress_before=state.last_observation.goal_progress if state.last_observation else 0.0,
+            goal_progress_after=min(1.0, (state.last_observation.goal_progress if state.last_observation else 0.0) + 0.2),
+            hypotheses_affected=[h.hypothesis_id for h in state.hypotheses],
+            result_quality="acceptable" if exec_results else "insufficient",
+            requires_replanning=not exec_results,
+        )
+        state.evaluations.append(evaluation)
+        return {
+            "slope": slope,
+            "mean_uncertainty": mean_std,
+            "verdict_candidate": verdict_candidate,
+            "note": "最終判定は研究者が行う（Human-in-the-loop）",
+            "evaluation": evaluation.model_dump(),
+        }

--- a/mi_hub2/src/mi_hub/agent/states.py
+++ b/mi_hub2/src/mi_hub/agent/states.py
@@ -1,0 +1,86 @@
+"""状態定義（指示書 §6）。"""
+
+from enum import Enum
+
+
+class AgentState(str, Enum):
+    IDLE = "idle"
+    OBSERVING = "observing"
+    PLANNING = "planning"
+    AWAITING_HUMAN_INPUT = "awaiting_human_input"
+    AWAITING_APPROVAL = "awaiting_approval"
+    EXECUTING = "executing"
+    MONITORING = "monitoring"
+    EVALUATING = "evaluating"
+    REPLANNING = "replanning"
+    BLOCKED = "blocked"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    PAUSED = "paused"
+
+
+class TaskState(str, Enum):
+    PROPOSED = "proposed"
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+    PENDING = "pending"
+    READY = "ready"
+    AWAITING_APPROVAL = "awaiting_approval"
+    QUEUED = "queued"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    PARTIALLY_COMPLETED = "partially_completed"
+    BLOCKED = "blocked"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    SKIPPED = "skipped"
+
+
+class HypothesisState(str, Enum):
+    DRAFT = "draft"
+    PROPOSED = "proposed"
+    HUMAN_REVIEWED = "human_reviewed"
+    APPROVED_FOR_TESTING = "approved_for_testing"
+    UNDER_EVALUATION = "under_evaluation"
+    SUPPORTED = "supported"
+    FALSIFIED = "falsified"
+    CONDITIONALLY_SUPPORTED = "conditionally_supported"
+    INCONCLUSIVE = "inconclusive"
+    REJECTED_BY_HUMAN = "rejected_by_human"
+    ARCHIVED = "archived"
+
+
+class ErrorType(str, Enum):
+    VALIDATION_ERROR = "validation_error"
+    SCHEMA_MISMATCH = "schema_mismatch"
+    UNIT_MISMATCH = "unit_mismatch"
+    MISSING_INPUT = "missing_input"
+    MODEL_LOAD_ERROR = "model_load_error"
+    MODEL_RUNTIME_ERROR = "model_runtime_error"
+    OUT_OF_MEMORY = "out_of_memory"
+    TIMEOUT = "timeout"
+    PERMISSION_ERROR = "permission_error"
+    NETWORK_ERROR = "network_error"
+    EXTERNAL_SERVICE_ERROR = "external_service_error"
+    OUT_OF_DOMAIN = "out_of_domain"
+    PHYSICAL_CONSTRAINT_VIOLATION = "physical_constraint_violation"
+    UNKNOWN_ERROR = "unknown_error"
+
+
+# 自動修正可能なエラー種別（§9.2）
+AUTO_RECOVERABLE_ERRORS = {
+    ErrorType.UNIT_MISMATCH,
+    ErrorType.SCHEMA_MISMATCH,
+    ErrorType.NETWORK_ERROR,
+    ErrorType.TIMEOUT,
+}
+
+# 人間確認が必要なエラー種別（§9.3）
+HUMAN_REVIEW_ERRORS = {
+    ErrorType.OUT_OF_DOMAIN,
+    ErrorType.PERMISSION_ERROR,
+    ErrorType.PHYSICAL_CONSTRAINT_VIOLATION,
+    ErrorType.MISSING_INPUT,
+    ErrorType.UNKNOWN_ERROR,
+}

--- a/mi_hub2/src/mi_hub/agent/tools.py
+++ b/mi_hub2/src/mi_hub/agent/tools.py
@@ -1,0 +1,171 @@
+"""t2X／MCPゲートウェイのモック実装（指示書 §3）。
+
+実運用では MInt モデルレジストリ・推論サービス・GraphRAG・論文検索等の
+MCP エンドポイントへ差し替える。ここでは MVP 用に決定論的なモックを提供し、
+インターフェイス（ToolGateway）を固定する。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import random
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ModelInfo(BaseModel):
+    model_id: str
+    name: str
+    target_property: str
+    elements: list[str]
+    phase: str | None = None
+    composition_range: dict[str, list[float]] = Field(default_factory=dict)
+    temperature_range_K: list[float] = Field(default_factory=lambda: [300.0, 1500.0])
+    cost: str = "low"  # low / high
+    maturity: str = "validated"
+    independence_group: str = "GROUP-A"
+
+
+# モックの MInt モデルレジストリ
+MOCK_MODELS: list[ModelInfo] = [
+    ModelInfo(model_id="MINT-001", name="B2生成エンタルピーGBRT", target_property="formation_enthalpy",
+              elements=["Ni", "Al"], phase="B2", temperature_range_K=[300, 1200], cost="low",
+              independence_group="GROUP-A"),
+    ModelInfo(model_id="MINT-002", name="B2生成エンタルピーNN", target_property="formation_enthalpy",
+              elements=["Ni", "Al"], phase="B2", temperature_range_K=[300, 1000], cost="low",
+              independence_group="GROUP-B"),
+    ModelInfo(model_id="MINT-003", name="欠陥形成エネルギー回帰", target_property="defect_formation_energy",
+              elements=["Ni", "Al"], phase="B2", cost="low", independence_group="GROUP-A"),
+    ModelInfo(model_id="MINT-004", name="CALPHAD代理モデル", target_property="phase_stability",
+              elements=["Ni", "Al", "Cr"], phase=None, cost="high", independence_group="GROUP-C"),
+    ModelInfo(model_id="MINT-005", name="格子定数XGBoost", target_property="lattice_constant",
+              elements=["Ni", "Al", "Co", "Cr", "Fe"], phase="FCC", cost="low",
+              independence_group="GROUP-A"),
+]
+
+# モックの文献データベース
+MOCK_LITERATURE: list[dict[str, Any]] = [
+    {"title": "Point defects and order in B2 NiAl", "source_type": "journal_article",
+     "claim": "Al過剰側ではB2規則度が低下する", "evidence_type": "experiment",
+     "conditions": {"temperature_K": 1200, "composition_range": {"Al": [0.50, 0.58]}},
+     "keywords": ["antisite", "B2", "NiAl", "アンチサイト", "規則度"],
+     "limitations": ["欠陥種を直接測定していない"]},
+    {"title": "First-principles study of antisite defects in NiAl", "source_type": "journal_article",
+     "claim": "Alアンチサイトの形成エネルギーはNi空孔より高い", "evidence_type": "computation",
+     "conditions": {"temperature_K": 0}, "keywords": ["antisite", "DFT", "NiAl", "vacancy"],
+     "limitations": ["0Kでの計算のみ"]},
+    {"title": "Thermodynamic assessment of the Ni-Al system", "source_type": "journal_article",
+     "claim": "B2相はNi過剰側で広い安定領域を持つ", "evidence_type": "assessment",
+     "conditions": {"composition_range": {"Al": [0.40, 0.55]}},
+     "keywords": ["CALPHAD", "NiAl", "phase diagram", "B2", "安定"],
+     "limitations": ["欠陥機構は含まない"]},
+]
+
+
+class ToolError(Exception):
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.message = message
+
+
+class ToolGateway:
+    """MCPゲートウェイのインターフェイス兼モック実装。"""
+
+    def __init__(self, fail_next: str | None = None):
+        self.models = list(MOCK_MODELS)
+        self.literature = list(MOCK_LITERATURE)
+        self._fail_next = fail_next  # テスト用: 次回呼出しを指定エラーで失敗させる
+        self.call_log: list[dict[str, Any]] = []
+
+    def _maybe_fail(self, tool: str) -> None:
+        if self._fail_next:
+            msg = self._fail_next
+            self._fail_next = None
+            raise ToolError(msg)
+
+    def inject_failure(self, message: str) -> None:
+        self._fail_next = message
+
+    # --- t2LiteratureQuery ---
+    def search_literature(self, query: str, limit: int = 10) -> list[dict[str, Any]]:
+        self._maybe_fail("search_literature")
+        self.call_log.append({"tool": "search_literature", "query": query})
+        terms = [w for w in query.replace("、", " ").split() if w]
+        hits = []
+        for doc in self.literature:
+            text = doc["title"] + " " + doc["claim"] + " " + " ".join(doc["keywords"])
+            score = sum(1 for t in terms if t.lower() in text.lower())
+            if score > 0:
+                hits.append((score, doc))
+        hits.sort(key=lambda x: -x[0])
+        return [d for _, d in hits[:limit]]
+
+    # --- t2ModelQuery ---
+    def search_models(self, target_property: str, elements: list[str],
+                      phase: str | None = None) -> list[ModelInfo]:
+        self._maybe_fail("search_models")
+        self.call_log.append({"tool": "search_models", "property": target_property})
+        out = []
+        for m in self.models:
+            if m.target_property != target_property:
+                continue
+            if not set(elements) <= set(m.elements):
+                continue
+            if phase and m.phase and m.phase != phase:
+                continue
+            out.append(m)
+        return out
+
+    def get_model(self, model_id: str) -> ModelInfo | None:
+        for m in self.models:
+            if m.model_id == model_id:
+                return m
+        return None
+
+    # --- t2PredictionJob ---
+    def run_model(self, model_id: str, inputs: dict[str, Any]) -> dict[str, Any]:
+        """モック推論。決定論的（入力ハッシュのシードで再現可能）。"""
+        self._maybe_fail("run_model")
+        self.call_log.append({"tool": "run_model", "model_id": model_id, "inputs": inputs})
+        model = self.get_model(model_id)
+        if model is None:
+            raise ToolError(f"model_load_error: model {model_id} not found")
+        if "composition" not in inputs:
+            raise ToolError("missing input: composition")
+        temp = inputs.get("temperature")
+        unit = str(inputs.get("temperature_unit", "K"))
+        if unit.strip().lower() != "k":
+            raise ToolError(f"unit mismatch: temperature unit {unit} is not K")
+        if temp is not None and model.temperature_range_K:
+            lo, hi = model.temperature_range_K
+            if not (lo <= float(temp) <= hi):
+                raise ToolError(
+                    f"out of domain: temperature {temp} K outside model range [{lo}, {hi}]"
+                )
+        seed = int(hashlib.md5(
+            f"{model_id}:{sorted(inputs.items())!r}".encode()).hexdigest()[:8], 16)
+        rng = random.Random(seed)
+        comp = inputs["composition"]
+        x_al = float(comp.get("Al", 0.5))
+        # Alアンチサイト仮説と整合するモック傾向: Al過剰で生成エンタルピー上昇（不安定化）
+        base = -0.62 + 1.8 * max(0.0, x_al - 0.5)
+        value = base + rng.gauss(0, 0.02)
+        return {
+            "model_id": model_id,
+            "prediction": round(value, 4),
+            "unit": "eV/atom",
+            "uncertainty": round(abs(rng.gauss(0.03, 0.01)), 4),
+            "in_domain": True,
+            "independence_group": model.independence_group,
+        }
+
+    # --- t2Python（統計評価） ---
+    def analyze(self, values: list[float]) -> dict[str, float]:
+        self._maybe_fail("analyze")
+        if not values:
+            return {"n": 0, "mean": 0.0, "std": 0.0}
+        n = len(values)
+        mean = sum(values) / n
+        var = sum((v - mean) ** 2 for v in values) / max(1, n - 1)
+        return {"n": n, "mean": mean, "std": var ** 0.5}

--- a/mi_hub2/src/mi_hub/agent/ui_streamlit.py
+++ b/mi_hub2/src/mi_hub/agent/ui_streamlit.py
@@ -1,0 +1,182 @@
+"""チャットUI + Agentタブ（指示書 §13）。
+
+起動:  streamlit run src/mi_hub/agent/ui_streamlit.py
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import streamlit as st
+
+from mi_hub.agent.loop import ResearchManager
+from mi_hub.agent.models import SessionState
+from mi_hub.agent.states import HypothesisState
+
+st.set_page_config(page_title="MI-HUB2 研究エージェント", layout="wide")
+
+
+@st.cache_resource
+def get_manager() -> ResearchManager:
+    return ResearchManager()
+
+
+m = get_manager()
+
+st.title("MI-HUB2 pinax2.0-pilot 研究エージェント")
+
+# --- セッション選択 / 作成 ---
+with st.sidebar:
+    st.header("研究セッション")
+    sessions = m.store.list_sessions()
+    selected = st.selectbox("既存セッション", ["(新規)"] + sessions)
+    goal_text = st.text_area(
+        "研究目標",
+        "Ni-Al B2相において、Alアンチサイトが相安定性低下の主要因であるか、"
+        "登録済みモデル群を用いて検証する。",
+    )
+    if st.button("セッション開始", type="primary"):
+        state = m.create_session(goal_text)
+        m.generate_plan(state)
+        st.session_state["sid"] = state.session_id
+        st.rerun()
+    if selected != "(新規)":
+        st.session_state["sid"] = selected
+
+sid = st.session_state.get("sid")
+if not sid:
+    st.info("左のサイドバーから研究セッションを開始してください。")
+    st.stop()
+
+state: SessionState | None = m.store.load(sid)
+if state is None:
+    st.error(f"セッションが見つかりません: {sid}")
+    st.stop()
+
+chat_col, agent_col = st.columns([3, 2])
+
+with chat_col:
+    st.subheader("チャット")
+    for msg in state.chat_history:
+        with st.chat_message(msg["role"]):
+            st.markdown(msg["content"])
+    user_msg = st.chat_input("メッセージを入力（例: 実行を続けて / 一時停止 / 終了）")
+    if user_msg:
+        state.chat_history.append({"role": "user", "content": user_msg})
+        if "一時停止" in user_msg:
+            m.pause(state)
+            reply = "セッションを一時停止しました。"
+        elif "再開" in user_msg:
+            m.resume(state)
+            reply = "セッションを再開しました。"
+        elif "終了" in user_msg:
+            m.complete(state)
+            reply = "セッションを終了しました。"
+        else:
+            result = m.run_auto(state)
+            n = len(result["executed"])
+            reply = (
+                f"{n} 件のタスクを実行しました。現在の状態: {result['agent_state']}"
+                + (f"（{result['stop_reason']}）" if result["stop_reason"] else "")
+            )
+            if state.agent_state.value == "awaiting_approval":
+                reply += "\n\n承認待ちの操作があります。Agentタブで承認してください。"
+        state.chat_history.append({"role": "assistant", "content": reply})
+        m.store.save(state)
+        st.rerun()
+
+with agent_col:
+    st.subheader("Agent")
+    obs = m.observe(state)
+    m.store.save(state)
+    c1, c2, c3 = st.columns(3)
+    c1.metric("状態", state.agent_state.value)
+    c2.metric("進捗", f"{obs.goal_progress:.0%}")
+    c3.metric("残り反復", obs.iterations_remaining)
+    c1.metric("適用可能モデル", f"{obs.applicable_models}/{obs.available_models}")
+    c2.metric("残り実行予算", obs.budget_remaining_runs)
+    c3.metric("証拠数", obs.evidence_count)
+    if state.stop_reason:
+        st.warning(f"停止理由: {state.stop_reason}")
+
+    tabs = st.tabs(["計画", "仮説", "承認", "証拠", "エラー", "履歴"])
+
+    with tabs[0]:
+        if state.plan:
+            st.caption(
+                f"plan {state.plan.plan_id} v{state.plan.version}"
+                f"（変更理由: {state.plan.reason_for_change}）"
+            )
+            df = pd.DataFrame(
+                [
+                    {
+                        "task": t.task_id,
+                        "agent": t.agent,
+                        "action": t.action,
+                        "状態": t.status.value,
+                        "依存": ",".join(t.depends_on),
+                        "承認要": "要" if t.requires_approval else "-",
+                        "説明": t.description,
+                    }
+                    for t in state.plan.tasks
+                ]
+            )
+            st.dataframe(df, use_container_width=True, hide_index=True)
+            for a in m.next_actions(state):
+                label = f"実行: {a['action']} ({a['task_id']})"
+                if st.button(label, key=f"run-{a['task_id']}"):
+                    m.execute_task(state, a["task_id"])
+                    st.rerun()
+        else:
+            if st.button("計画を生成"):
+                m.generate_plan(state)
+                st.rerun()
+
+    with tabs[1]:
+        for h in state.hypotheses:
+            with st.expander(f"{h.hypothesis_id}: {h.statement[:40]}"):
+                st.write("状態:", h.status.value)
+                st.write("反証条件:", h.falsification_conditions)
+                st.write("反証条件承認済:", h.falsification_approved)
+                cols = st.columns(2)
+                if cols[0].button("検証承認", key=f"appr-{h.hypothesis_id}"):
+                    m.set_hypothesis_status(
+                        state, h.hypothesis_id, HypothesisState.APPROVED_FOR_TESTING
+                    )
+                    st.rerun()
+                if cols[1].button("却下", key=f"rej-{h.hypothesis_id}"):
+                    m.set_hypothesis_status(
+                        state, h.hypothesis_id, HypothesisState.REJECTED_BY_HUMAN
+                    )
+                    st.rerun()
+
+    with tabs[2]:
+        pending = [a for a in state.approvals if a.status == "pending"]
+        if not pending:
+            st.caption("承認待ちはありません。")
+        for a in pending:
+            st.write(f"{a.approval_id}: {a.description}（task: {a.task_id}）")
+            cols = st.columns(2)
+            if cols[0].button("承認", key=f"ok-{a.approval_id}"):
+                m.resolve_approval(state, a.approval_id, True)
+                st.rerun()
+            if cols[1].button("却下", key=f"ng-{a.approval_id}"):
+                m.resolve_approval(state, a.approval_id, False)
+                st.rerun()
+
+    with tabs[3]:
+        for e in state.evidence:
+            st.write(f"- **{e.evidence_id}** [{e.evidence_type}] {e.claim}")
+
+    with tabs[4]:
+        for err in state.errors:
+            st.write(
+                f"- {err.error_type.value}: {err.message}"
+                f"（{'解決済' if err.resolved else '未解決'}）"
+            )
+
+    with tabs[5]:
+        for c in state.plan_history:
+            st.write(
+                f"- v{c.version} by {c.created_by}: {c.reason_for_change} "
+                f"(+{len(c.added_tasks)} / -{len(c.removed_tasks)})"
+            )

--- a/mi_hub2/src/mi_hub/automl.py
+++ b/mi_hub2/src/mi_hub/automl.py
@@ -1,0 +1,70 @@
+"""mi_hub.automl — FLAML ベースの AutoML ラッパー(Phase 4)。
+
+方針:
+  - まず FLAML(依存が軽い)。AutoGluon は別 conda 環境で必要時のみ。
+  - 学習は必ず tracking.track() の中で行い、best config / CV 指標 /
+    ホールドアウト指標 / モデル本体 を MLflow に残す。
+  - 特徴量は datastore の kind (例 "hea_features") か Feast の
+    get_historical_features() 出力をそのまま渡せる。
+
+使用例:
+    from mi_hub import automl, datastore as ds
+    df = ds.load("hea_features")
+    res = automl.fit_baseline(df, target="yield_strength",
+                              task="regression", time_budget=120,
+                              drop=ds.PROVENANCE_COLS)
+    print(res["holdout_metrics"], res["best_estimator"])
+"""
+from __future__ import annotations
+
+import pandas as pd
+
+from . import datastore as ds
+from . import tracking as tr
+
+
+def fit_baseline(df: pd.DataFrame, *, target: str, task: str = "regression",
+                 time_budget: int = 60, test_size: float = 0.2,
+                 drop: list[str] | None = None, experiment: str = "automl",
+                 seed: int = 0) -> dict:
+    try:
+        from flaml import AutoML
+    except ImportError as e:
+        raise ImportError("pip install 'flaml[automl]' が必要です。") from e
+    from sklearn.metrics import mean_absolute_error, r2_score, accuracy_score
+    from sklearn.model_selection import train_test_split
+
+    drop = [c for c in (drop or []) if c in df.columns]
+    X = df.drop(columns=drop + [target]).select_dtypes("number")
+    y = df[target]
+    X_tr, X_te, y_tr, y_te = train_test_split(X, y, test_size=test_size, random_state=seed)
+
+    rid = ds.new_run_id()
+    with tr.track(experiment, run_id=rid,
+                  params={"target": target, "task": task,
+                          "time_budget": time_budget, "n_features": X.shape[1],
+                          "n_train": len(X_tr)}):
+        # FLAML 自身の MLflow 自動ロギングは skops 直列化で失敗しやすく、
+        # 記録は mi_hub 側で一元化するため無効にする。
+        am = AutoML(mlflow_logging=False)
+        am.fit(X_tr, y_tr, task=task, time_budget=time_budget, seed=seed,
+               verbose=0, mlflow_logging=False)
+        pred = am.predict(X_te)
+        if task == "regression":
+            metrics = {"mae": mean_absolute_error(y_te, pred),
+                       "r2": r2_score(y_te, pred)}
+        else:
+            metrics = {"accuracy": accuracy_score(y_te, pred)}
+        tr.log_metrics(metrics)
+        import mlflow
+        mlflow.log_params({"best_estimator": am.best_estimator})
+        mlflow.sklearn.log_model(am.model, name="model",
+                                 serialization_format="cloudpickle")
+        pred_df = X_te.copy()
+        pred_df[target] = y_te.values
+        pred_df["prediction"] = pred
+        ds.save(pred_df, "predictions", run_id=rid, source="flaml")
+        tr.log_table(pred_df, "holdout_predictions.parquet")
+
+    return {"run_id": rid, "best_estimator": am.best_estimator,
+            "best_config": am.best_config, "holdout_metrics": metrics}

--- a/mi_hub2/src/mi_hub/datastore.py
+++ b/mi_hub2/src/mi_hub/datastore.py
@@ -1,0 +1,83 @@
+"""mi_hub.datastore — 統合環境の共通データ層。
+
+規約:
+  - 全ツール間の受け渡しは parquet に統一(pandas + pyarrow)。
+  - 全レコードに provenance 列を強制付与:
+      run_id      : UUID4。MLflow run と 1:1 対応させる
+      created_at  : UTC ISO8601
+      source      : 生成元 ("tc_python" | "optimat" | "dft" | "manual" | ...)
+      code_ver    : スクリプト側が渡すバージョン文字列(git hash 推奨)
+  - 保存先は MI_HUB_DATA (env) 直下の kind 別ディレクトリ:
+      data/<kind>/<run_id>.parquet
+    kind 例: "ternary_sections", "hea_features", "optimat_snapshot", "predictions"
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+
+PROVENANCE_COLS = ["run_id", "created_at", "source", "code_ver"]
+
+
+def data_root() -> Path:
+    root = Path(os.environ.get("MI_HUB_DATA", Path.home() / "mi_hub_data"))
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def new_run_id() -> str:
+    return str(uuid.uuid4())
+
+
+def stamp(df: pd.DataFrame, *, run_id: str, source: str, code_ver: str = "unknown") -> pd.DataFrame:
+    """provenance 列を付与した新しい DataFrame を返す。"""
+    out = df.copy()
+    out["run_id"] = run_id
+    out["created_at"] = datetime.now(timezone.utc).isoformat()
+    out["source"] = source
+    out["code_ver"] = code_ver
+    return out
+
+
+def save(df: pd.DataFrame, kind: str, *, run_id: str | None = None,
+         source: str = "manual", code_ver: str = "unknown") -> Path:
+    """provenance を付与して data/<kind>/<run_id>.parquet に保存し、パスを返す。"""
+    run_id = run_id or new_run_id()
+    if not set(PROVENANCE_COLS).issubset(df.columns):
+        df = stamp(df, run_id=run_id, source=source, code_ver=code_ver)
+    d = data_root() / kind
+    d.mkdir(parents=True, exist_ok=True)
+    path = d / f"{run_id}.parquet"
+    df.to_parquet(path, index=False)
+    return path
+
+
+def load(kind: str, *, run_id: str | None = None) -> pd.DataFrame:
+    """kind 配下を全結合して返す。run_id 指定時は単一ファイル。"""
+    d = data_root() / kind
+    if run_id:
+        return pd.read_parquet(d / f"{run_id}.parquet")
+    files = sorted(d.glob("*.parquet"))
+    if not files:
+        raise FileNotFoundError(f"no parquet under {d}")
+    return pd.concat([pd.read_parquet(f) for f in files], ignore_index=True)
+
+
+def catalog() -> pd.DataFrame:
+    """全 kind の在庫一覧(kind, ファイル数, 最終更新)。"""
+    rows = []
+    for d in sorted(p for p in data_root().iterdir() if p.is_dir()):
+        files = list(d.glob("*.parquet"))
+        if files:
+            rows.append({
+                "kind": d.name,
+                "n_files": len(files),
+                "last_modified": datetime.fromtimestamp(
+                    max(f.stat().st_mtime for f in files), tz=timezone.utc
+                ).isoformat(),
+            })
+    return pd.DataFrame(rows)

--- a/mi_hub2/src/mi_hub/optimat_bridge.py
+++ b/mi_hub2/src/mi_hub/optimat_bridge.py
@@ -1,0 +1,84 @@
+"""mi_hub.optimat_bridge — OptiMat Alloys living DB の読み取りブリッジ。
+
+前提:
+  - OptiMat Alloys コンテナの DB ディレクトリをホスト側にボリュームマウントし、
+    そのパスを env MI_HUB_OPTIMAT_DB で指す(setup/phase2_optimat 参照)。
+  - living DB は UUID インデックス + provenance 付きで、実装上は
+    SQLite / JSON ファイル群のいずれかが想定される。公開イメージの
+    実スキーマはバージョン依存のため、本モジュールは
+      (1) SQLite があれば全テーブルを吸い上げ
+      (2) なければ JSON/JSONL を再帰走査してフラット化
+    する汎用スナップショット取得に徹する。列名の正規化は取得後に
+    ノートブック側(runcell に任せると速い)で行う設計。
+
+使用例:
+    from mi_hub import optimat_bridge as ob, datastore as ds
+    snap = ob.snapshot()                      # {name: DataFrame}
+    for name, df in snap.items():
+        ds.save(df, f"optimat_{name}", source="optimat")
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+import pandas as pd
+
+
+def db_root() -> Path:
+    p = os.environ.get("MI_HUB_OPTIMAT_DB")
+    if not p:
+        raise EnvironmentError(
+            "MI_HUB_OPTIMAT_DB が未設定です。OptiMat コンテナの DB ボリューム"
+            "のホスト側パスを指定してください(例: /data/optimat_db)。")
+    return Path(p)
+
+
+def _sqlite_tables(path: Path) -> dict[str, pd.DataFrame]:
+    con = sqlite3.connect(path)
+    try:
+        names = [r[0] for r in con.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'")]
+        return {n: pd.read_sql_query(f"SELECT * FROM '{n}'", con) for n in names}
+    finally:
+        con.close()
+
+
+def _json_records(root: Path) -> pd.DataFrame:
+    rows = []
+    for f in root.rglob("*.json*"):
+        try:
+            text = f.read_text(encoding="utf-8")
+            if f.suffix == ".jsonl":
+                objs = [json.loads(line) for line in text.splitlines() if line.strip()]
+            else:
+                obj = json.loads(text)
+                objs = obj if isinstance(obj, list) else [obj]
+            for o in objs:
+                if isinstance(o, dict):
+                    o["_file"] = str(f.relative_to(root))
+                    rows.append(o)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+    return pd.json_normalize(rows) if rows else pd.DataFrame()
+
+
+def snapshot() -> dict[str, pd.DataFrame]:
+    """living DB の現在状態を {name: DataFrame} で返す。"""
+    root = db_root()
+    out: dict[str, pd.DataFrame] = {}
+    for db in root.rglob("*.db"):
+        for tname, df in _sqlite_tables(db).items():
+            out[f"{db.stem}__{tname}"] = df
+    for db in root.rglob("*.sqlite*"):
+        for tname, df in _sqlite_tables(db).items():
+            out[f"{db.stem}__{tname}"] = df
+    if not out:
+        df = _json_records(root)
+        if not df.empty:
+            out["json_records"] = df
+    if not out:
+        raise FileNotFoundError(f"{root} に SQLite / JSON が見つかりません。")
+    return out

--- a/mi_hub2/src/mi_hub/tracking.py
+++ b/mi_hub2/src/mi_hub/tracking.py
@@ -1,0 +1,73 @@
+"""mi_hub.tracking — MLflow 記録層。
+
+方針:
+  - tracking URI は env MI_HUB_MLFLOW (既定 sqlite:///<data_root>/mlflow.db)。
+  - datastore.save() で書いた parquet をそのまま artifact 化し、
+    run_id を MLflow の tag "mi_hub.run_id" に載せて相互参照する。
+  - TC-Python / OptiMat / AutoML のどの出力も同じ流儀で記録する。
+
+使用例:
+    from mi_hub import datastore as ds, tracking as tr
+
+    rid = ds.new_run_id()
+    with tr.track("ternary_sections", run_id=rid,
+                  params={"database": "TCHEA7", "T": 1273}) as run:
+        df = compute_something()
+        path = ds.save(df, "ternary_sections", run_id=rid, source="tc_python")
+        tr.log_table(df, "section.parquet")
+        tr.log_metrics({"n_points": len(df)})
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+
+import mlflow
+import pandas as pd
+
+from . import datastore as ds
+
+
+def tracking_uri() -> str:
+    return os.environ.get("MI_HUB_MLFLOW", f"sqlite:///{ds.data_root() / 'mlflow.db'}")
+
+
+def _setup(experiment: str) -> None:
+    mlflow.set_tracking_uri(tracking_uri())
+    mlflow.set_experiment(experiment)
+
+
+@contextmanager
+def track(experiment: str, *, run_id: str | None = None,
+          params: dict | None = None, tags: dict | None = None):
+    """MLflow run を開き、mi_hub.run_id タグで datastore と紐づける。"""
+    _setup(experiment)
+    run_id = run_id or ds.new_run_id()
+    all_tags = {"mi_hub.run_id": run_id, **(tags or {})}
+    with mlflow.start_run(tags=all_tags) as run:
+        if params:
+            mlflow.log_params(params)
+        yield run
+
+
+def log_table(df: pd.DataFrame, name: str = "table.parquet") -> None:
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / name
+        df.to_parquet(p, index=False)
+        mlflow.log_artifact(str(p))
+
+
+def log_metrics(metrics: dict) -> None:
+    mlflow.log_metrics({k: float(v) for k, v in metrics.items()})
+
+
+def log_file(path: str | Path) -> None:
+    mlflow.log_artifact(str(path))
+
+
+def runs(experiment: str) -> pd.DataFrame:
+    """実験の全 run を DataFrame で返す(pygwalker でそのまま可視化可)。"""
+    _setup(experiment)
+    return mlflow.search_runs(search_all_experiments=False)

--- a/mi_hub2/tests/test_agent_acceptance.py
+++ b/mi_hub2/tests/test_agent_acceptance.py
@@ -1,0 +1,274 @@
+"""受入試験（指示書 §19）。"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from mi_hub.agent.errors import classify_error, convert_unit, try_auto_fix
+from mi_hub.agent.loop import ResearchManager, SessionStore
+from mi_hub.agent.models import Task
+from mi_hub.agent.states import (
+    AgentState,
+    ErrorType,
+    HypothesisState,
+    TaskState,
+)
+from mi_hub.agent.tools import ToolGateway
+
+GOAL = (
+    "Ni-Al B2相において、Alアンチサイトが相安定性低下の主要因であるか、"
+    "登録済みモデル群を用いて検証する。"
+)
+
+
+@pytest.fixture()
+def manager(tmp_path):
+    return ResearchManager(gateway=ToolGateway(), store=SessionStore(str(tmp_path)))
+
+
+@pytest.fixture()
+def session(manager):
+    state = manager.create_session(GOAL)
+    manager.generate_plan(state)
+    return state
+
+
+# ---------- §19.1 計画機能 ----------
+class TestPlanning:
+    def test_plan_generated_from_goal(self, manager, session):
+        assert session.plan is not None
+        assert session.plan.goal_id == session.goal.goal_id
+
+    def test_plan_decomposed_into_tasks(self, session):
+        assert len(session.plan.tasks) >= 3
+
+    def test_task_dependencies_stored(self, session):
+        deps = [t for t in session.plan.tasks if t.depends_on]
+        assert deps, "依存関係を持つタスクが存在する"
+
+    def test_human_can_edit_plan(self, manager, session):
+        new_task = Task(agent="EvidenceAgent", action="search_literature",
+                        description="追加の文献検索")
+        manager.apply_plan_change(session, created_by="human", reason="人間による追加",
+                                  add_tasks=[new_task])
+        assert session.plan.task(new_task.task_id) is not None
+        manager.apply_plan_change(session, created_by="human", reason="人間による削除",
+                                  remove_task_ids=[new_task.task_id])
+        assert session.plan.task(new_task.task_id) is None
+
+    def test_plan_change_history_recorded(self, manager, session):
+        v0 = session.plan.version
+        manager.apply_plan_change(session, created_by="human", reason="編集",
+                                  add_tasks=[Task(action="search_literature",
+                                                  agent="EvidenceAgent")])
+        assert session.plan.version == v0 + 1
+        last = session.plan_history[-1]
+        assert last.reason_for_change == "編集"
+        assert last.previous_plan_version == v0
+        assert last.human_approval
+
+
+# ---------- §19.2 Observe–Act機能 ----------
+class TestObserveAct:
+    def test_result_reflected_in_state(self, manager, session):
+        t1 = session.plan.tasks[0]
+        res = manager.execute_task(session, t1.task_id)
+        assert res["status"] == "completed"
+        assert session.evidence, "証拠が状態へ反映される"
+        obs = manager.observe(session)
+        assert t1.task_id in obs.completed_tasks
+
+    def test_success_failure_distinguished(self, manager, session):
+        t1 = session.plan.tasks[0]
+        assert manager.execute_task(session, t1.task_id)["status"] == "completed"
+        manager.gateway.inject_failure("unknown catastrophic failure")
+        t2 = session.plan.ready_tasks()[0]
+        # EvidenceAgent 以外の役割はツール例外を FAILED として記録する
+        res2 = manager.execute_task(session, t2.task_id)
+        assert res2["status"] in ("completed", "failed")
+
+    def test_next_actions_generated(self, manager, session):
+        actions = manager.next_actions(session)
+        assert actions and actions[0]["action"] == "search_literature"
+
+    def test_replanning_updates_plan(self, manager, session):
+        v0 = session.plan.version
+        manager.apply_plan_change(session, created_by="agent",
+                                  reason="モデル不足のため代理物性検索を追加",
+                                  add_tasks=[Task(agent="ModelSelectionAgent",
+                                                  action="search_models",
+                                                  description="代理物性モデル検索")])
+        assert session.plan.version == v0 + 1
+
+
+# ---------- §19.3 エラー回復 ----------
+class TestErrorRecovery:
+    def test_unit_error_auto_fixed(self):
+        assert classify_error("unit mismatch: temperature unit C is not K") \
+            == ErrorType.UNIT_MISMATCH
+        fixed = try_auto_fix(ErrorType.UNIT_MISMATCH,
+                             {"temperature": 527.0, "temperature_unit": "C",
+                              "composition": {"Al": 0.5}})
+        assert fixed is not None
+        assert fixed["temperature"] == pytest.approx(800.15)
+        assert fixed["temperature_unit"] == "K"
+
+    def test_unit_conversion_rules(self):
+        assert convert_unit(0.0, "C", "K") == pytest.approx(273.15)
+        with pytest.raises(ValueError):
+            convert_unit(1.0, "furlong", "K")
+
+    def test_transient_network_error_retry(self):
+        fixed = try_auto_fix(ErrorType.NETWORK_ERROR, {"composition": {"Al": 0.5}})
+        assert fixed == {"composition": {"Al": 0.5}}
+
+    def test_semantic_change_requires_human(self):
+        # 意味変更を伴う修正（適用範囲外・入力欠落）は自動修正しない
+        assert try_auto_fix(ErrorType.OUT_OF_DOMAIN, {"temperature": 2000}) is None
+        assert try_auto_fix(ErrorType.MISSING_INPUT, {}) is None
+
+    def test_retry_limit_stops(self, manager, session):
+        session.stop_conditions.max_retries_per_task = 1
+        # 実行フローを run_models_bulk まで進める
+        self._advance_to_execution(manager, session)
+        exec_task = next(t for t in session.plan.tasks if t.action == "run_models_bulk")
+        # OOD ジョブ（人間確認要）を混ぜる
+        exec_task.inputs["jobs"] = [
+            {"model_id": "MINT-001",
+             "inputs": {"composition": {"Al": 0.5}, "temperature": 5000,
+                        "temperature_unit": "K"}},
+        ]
+        res = manager.execute_task(session, exec_task.task_id)
+        assert res["result"]["n_failed"] == 1
+        assert res["result"]["failures"][0]["needs_human"]
+
+    @staticmethod
+    def _advance_to_execution(manager, session):
+        for _ in range(4):
+            actions = manager.next_actions(session)
+            runnable = [a for a in actions if not a["requires_approval"]]
+            if not runnable:
+                break
+            manager.execute_task(session, runnable[0]["task_id"])
+        exec_task = next(t for t in session.plan.tasks if t.action == "run_models_bulk")
+        manager.execute_task(session, exec_task.task_id)  # 承認要求を生成
+        approval = session.approvals[-1]
+        manager.resolve_approval(session, approval.approval_id, True)
+
+
+# ---------- §19.4 停止機能 ----------
+class TestStopping:
+    def test_iteration_limit_stops(self, manager, session):
+        session.stop_conditions.max_iterations = 1
+        t1 = session.plan.tasks[0]
+        manager.execute_task(session, t1.task_id)
+        assert session.stop_reason is not None
+        assert "反復回数上限" in session.stop_reason
+
+    def test_budget_limit_stops(self, manager, session):
+        session.budget.max_model_runs = 0
+        result = manager.run_auto(session)
+        assert session.budget.used_model_runs == 0
+        assert result["agent_state"] in ("blocked", "awaiting_approval", "replanning",
+                                         "evaluating")
+
+    def test_pause_on_human_decision(self, manager, session):
+        result = manager.run_auto(session)
+        # 承認要タスク（run_models_bulk）で一時停止する
+        assert any(r["status"] == "awaiting_approval" for r in result["executed"])
+        assert session.agent_state == AgentState.AWAITING_APPROVAL
+
+    def test_manual_pause(self, manager, session):
+        manager.pause(session)
+        assert session.agent_state == AgentState.PAUSED
+        res = manager.execute_task(session, session.plan.tasks[0].task_id)
+        assert res["status"] == "paused"
+
+    def test_resume_after_pause_preserves_state(self, manager, session):
+        t1 = session.plan.tasks[0]
+        manager.execute_task(session, t1.task_id)
+        n_evidence = len(session.evidence)
+        manager.pause(session)
+        reloaded = manager.store.load(session.session_id)
+        assert reloaded.agent_state == AgentState.PAUSED
+        assert len(reloaded.evidence) == n_evidence
+        manager.resume(reloaded)
+        assert reloaded.agent_state != AgentState.PAUSED
+
+
+# ---------- §19.5 Human-in-the-loop ----------
+class TestHumanInTheLoop:
+    def test_unapproved_high_cost_blocked(self, manager, session):
+        exec_task = next(t for t in session.plan.tasks if t.action == "run_models_bulk")
+        exec_task.depends_on = []  # 依存を外して直接実行を試みる
+        res = manager.execute_task(session, exec_task.task_id)
+        assert res["status"] == "awaiting_approval"
+        assert exec_task.status == TaskState.AWAITING_APPROVAL
+
+    def test_approval_then_execution(self, manager, session):
+        result = manager.run_auto(session)
+        approval = next(a for a in session.approvals if a.status == "pending")
+        manager.resolve_approval(session, approval.approval_id, True)
+        manager.run_auto(session)
+        exec_task = next(t for t in session.plan.tasks if t.action == "run_models_bulk")
+        assert exec_task.status in (TaskState.COMPLETED, TaskState.PARTIALLY_COMPLETED)
+        assert session.budget.used_model_runs > 0
+
+    def test_rejection_blocks_task(self, manager, session):
+        manager.run_auto(session)
+        approval = next(a for a in session.approvals if a.status == "pending")
+        manager.resolve_approval(session, approval.approval_id, False)
+        exec_task = next(t for t in session.plan.tasks if t.action == "run_models_bulk")
+        assert exec_task.status == TaskState.REJECTED
+
+    def test_human_edits_hypothesis(self, manager, session):
+        manager.run_auto(session)
+        h = session.hypotheses[0]
+        manager.set_hypothesis_status(session, h.hypothesis_id,
+                                      HypothesisState.APPROVED_FOR_TESTING)
+        assert h.status == HypothesisState.APPROVED_FOR_TESTING
+        assert h.falsification_approved
+
+    def test_falsification_change_requires_human(self, manager, session):
+        manager.run_auto(session)
+        h = session.hypotheses[0]
+        with pytest.raises(PermissionError):
+            manager.update_falsification_conditions(
+                session, h.hypothesis_id, ["新条件"], by="agent")
+        manager.update_falsification_conditions(
+            session, h.hypothesis_id, ["新条件"], by="human")
+        assert h.falsification_conditions == ["新条件"]
+        entry = session.audit_log[-1]
+        assert entry.action == "falsification_conditions_changed"
+        assert "before" in entry.detail and "after" in entry.detail
+
+    def test_replan_after_human_change(self, manager, session):
+        v0 = session.plan.version
+        manager.apply_plan_change(session, created_by="human", reason="条件変更",
+                                  add_tasks=[Task(agent="EvidenceAgent",
+                                                  action="search_literature")])
+        assert session.plan.version == v0 + 1
+        actions = manager.next_actions(session)
+        assert actions  # 変更後も次行動候補が生成される
+
+
+# ---------- エンドツーエンド ----------
+def test_full_cycle_end_to_end(manager, session):
+    """Goal→Observe→Plan→承認→Act→Evaluate まで一巡できる。"""
+    session.stop_conditions.max_iterations = 20
+    manager.run_auto(session)
+    approval = next(a for a in session.approvals if a.status == "pending")
+    manager.resolve_approval(session, approval.approval_id, True)
+    manager.run_auto(session)
+    eval_task = next(t for t in session.plan.tasks if t.action == "evaluate_hypothesis")
+    assert eval_task.status == TaskState.COMPLETED
+    assert eval_task.result["verdict_candidate"] in (
+        "supported", "falsification_candidate", "inconclusive")
+    assert "最終判定は研究者が行う" in eval_task.result["note"]
+    assert session.evaluations
+    assert session.stop_reason and "正常終了" in session.stop_reason

--- a/mi_hub2/tests/test_agent_api.py
+++ b/mi_hub2/tests/test_agent_api.py
@@ -1,0 +1,102 @@
+"""研究エージェント API（§14）のテスト。"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from mi_hub.agent import api
+from mi_hub.agent.loop import ResearchManager, SessionStore
+from mi_hub.agent.tools import ToolGateway
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    manager = ResearchManager(gateway=ToolGateway(), store=SessionStore(str(tmp_path)))
+    monkeypatch.setattr(api, "_manager", manager)
+    return TestClient(api.app)
+
+
+def _create(client) -> str:
+    r = client.post("/api/agent/goals", json={
+        "statement": "Ni-Al B2相のAlアンチサイト仮説を検証する"})
+    assert r.status_code == 200
+    return r.json()["session_id"]
+
+
+def test_goal_and_state(client):
+    sid = _create(client)
+    r = client.get(f"/api/agent/sessions/{sid}/state")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["agent_state"] == "observing"
+    assert body["goal"]["target_phase"] == "B2"
+
+
+def test_plan_lifecycle(client):
+    sid = _create(client)
+    plan = client.post(f"/api/agent/sessions/{sid}/plans").json()
+    assert len(plan["tasks"]) >= 3
+    r = client.patch(f"/api/agent/plans/{plan['plan_id']}?session_id={sid}", json={
+        "reason": "人間による編集",
+        "add_tasks": [{"agent": "EvidenceAgent", "action": "search_literature",
+                       "description": "追加検索"}],
+    })
+    assert r.status_code == 200
+    assert r.json()["version"] == plan["version"] + 1
+
+
+def test_next_actions_and_execute(client):
+    sid = _create(client)
+    client.post(f"/api/agent/sessions/{sid}/plans")
+    actions = client.get(f"/api/agent/sessions/{sid}/next-actions").json()["next_actions"]
+    assert actions
+    r = client.post("/api/agent/actions", json={
+        "session_id": sid, "task_id": actions[0]["task_id"]})
+    assert r.status_code == 200
+    assert r.json()["status"] == "completed"
+
+
+def test_approval_flow(client):
+    sid = _create(client)
+    client.post(f"/api/agent/sessions/{sid}/plans")
+    client.post(f"/api/agent/sessions/{sid}/run-auto")
+    state = client.get(f"/api/agent/sessions/{sid}/state").json()
+    pending = [a for a in state["approvals"] if a["status"] == "pending"]
+    assert pending
+    r = client.post(f"/api/agent/approvals/{pending[0]['approval_id']}", json={
+        "session_id": sid, "approve": True})
+    assert r.json()["status"] == "approved"
+    client.post(f"/api/agent/sessions/{sid}/run-auto")
+    state = client.get(f"/api/agent/sessions/{sid}/state").json()
+    exec_task = next(t for t in state["plan"]["tasks"]
+                     if t["action"] == "run_models_bulk")
+    assert exec_task["status"] in ("completed", "partially_completed")
+
+
+def test_pause_resume_complete(client):
+    sid = _create(client)
+    client.post(f"/api/agent/sessions/{sid}/plans")
+    assert client.post(f"/api/agent/sessions/{sid}/pause").json()["agent_state"] == "paused"
+    assert client.post(f"/api/agent/sessions/{sid}/resume").json()["agent_state"] != "paused"
+    assert client.post(f"/api/agent/sessions/{sid}/complete").json()["agent_state"] == "completed"
+
+
+def test_hypothesis_patch_permissions(client):
+    sid = _create(client)
+    client.post(f"/api/agent/sessions/{sid}/plans")
+    client.post(f"/api/agent/sessions/{sid}/run-auto")
+    state = client.get(f"/api/agent/sessions/{sid}/state").json()
+    hid = state["hypotheses"][0]["hypothesis_id"]
+    r = client.patch(f"/api/agent/hypotheses/{hid}", json={
+        "session_id": sid, "falsification_conditions": ["x"], "by": "agent"})
+    assert r.status_code == 403
+    r = client.patch(f"/api/agent/hypotheses/{hid}", json={
+        "session_id": sid, "falsification_conditions": ["x"], "by": "human"})
+    assert r.status_code == 200
+    assert r.json()["falsification_conditions"] == ["x"]


### PR DESCRIPTION
## Summary

指示書「MInt予測モデル群を用いた仮説・反証検証チャットアプリ — 研究エージェント機能追加改訂版」に基づき、`mi_hub2/` を新設。ユーザ提供の mi_hub.zip（Phase1-4: datastore/tracking/automl/optimat_bridge/feast/case_template）を基盤として取り込み、その上に Devin/OpenHands 型の状態駆動研究エージェント `mi_hub.agent` を追加（Phase 5）。

実行ループ（§4）: `Goal → Observe → Plan → Human Check → Act → Observe Result → Evaluate → Replan`

- `agent/states.py` — エージェント13状態・タスク14状態・仮説11状態・エラー14分類（§6, §9.1）
- `agent/models.py` — `ResearchGoal / Plan / Task / Hypothesis / Budget / StopConditions / PlanChange / SessionState`。計画は依存関係付きタスクグラフ + 版管理（§8）
- `agent/roles.py` — Evidence / Hypothesis / ModelSelection / VerificationPlanning / Execution / Evaluation / SafetyApproval の論理エージェント（§5、MVP方針で物理並列なし §18）。`SafetyApprovalAgent.check()` は決定論的ルールで、`run_models_bulk`・DFT投入等（§11.2）は承認なしでは遮断
- `agent/loop.py` — `ResearchManager`: 実行ループ・停止条件（正常終了/反復上限/予算上限/承認待ち §12）・HITL介入（計画編集・仮説修正・反証条件変更は human のみ、変更前後を監査ログ保存）・`SessionStore` によるJSON永続化と再開（§7.1）
- `agent/errors.py` — エラー分類 + 事前定義ルール内の自動修正（単位変換 C→K 等）+ 再試行上限。意味変更を伴う修正（OOD・入力欠落）は人間確認へ（§9）
- `agent/tools.py` — t2X/MCPゲートウェイのモック（MIntモデルレジストリ5件・文献検索・決定論的推論）。実接続時は `ToolGateway` を同一インターフェイスで差し替え
- `agent/llm.py` — LLMは構造化・仮説候補・要約のみ（§16）。`OPENAI_API_KEY` 未設定時は決定論的フォールバック
- `agent/api.py` — §14 の全エンドポイント（goals/state/plans/next-actions/actions/results/replan/pause/resume/complete + approvals/hypotheses）
- `agent/ui_streamlit.py` — チャットUI + Agentペイン（計画表・仮説・承認・証拠・エラー・計画履歴タブ、§13）

## 検証

- `tests/` に §19 受入試験（計画/Observe-Act/エラー回復/停止/HITL + E2E）: **32 passed**
- FastAPI・Streamlit UI とも起動確認済（UIは AppTest でセッション作成→自動実行→承認待ち到達まで確認)
- `mi_hub/__init__.py` を遅延importに変更（mlflow 等の重依存なしで agent を利用可能に）

## 起動

```bash
cd mi_hub2 && pip install -e ".[agent]"
PYTHONPATH=src streamlit run src/mi_hub/agent/ui_streamlit.py
PYTHONPATH=src uvicorn mi_hub.agent.api:app --port 8800
```


Link to Devin session: https://app.devin.ai/sessions/34d6cef6e2bf43a5a42921d909d237b3
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->