### PR TITLE
fix(mi_hub2): LLM出力の型ゆらぎで ResearchGoal 検証エラーになるのを修正

### DIFF
--- a/mi_hub2/src/mi_hub/agent/llm.py
+++ b/mi_hub2/src/mi_hub/agent/llm.py
@@ -38,15 +38,35 @@ def _chat_json(system: str, user: str) -> dict[str, Any] | None:
         return None
 
 
+def _normalize_goal(out: dict[str, Any]) -> dict[str, Any]:
+    """LLM 出力の型ゆらぎを吸収する（success_criteria が文字列で返る等）。"""
+    norm: dict[str, Any] = {}
+    for key in ("target_material", "target_phase", "target_property"):
+        v = out.get(key)
+        if isinstance(v, list):
+            v = v[0] if v else None
+        norm[key] = str(v) if v is not None else None
+    sc = out.get("success_criteria")
+    if isinstance(sc, str):
+        sc = [s.strip() for s in sc.replace("\n", "。").split("。") if s.strip()]
+    elif isinstance(sc, list):
+        sc = [str(s) for s in sc if s]
+    else:
+        sc = None
+    norm["success_criteria"] = sc or None
+    return norm
+
+
 def structure_goal(statement: str) -> dict[str, Any]:
     """研究目標文を構造化する。LLM 不可時はルールベース。"""
     out = _chat_json(
         "あなたは材料科学の研究目標を構造化するアシスタントです。"
-        "JSON で target_material, target_phase, target_property, success_criteria を返してください。",
+        "JSON で target_material (str), target_phase (str), target_property (str), "
+        "success_criteria (list[str]) を返してください。",
         statement,
     )
     if out:
-        return out
+        return _normalize_goal(out)
     # フォールバック: 簡易キーワード抽出
     phase = None
     for p in ("B2", "L12", "L1_2", "FCC", "BCC", "HCP"):

--- a/mi_hub2/tests/conftest.py
+++ b/mi_hub2/tests/conftest.py
@@ -1,0 +1,8 @@
+"""テストは決定論的フォールバック経路で実行する（実LLMを呼ばない）。"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_llm(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)


### PR DESCRIPTION
## Summary

セッション作成時、LLM が `success_criteria` を list ではなく文字列（または `target_*` を list）で返すと `ResearchGoal` の Pydantic 検証で `ValidationError: Input should be a valid list` が発生していた（ユーザー報告）。

- `llm._normalize_goal()` を追加し `structure_goal()` の LLM 出力を正規化: `target_*` は str|None に強制（list なら先頭要素）、`success_criteria` は文字列なら「。」区切りで list 化、list なら各要素を str 化。プロンプトにも型を明記。
- `tests/conftest.py` に autouse fixture を追加し `OPENAI_API_KEY` を除去。openai がインストールされた環境でテストが実 API を呼んで遅延・非決定化するのを防止。

## 検証

- 文字列 `success_criteria` の正規化と `ResearchGoal` 構築を確認
- 実 OPENAI_API_KEY でのセッション作成が成功することを確認
- pytest 34件合格（0.4s、LLM 非呼出）


Link to Devin session: https://app.devin.ai/sessions/34d6cef6e2bf43a5a42921d909d237b3
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->