### PR TITLE
feat(mi_hub2): チャットの自由対話を追加（LLMによる状態説明・案内）

### DIFF
--- a/mi_hub2/src/mi_hub/agent/llm.py
+++ b/mi_hub2/src/mi_hub/agent/llm.py
@@ -101,6 +101,41 @@ def generate_hypotheses(goal_statement: str, evidence_claims: list[str]) -> list
     ]
 
 
+def chat_reply(context: dict[str, Any], history: list[dict[str, str]], message: str) -> str | None:
+    """セッション状態を文脈にした自由対話の応答（説明・要約のみ）。LLM 不可時は None。
+
+    科学的結論の確定・承認判定・数値計算は行わない（§16）。
+    """
+    if not llm_available():
+        return None
+    try:
+        from openai import OpenAI
+
+        client = OpenAI()
+        system = (
+            "あなたは材料研究エージェント MI-HUB2 の対話アシスタントです。"
+            "以下のセッション状態を踏まえ、研究者の質問に日本語で簡潔に答えてください。"
+            "できること: 状態・計画・仮説・証拠・エラーの説明、次の操作の案内"
+            "（実行は「実行を続けて」、一時停止/再開/終了、承認はAgentペインの承認タブ）。"
+            "してはいけないこと: 仮説の最終判定、承認の代行、数値の捏造。"
+            "最終的な科学判断は研究者に委ねる旨を必要に応じて添えてください。\n\n"
+            f"セッション状態:\n{json.dumps(context, ensure_ascii=False, default=str)}"
+        )
+        messages: list[dict[str, str]] = [{"role": "system", "content": system}]
+        for msg in history[-10:]:
+            if msg.get("role") in ("user", "assistant"):
+                messages.append({"role": msg["role"], "content": msg["content"]})
+        messages.append({"role": "user", "content": message})
+        resp = client.chat.completions.create(
+            model=os.environ.get("MI_HUB_LLM_MODEL", "gpt-4o-mini"),
+            messages=messages,
+            temperature=0.3,
+        )
+        return resp.choices[0].message.content
+    except Exception:
+        return None
+
+
 def summarize_for_human(payload: dict[str, Any]) -> str:
     """人間向け説明の生成。LLM 不可時は構造化テキスト。"""
     out = _chat_json(

--- a/mi_hub2/src/mi_hub/agent/ui_streamlit.py
+++ b/mi_hub2/src/mi_hub/agent/ui_streamlit.py
@@ -120,7 +120,7 @@ with chat_col:
                 "errors": [e.message for e in state.errors if not e.resolved],
                 "stop_reason": state.stop_reason,
             }
-            reply = llm.chat_reply(context, state.chat_history, user_msg)
+            reply = llm.chat_reply(context, state.chat_history[:-1], user_msg)
             if reply is None:
                 reply = (
                     f"現在の状態: {state.agent_state.value}、"

--- a/mi_hub2/src/mi_hub/agent/ui_streamlit.py
+++ b/mi_hub2/src/mi_hub/agent/ui_streamlit.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import pandas as pd
 import streamlit as st
 
+from mi_hub.agent import llm
 from mi_hub.agent.loop import ResearchManager
 from mi_hub.agent.models import SessionState
 from mi_hub.agent.states import HypothesisState
@@ -85,7 +86,7 @@ with chat_col:
         elif "終了" in user_msg:
             m.complete(state)
             reply = "セッションを終了しました。"
-        else:
+        elif any(k in user_msg for k in ("実行", "続けて", "進めて", "自動")):
             result = m.run_auto(state)
             n = len(result["executed"])
             reply = (
@@ -94,6 +95,41 @@ with chat_col:
             )
             if state.agent_state.value == "awaiting_approval":
                 reply += "\n\n承認待ちの操作があります。Agentタブで承認してください。"
+        else:
+            # 自由対話（LLM）。実行や承認は行わず、説明・案内のみ。
+            obs = m.observe(state)
+            context = {
+                "goal": state.goal.model_dump() if state.goal else None,
+                "agent_state": state.agent_state.value,
+                "observation": obs.model_dump(),
+                "plan": [
+                    {"task": t.task_id, "agent": t.agent, "action": t.action,
+                     "status": t.status.value, "description": t.description}
+                    for t in (state.plan.tasks if state.plan else [])
+                ],
+                "hypotheses": [
+                    {"id": h.hypothesis_id, "statement": h.statement,
+                     "status": h.status.value,
+                     "falsification_conditions": h.falsification_conditions}
+                    for h in state.hypotheses
+                ],
+                "pending_approvals": [
+                    {"id": a.approval_id, "description": a.description}
+                    for a in state.approvals if a.status == "pending"
+                ],
+                "errors": [e.message for e in state.errors if not e.resolved],
+                "stop_reason": state.stop_reason,
+            }
+            reply = llm.chat_reply(context, state.chat_history, user_msg)
+            if reply is None:
+                reply = (
+                    f"現在の状態: {state.agent_state.value}、"
+                    f"進捗 {obs.goal_progress:.0%}、証拠 {obs.evidence_count} 件。"
+                    + (f"停止理由: {state.stop_reason}。" if state.stop_reason else "")
+                    + "\n\n「実行を続けて」でタスクを進められます。"
+                    "承認・仮説判定はAgentペインの各タブから操作してください。"
+                    "（自由対話には OPENAI_API_KEY の設定が必要です）"
+                )
         state.chat_history.append({"role": "assistant", "content": reply})
         m.store.save(state)
         st.rerun()


### PR DESCRIPTION
## Summary

従来チャットは定型コマンド（一時停止/再開/終了）以外の入力をすべて `run_auto` に流していたため、会話が継続しなかった。ルーティングを変更:

- 「実行/続けて/進めて/自動」を含む入力のみ `run_auto` を起動
- それ以外は新設の `llm.chat_reply(context, history, message)` で自由対話。セッション状態（goal/plan/仮説/承認待ち/エラー/観察値）と直近10メッセージを文脈にした説明・案内のみを返し、実行・承認・仮説確定は行わない（§16 のLLM利用制限を維持）
- `OPENAI_API_KEY` 未設定・API失敗時は決定論的な状態要約にフォールバック

## 検証

- pytest 34件合格、ruff クリーン（既存のBLE001意図的except除く）
- OPENAI_API_KEY ありで実応答を確認、キーなしフォールバックも Streamlit AppTest で確認


Link to Devin session: https://app.devin.ai/sessions/34d6cef6e2bf43a5a42921d909d237b3
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/455" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->