### PR TITLE
feat(mi_hub2): 情報ギャップ提示・意図分類チャット・承認可視化・スクリプト実行・記憶分離・ナレッジ差込口

### DIFF
--- a/mi_hub2/src/mi_hub/agent/api.py
+++ b/mi_hub2/src/mi_hub/agent/api.py
@@ -103,6 +103,7 @@ def get_state(session_id: str) -> dict[str, Any]:
         "budget": state.budget.model_dump(),
         "stop_conditions": state.stop_conditions.model_dump(),
         "stop_reason": state.stop_reason,
+        "data_gaps": (state.evaluations[-1].data_gaps if state.evaluations else []),
         "plan_history": [c.model_dump() for c in state.plan_history],
     }
 

--- a/mi_hub2/src/mi_hub/agent/api.py
+++ b/mi_hub2/src/mi_hub/agent/api.py
@@ -105,6 +105,7 @@ def get_state(session_id: str) -> dict[str, Any]:
         "stop_reason": state.stop_reason,
         "data_gaps": (state.evaluations[-1].data_gaps if state.evaluations else []),
         "plan_history": [c.model_dump() for c in state.plan_history],
+        "memory": m.memory_context(state),
     }
 
 

--- a/mi_hub2/src/mi_hub/agent/llm.py
+++ b/mi_hub2/src/mi_hub/agent/llm.py
@@ -149,6 +149,51 @@ def generate_hypotheses(goal_statement: str, evidence_claims: list[str]) -> list
     ]
 
 
+_INTENTS = {"run", "pause", "resume", "complete", "approve", "reject", "script", "question"}
+
+
+def classify_intent(message: str, has_pending_approval: bool) -> dict[str, Any]:
+    """ユーザ発話の意図を分類する。実行系操作の最終判定は決定論的コード側で行う。
+
+    返り値: {"intent": str, "script": str|None, "reason": str|None}
+    intent: run（タスク実行の継続指示）/ pause / resume / complete /
+            approve / reject（承認待ち操作への回答）/
+            script（シェルスクリプト実行の依頼: ライブラリのインストールや計算実行）/
+            question（質問・相談・その他）
+    """
+    out = _chat_json(
+        "あなたは研究エージェントUIの意図分類器です。ユーザの発話を次のいずれかに分類し、"
+        'JSON {"intent": str, "script": str|null, "reason": str} を返してください。\n'
+        "- run: エージェントの計画タスクの実行を進める明確な指示（例: 実行を続けて、次に進めて）\n"
+        "- pause / resume / complete: セッションの一時停止・再開・終了の指示\n"
+        f"- approve / reject: 承認待ち操作への諾否（現在の承認待ち: {'あり' if has_pending_approval else 'なし'}）\n"
+        "- script: シェル/Pythonでの計算実行やライブラリのインストールの依頼。"
+        "この場合 script フィールドに実行可能な bash スクリプト（pip install等を含めてよい）を生成すること\n"
+        "- question: 上記以外（質問・相談・要約依頼など）\n"
+        "迷った場合は question を選ぶこと。実行してよいかの最終判断は人間が行う。",
+        message,
+    )
+    if out and out.get("intent") in _INTENTS:
+        return {"intent": out["intent"],
+                "script": out.get("script") if isinstance(out.get("script"), str) else None,
+                "reason": out.get("reason")}
+    # フォールバック: 明示的コマンドのみ反応し、それ以外は question
+    stripped = message.strip()
+    if "一時停止" in stripped:
+        return {"intent": "pause", "script": None, "reason": None}
+    if "再開" in stripped:
+        return {"intent": "resume", "script": None, "reason": None}
+    if "終了" in stripped:
+        return {"intent": "complete", "script": None, "reason": None}
+    if has_pending_approval and stripped in ("承認", "承認します", "OK", "ok", "はい"):
+        return {"intent": "approve", "script": None, "reason": None}
+    if has_pending_approval and stripped in ("却下", "却下します", "いいえ"):
+        return {"intent": "reject", "script": None, "reason": None}
+    if any(k in stripped for k in ("実行を続けて", "続けて", "進めて", "自動で実行")):
+        return {"intent": "run", "script": None, "reason": None}
+    return {"intent": "question", "script": None, "reason": None}
+
+
 def chat_reply(context: dict[str, Any], history: list[dict[str, str]], message: str) -> str | None:
     """セッション状態を文脈にした自由対話の応答（説明・要約のみ）。LLM 不可時は None。
 
@@ -162,9 +207,13 @@ def chat_reply(context: dict[str, Any], history: list[dict[str, str]], message: 
         client = OpenAI()
         system = (
             "あなたは材料研究エージェント MI-HUB2 の対話アシスタントです。"
-            "以下のセッション状態を踏まえ、研究者の質問に日本語で簡潔に答えてください。"
-            "できること: 状態・計画・仮説・証拠・エラーの説明、次の操作の案内"
-            "（実行は「実行を続けて」、一時停止/再開/終了、承認はAgentペインの承認タブ）。"
+            "以下のセッション状態を踏まえ、研究者と議論を前進させる相棒として日本語で答えてください。"
+            "できること: 状態・計画・仮説・証拠・エラーの説明、研究方針の議論"
+            "（特徴量設計、SQS・MLIP・CALPHAD等の手法比較、Materials Project/OQMD等の"
+            "データソース活用案など）、次の一手の具体的な提案、次の操作の案内"
+            "（実行は「実行を続けて」、一時停止/再開/終了、承認は承認タブまたはチャットで「承認」）。"
+            "ライブラリのインストールや計算実行を求められたら、承認後にスクリプトとして"
+            "実行できることを案内してください。"
             "してはいけないこと: 仮説の最終判定、承認の代行、数値の捏造。"
             "最終的な科学判断は研究者に委ねる旨を必要に応じて添えてください。\n\n"
             f"セッション状態:\n{json.dumps(context, ensure_ascii=False, default=str)}"

--- a/mi_hub2/src/mi_hub/agent/llm.py
+++ b/mi_hub2/src/mi_hub/agent/llm.py
@@ -38,14 +38,40 @@ def _chat_json(system: str, user: str) -> dict[str, Any] | None:
         return None
 
 
+# モデルレジストリの物性語彙への正規化（LLM が日本語・自由語彙で返す場合の吸収）
+_PROPERTY_ALIASES = {
+    "相安定性": "phase_stability",
+    "phase stability": "phase_stability",
+    "生成エンタルピー": "formation_enthalpy",
+    "formation enthalpy": "formation_enthalpy",
+    "欠陥形成エネルギー": "defect_formation_energy",
+    "defect formation": "defect_formation_energy",
+    "格子定数": "lattice_constant",
+    "lattice constant": "lattice_constant",
+    "拡散": "diffusivity",
+    "diffusivity": "diffusivity",
+}
+
+
+def _normalize_property(value: str | None) -> str | None:
+    if value is None:
+        return None
+    s = str(value).strip()
+    for alias, canonical in _PROPERTY_ALIASES.items():
+        if alias.lower() in s.lower():
+            return canonical
+    return s.replace(" ", "_").lower()
+
+
 def _normalize_goal(out: dict[str, Any]) -> dict[str, Any]:
-    """LLM 出力の型ゆらぎを吸収する（success_criteria が文字列で返る等）。"""
+    """LLM 出力の型・語彙のゆらぎを吸収する（success_criteria が文字列で返る等）。"""
     norm: dict[str, Any] = {}
     for key in ("target_material", "target_phase", "target_property"):
         v = out.get(key)
         if isinstance(v, list):
             v = v[0] if v else None
         norm[key] = str(v) if v is not None else None
+    norm["target_property"] = _normalize_property(norm["target_property"])
     sc = out.get("success_criteria")
     if isinstance(sc, str):
         sc = [s.strip() for s in sc.replace("\n", "。").split("。") if s.strip()]
@@ -62,7 +88,9 @@ def structure_goal(statement: str) -> dict[str, Any]:
     out = _chat_json(
         "あなたは材料科学の研究目標を構造化するアシスタントです。"
         "JSON で target_material (str), target_phase (str), target_property (str), "
-        "success_criteria (list[str]) を返してください。",
+        "success_criteria (list[str]) を返してください。"
+        "target_property は英語スネークケース（例: phase_stability, formation_enthalpy, "
+        "defect_formation_energy, lattice_constant, diffusivity）で返してください。",
         statement,
     )
     if out:

--- a/mi_hub2/src/mi_hub/agent/llm.py
+++ b/mi_hub2/src/mi_hub/agent/llm.py
@@ -168,7 +168,12 @@ def classify_intent(message: str, has_pending_approval: bool) -> dict[str, Any]:
         "- pause / resume / complete: セッションの一時停止・再開・終了の指示\n"
         f"- approve / reject: 承認待ち操作への諾否（現在の承認待ち: {'あり' if has_pending_approval else 'なし'}）\n"
         "- script: シェル/Pythonでの計算実行やライブラリのインストールの依頼。"
-        "この場合 script フィールドに実行可能な bash スクリプト（pip install等を含めてよい）を生成すること\n"
+        "この場合 script フィールドに bash として実行可能なスクリプトを生成すること。"
+        "ライブラリは `pip install -q <pkg>`（`!pip` は不可）、Python コードは "
+        "`python3 - <<'PY'` ... `PY` のヒアドキュメントで埋め込むこと。"
+        "改行を保持した完全なスクリプトとし、物理定数・式は正確に書くこと。"
+        "図・CSV等の成果物はカレントディレクトリに保存し、1回の実行で"
+        "結果を全て出力・保存すること（同じ計算の再実行を避ける）\n"
         "- question: 上記以外（質問・相談・要約依頼など）\n"
         "迷った場合は question を選ぶこと。実行してよいかの最終判断は人間が行う。",
         message,

--- a/mi_hub2/src/mi_hub/agent/loop.py
+++ b/mi_hub2/src/mi_hub/agent/loop.py
@@ -332,6 +332,44 @@ class ResearchManager:
             return None  # 承認待ちは execute 時に個別処理
         return None
 
+    # ---------- Memory ----------
+    def memory_context(self, state: SessionState) -> dict[str, Any]:
+        """短期記憶（直近の計算・評価）と長期記憶（セッション全体）を分けて返す。
+
+        短期: 直近ステップの妥当性評価に使う。長期: 蓄積された証拠・評価履歴から
+        全体としての妥当性を判断する材料に使う。判断は研究者が行う。
+        """
+        recent_tasks = [
+            {"task": t.task_id, "action": t.action, "status": t.status.value,
+             "description": t.description}
+            for t in (state.plan.tasks if state.plan else [])
+            if t.status in (TaskState.COMPLETED, TaskState.FAILED)
+        ][-3:]
+        short_term = {
+            "last_evaluation": state.evaluations[-1].model_dump() if state.evaluations else None,
+            "recent_tasks": recent_tasks,
+            "unresolved_errors": [e.message for e in state.errors if not e.resolved],
+        }
+        long_term = {
+            "goal": state.goal.model_dump() if state.goal else None,
+            "hypotheses": [
+                {"id": h.hypothesis_id, "statement": h.statement, "status": h.status.value,
+                 "falsification_conditions": h.falsification_conditions}
+                for h in state.hypotheses
+            ],
+            "evidence": [
+                {"id": e.evidence_id, "type": e.evidence_type, "claim": e.claim}
+                for e in state.evidence
+            ],
+            "evaluation_history": [
+                {"result": ev.step_result, "quality": ev.result_quality,
+                 "progress_after": ev.goal_progress_after, "data_gaps": ev.data_gaps}
+                for ev in state.evaluations
+            ],
+            "plan_versions": len(state.plan_history),
+        }
+        return {"short_term_memory": short_term, "long_term_memory": long_term}
+
     # ---------- Human-in-the-loop (§10) ----------
     def resolve_approval(self, state: SessionState, approval_id: str,
                          approve: bool, by: str = "human") -> dict[str, Any]:

--- a/mi_hub2/src/mi_hub/agent/loop.py
+++ b/mi_hub2/src/mi_hub/agent/loop.py
@@ -332,6 +332,13 @@ class ResearchManager:
             return None  # 承認待ちは execute 時に個別処理
         return None
 
+    # ---------- Workspace ----------
+    def session_workspace(self, state: SessionState) -> str:
+        """セッション専用の作業ディレクトリ（スクリプト実行の成果物置き場）を返す。"""
+        d = self.store.base_dir / "workspaces" / state.session_id
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
     # ---------- Memory ----------
     def memory_context(self, state: SessionState) -> dict[str, Any]:
         """短期記憶（直近の計算・評価）と長期記憶（セッション全体）を分けて返す。

--- a/mi_hub2/src/mi_hub/agent/loop.py
+++ b/mi_hub2/src/mi_hub/agent/loop.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import platform
 import re
 from pathlib import Path
 from typing import Any
@@ -338,6 +339,75 @@ class ResearchManager:
         d = self.store.base_dir / "workspaces" / state.session_id
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
+
+    # ---------- Case report (事例の蓄積) ----------
+    def export_case_report(self, state: SessionState) -> str:
+        """セッションを事例レポート（Markdown）として作業ディレクトリに書き出す。
+
+        会話・提案スクリプト・実行環境・結果・情報ギャップを1ファイルに集約し、
+        今後の機能改修や類似研究の参照に使う。書き出し先のパスを返す。
+        """
+        lines: list[str] = [f"# 事例レポート: {state.session_id}", ""]
+        if state.goal:
+            lines += ["## 研究目標", state.goal.statement, ""]
+            if state.goal.success_criteria:
+                lines += ["成功基準:"] + [
+                    f"- {c}" for c in state.goal.success_criteria
+                ] + [""]
+        lines += [
+            "## 実行環境",
+            f"- python: {platform.python_version()} / {platform.platform()}",
+            f"- agent_state: {state.agent_state.value}"
+            + (f" / 停止理由: {state.stop_reason}" if state.stop_reason else ""),
+            "",
+        ]
+        if state.hypotheses:
+            lines += ["## 仮説"] + [
+                f"- [{h.status.value}] {h.statement}" for h in state.hypotheses
+            ] + [""]
+        if state.chat_history:
+            lines += ["## 会話ログ"]
+            for msg in state.chat_history:
+                lines += [f"### {msg['role']}", msg["content"], ""]
+        script_approvals = [a for a in state.approvals if a.kind == "script_execution"]
+        if script_approvals:
+            lines += ["## 提案・実行スクリプト"]
+            for a in script_approvals:
+                lines += [
+                    f"### {a.approval_id}（{a.status}）",
+                    a.description,
+                    "```bash",
+                    a.payload.get("script", ""),
+                    "```",
+                    "",
+                ]
+        if state.evidence:
+            lines += ["## 証拠・実行結果"]
+            for e in state.evidence:
+                lines += [f"### {e.evidence_id} [{e.evidence_type}]", e.claim]
+                if e.conditions.get("stdout"):
+                    lines += ["```", str(e.conditions["stdout"]), "```"]
+                for f in e.conditions.get("generated_files") or []:
+                    if str(f).lower().endswith((".png", ".jpg", ".jpeg", ".svg")):
+                        lines += [f"![{f}]({f})"]  # レポートと同じ作業ディレクトリ
+                    else:
+                        lines += [f"- 成果物: {e.conditions.get('workdir', '')}/{f}"]
+                lines += [""]
+        gaps = state.evaluations[-1].data_gaps if state.evaluations else []
+        if gaps:
+            lines += ["## 追加的に必要なデータ"] + [f"- {g}" for g in gaps] + [""]
+        if state.errors:
+            lines += ["## エラー"] + [
+                f"- {e.error_type.value}: {e.message}"
+                f"（{'解決済' if e.resolved else '未解決'}）"
+                for e in state.errors
+            ] + [""]
+        path = os.path.join(self.session_workspace(state), "case_report.md")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines))
+        state.audit("ResearchManager", "case_report_exported", path=path)
+        self.store.save(state)
+        return path
 
     # ---------- Memory ----------
     def memory_context(self, state: SessionState) -> dict[str, Any]:

--- a/mi_hub2/src/mi_hub/agent/models.py
+++ b/mi_hub2/src/mi_hub/agent/models.py
@@ -157,6 +157,7 @@ class StepEvaluation(BaseModel):
     new_conflicts: list[str] = Field(default_factory=list)
     result_quality: str = "acceptable"
     requires_replanning: bool = False
+    data_gaps: list[str] = Field(default_factory=list)  # 追加的に必要なデータ
 
 
 class ErrorRecord(BaseModel):

--- a/mi_hub2/src/mi_hub/agent/models.py
+++ b/mi_hub2/src/mi_hub/agent/models.py
@@ -122,6 +122,7 @@ class ApprovalRequest(BaseModel):
     task_id: str | None = None
     kind: str = "task_execution"
     description: str = ""
+    payload: dict[str, Any] = Field(default_factory=dict)  # 例: script_execution の script 本文
     status: str = "pending"  # pending / approved / rejected
     requested_at: float = Field(default_factory=time.time)
     resolved_at: float | None = None

--- a/mi_hub2/src/mi_hub/agent/roles.py
+++ b/mi_hub2/src/mi_hub/agent/roles.py
@@ -89,7 +89,7 @@ class EvidenceAgent:
 
     def run(self, state: SessionState, gateway: ToolGateway, task: Task) -> dict[str, Any]:
         query = task.inputs.get("query") or (state.goal.statement if state.goal else "")
-        docs = gateway.search_literature(query)
+        docs = gateway.search_knowledge(query)
         added = []
         for doc in docs:
             ev = Evidence(

--- a/mi_hub2/src/mi_hub/agent/roles.py
+++ b/mi_hub2/src/mi_hub/agent/roles.py
@@ -249,6 +249,7 @@ class EvaluationAgent:
         verdict_candidate = "inconclusive"
         if xs and abs(slope) > 3 * (mean_std + 1e-9):
             verdict_candidate = "supported" if slope > 0 else "falsification_candidate"
+        data_gaps = self._data_gaps(state, gateway, exec_results, xs, slope, mean_std)
         for h in state.hypotheses:
             if h.status == HypothesisState.APPROVED_FOR_TESTING:
                 h.status = HypothesisState.UNDER_EVALUATION
@@ -259,12 +260,48 @@ class EvaluationAgent:
             hypotheses_affected=[h.hypothesis_id for h in state.hypotheses],
             result_quality="acceptable" if exec_results else "insufficient",
             requires_replanning=not exec_results,
+            data_gaps=data_gaps,
         )
         state.evaluations.append(evaluation)
         return {
             "slope": slope,
             "mean_uncertainty": mean_std,
             "verdict_candidate": verdict_candidate,
+            "data_gaps": data_gaps,
             "note": "最終判定は研究者が行う（Human-in-the-loop）",
             "evaluation": evaluation.model_dump(),
         }
+
+    def _data_gaps(
+        self,
+        state: SessionState,
+        gateway: ToolGateway,
+        exec_results: list[dict[str, Any]],
+        xs: list[float],
+        slope: float,
+        mean_std: float,
+    ) -> list[str]:
+        """判定材料を強化するために追加的に必要なデータを決定論的に列挙する。"""
+        gaps: list[str] = []
+        if not exec_results:
+            gaps.append("モデル予測結果（承認済みジョブの実行結果）")
+            return gaps
+        if len(xs) < 5:
+            gaps.append(
+                f"追加の組成点（現在 {len(xs)} 点。傾き推定の信頼性向上に 5 点以上を推奨）"
+            )
+        groups = set()
+        for r in exec_results:
+            info = gateway.get_model(r["job"]["model_id"])
+            if info is not None:
+                groups.add(info.independence_group)
+        if len(groups) < 2:
+            gaps.append("独立なモデル系列（別の independence_group）による再予測")
+        if xs and abs(slope) <= 3 * (mean_std + 1e-9):
+            gaps.append("不確実性低減のための追加サンプリング（傾きが不確実性に埋もれている）")
+        if not any(e.evidence_type == "experiment" for e in state.evidence):
+            gaps.append("実験参照値（相安定性・欠陥形成エネルギーの実測データ）")
+        temps = {r["job"]["inputs"].get("temperature") for r in exec_results}
+        if len(temps) < 2:
+            gaps.append("温度依存性の確認（複数温度での予測）")
+        return gaps

--- a/mi_hub2/src/mi_hub/agent/tools.py
+++ b/mi_hub2/src/mi_hub/agent/tools.py
@@ -8,7 +8,10 @@ MCP エンドポイントへ差し替える。ここでは MVP 用に決定論�
 from __future__ import annotations
 
 import hashlib
+import os
 import random
+import subprocess
+import tempfile
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -69,6 +72,29 @@ class ToolError(Exception):
         self.message = message
 
 
+class KnowledgeProvider:
+    """外部ナレッジ源（MCPサーバ・GraphRAG・社内DB等）の差し込み口。
+
+    search() を実装したオブジェクトを ToolGateway.register_knowledge_provider()
+    で登録すると、文献検索時にモックレジストリと併せて照会される。
+    MCP 接続の場合は search() 内で MCP クライアント呼出しを実装する。
+    """
+
+    name: str = "knowledge"
+
+    def __init__(self, name: str = "knowledge"):
+        self.name = name
+
+    def search(self, query: str, limit: int = 10) -> list[dict[str, Any]]:
+        """query に関連する文書のリストを返す。
+
+        各文書は search_literature と同じスキーマ
+        （title / source_type / claim / evidence_type / conditions /
+        keywords / limitations）に従うこと。
+        """
+        raise NotImplementedError
+
+
 class ToolGateway:
     """MCPゲートウェイのインターフェイス兼モック実装。"""
 
@@ -77,6 +103,26 @@ class ToolGateway:
         self.literature = list(MOCK_LITERATURE)
         self._fail_next = fail_next  # テスト用: 次回呼出しを指定エラーで失敗させる
         self.call_log: list[dict[str, Any]] = []
+        self.knowledge_providers: list[KnowledgeProvider] = []
+
+    def register_knowledge_provider(self, provider: KnowledgeProvider) -> None:
+        """外部ナレッジ源（MCP/GraphRAG等）を登録する。"""
+        self.knowledge_providers.append(provider)
+
+    def search_knowledge(self, query: str, limit: int = 10) -> list[dict[str, Any]]:
+        """モック文献DBと登録済みナレッジプロバイダを横断検索する。"""
+        results = self.search_literature(query, limit)
+        for r in results:
+            r.setdefault("provider", "mock_literature")
+        for p in self.knowledge_providers:
+            try:
+                for doc in p.search(query, limit):
+                    doc.setdefault("provider", p.name)
+                    results.append(doc)
+            except (ToolError, NotImplementedError, ConnectionError, TimeoutError, OSError, ValueError) as exc:
+                self.call_log.append({"tool": "search_knowledge", "provider": p.name,
+                                      "error": str(exc)})
+        return results[:limit]
 
     def _maybe_fail(self, tool: str) -> None:
         if self._fail_next:
@@ -159,6 +205,34 @@ class ToolGateway:
             "in_domain": True,
             "independence_group": model.independence_group,
         }
+
+    # --- t2Shell（サンドボックススクリプト実行。実行は必ず人間承認後） ---
+    def run_script(self, script: str, timeout_s: int = 300) -> dict[str, Any]:
+        """承認済みシェルスクリプトを実行し、exit code / stdout / stderr を返す。
+
+        ライブラリのインストール（pip 等）や計算スクリプトの実行に使う。
+        呼び出し側（UI/API）が承認ゲートを通した後にのみ呼ぶこと。
+        """
+        self._maybe_fail("run_script")
+        self.call_log.append({"tool": "run_script", "script_head": script[:200]})
+        fd, path = tempfile.mkstemp(suffix=".sh")
+        try:
+            with os.fdopen(fd, "w") as f:
+                f.write(script)
+            proc = subprocess.run(
+                ["bash", path], capture_output=True, text=True, timeout=timeout_s,
+                check=False,
+            )
+            return {
+                "exit_code": proc.returncode,
+                "stdout": proc.stdout[-8000:],
+                "stderr": proc.stderr[-8000:],
+            }
+        except subprocess.TimeoutExpired:
+            return {"exit_code": -1, "stdout": "",
+                    "stderr": f"timeout: 実行が {timeout_s} 秒を超過"}
+        finally:
+            os.unlink(path)
 
     # --- t2Python（統計評価） ---
     def analyze(self, values: list[float]) -> dict[str, float]:

--- a/mi_hub2/src/mi_hub/agent/tools.py
+++ b/mi_hub2/src/mi_hub/agent/tools.py
@@ -207,30 +207,43 @@ class ToolGateway:
         }
 
     # --- t2Shell（サンドボックススクリプト実行。実行は必ず人間承認後） ---
-    def run_script(self, script: str, timeout_s: int = 300) -> dict[str, Any]:
+    def run_script(
+        self, script: str, timeout_s: int = 300, workdir: str | None = None
+    ) -> dict[str, Any]:
         """承認済みシェルスクリプトを実行し、exit code / stdout / stderr を返す。
 
         ライブラリのインストール（pip 等）や計算スクリプトの実行に使う。
         呼び出し側（UI/API）が承認ゲートを通した後にのみ呼ぶこと。
+        workdir を指定すると、その作業ディレクトリで実行し、生成された
+        ファイル（図・CSV等）の一覧を generated_files として返す。
         """
         self._maybe_fail("run_script")
         self.call_log.append({"tool": "run_script", "script_head": script[:200]})
+        if workdir:
+            os.makedirs(workdir, exist_ok=True)
+            before = set(os.listdir(workdir))
         fd, path = tempfile.mkstemp(suffix=".sh")
         try:
             with os.fdopen(fd, "w") as f:
                 f.write(script)
             proc = subprocess.run(
                 ["bash", path], capture_output=True, text=True, timeout=timeout_s,
-                check=False,
+                cwd=workdir, check=False,
             )
+            generated: list[str] = []
+            if workdir:
+                generated = sorted(set(os.listdir(workdir)) - before)
             return {
                 "exit_code": proc.returncode,
                 "stdout": proc.stdout[-8000:],
                 "stderr": proc.stderr[-8000:],
+                "workdir": workdir,
+                "generated_files": generated,
             }
         except subprocess.TimeoutExpired:
             return {"exit_code": -1, "stdout": "",
-                    "stderr": f"timeout: 実行が {timeout_s} 秒を超過"}
+                    "stderr": f"timeout: 実行が {timeout_s} 秒を超過",
+                    "workdir": workdir, "generated_files": []}
         finally:
             os.unlink(path)
 

--- a/mi_hub2/src/mi_hub/agent/ui_streamlit.py
+++ b/mi_hub2/src/mi_hub/agent/ui_streamlit.py
@@ -105,6 +105,16 @@ with st.sidebar:
         st.rerun()
     if selected != "(新規)":
         st.session_state["sid"] = selected
+    if st.session_state.get("sid"):
+        cur = m.store.load(st.session_state["sid"])
+        if cur is not None and st.button("事例レポートを書き出す"):
+            report_path = m.export_case_report(cur)
+            st.success(f"書き出しました: {report_path}")
+            with open(report_path, encoding="utf-8") as rf:
+                st.download_button(
+                    "レポートをダウンロード", rf.read(),
+                    file_name=f"case_report_{cur.session_id}.md",
+                )
 
 sid = st.session_state.get("sid")
 if not sid:

--- a/mi_hub2/src/mi_hub/agent/ui_streamlit.py
+++ b/mi_hub2/src/mi_hub/agent/ui_streamlit.py
@@ -95,6 +95,9 @@ with chat_col:
             )
             if state.agent_state.value == "awaiting_approval":
                 reply += "\n\n承認待ちの操作があります。Agentタブで承認してください。"
+            if state.evaluations and state.evaluations[-1].data_gaps:
+                gaps = "\n".join(f"- {g}" for g in state.evaluations[-1].data_gaps)
+                reply += f"\n\n**追加的に必要なデータ:**\n{gaps}"
         else:
             # 自由対話（LLM）。実行や承認は行わず、説明・案内のみ。
             obs = m.observe(state)
@@ -118,6 +121,7 @@ with chat_col:
                     for a in state.approvals if a.status == "pending"
                 ],
                 "errors": [e.message for e in state.errors if not e.resolved],
+                "data_gaps": (state.evaluations[-1].data_gaps if state.evaluations else []),
                 "stop_reason": state.stop_reason,
             }
             reply = llm.chat_reply(context, state.chat_history[:-1], user_msg)
@@ -146,6 +150,12 @@ with agent_col:
     c3.metric("証拠数", obs.evidence_count)
     if state.stop_reason:
         st.warning(f"停止理由: {state.stop_reason}")
+
+    if state.evaluations and state.evaluations[-1].data_gaps:
+        with st.container(border=True):
+            st.markdown("**追加的に必要なデータ**")
+            for gap in state.evaluations[-1].data_gaps:
+                st.write(f"- {gap}")
 
     tabs = st.tabs(["計画", "仮説", "承認", "証拠", "エラー", "履歴"])
 

--- a/mi_hub2/src/mi_hub/agent/ui_streamlit.py
+++ b/mi_hub2/src/mi_hub/agent/ui_streamlit.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import os
 import time
 
 import pandas as pd
@@ -350,6 +351,19 @@ with agent_col:
     with tabs[3]:
         for e in state.evidence:
             st.write(f"- **{e.evidence_id}** [{e.evidence_type}] {e.claim}")
+            workdir = e.conditions.get("workdir")
+            files = e.conditions.get("generated_files") or []
+            if e.conditions.get("stdout"):
+                with st.expander(f"実行出力（{e.evidence_id}）"):
+                    st.code(str(e.conditions["stdout"]))
+            if workdir and files:
+                for fname in files:
+                    fpath = os.path.join(str(workdir), str(fname))
+                    if str(fname).lower().endswith((".png", ".jpg", ".jpeg", ".svg")) \
+                            and os.path.exists(fpath):
+                        st.image(fpath, caption=fname)
+                    else:
+                        st.write(f"  - 成果物: {fpath}")
 
     with tabs[4]:
         for err in state.errors:

--- a/mi_hub2/src/mi_hub/agent/ui_streamlit.py
+++ b/mi_hub2/src/mi_hub/agent/ui_streamlit.py
@@ -25,11 +25,17 @@ def execute_script_approval(manager: ResearchManager, s: SessionState,
                             approval: ApprovalRequest) -> str:
     """承認済みスクリプトを実行し、結果を証拠と監査ログに記録して応答文を返す。"""
     script = approval.payload.get("script", "")
-    res = manager.gateway.run_script(script)
+    workdir = manager.session_workspace(s)
+    res = manager.gateway.run_script(script, workdir=workdir)
     s.evidence.append(Evidence(
         source_type="script_execution",
         claim=f"スクリプト実行（exit code {res['exit_code']}）: {approval.description}",
-        conditions={"approval_id": approval.approval_id},
+        conditions={
+            "approval_id": approval.approval_id,
+            "stdout": res["stdout"][-2000:],
+            "workdir": workdir,
+            "generated_files": res["generated_files"],
+        },
         evidence_type="computation",
         limitations=["サンドボックス実行結果。再現性はスクリプト本文を参照"],
     ))
@@ -40,6 +46,9 @@ def execute_script_approval(manager: ResearchManager, s: SessionState,
         reply += f"\n\n出力:\n```\n{res['stdout'].strip()[-3000:]}\n```"
     if res["stderr"].strip():
         reply += f"\n\nstderr:\n```\n{res['stderr'].strip()[-2000:]}\n```"
+    if res["generated_files"]:
+        files = "\n".join(f"- {workdir}/{f}" for f in res["generated_files"])
+        reply += f"\n\n生成ファイル:\n{files}"
     reply += "\n\n実行結果は証拠タブに記録しました。"
     return reply
 

--- a/mi_hub2/src/mi_hub/agent/ui_streamlit.py
+++ b/mi_hub2/src/mi_hub/agent/ui_streamlit.py
@@ -5,13 +5,52 @@
 
 from __future__ import annotations
 
+import time
+
 import pandas as pd
 import streamlit as st
 
 from mi_hub.agent import llm
 from mi_hub.agent.loop import ResearchManager
-from mi_hub.agent.models import SessionState
+from mi_hub.agent.models import ApprovalRequest, Evidence, SessionState
 from mi_hub.agent.states import HypothesisState
+
+APPROVAL_KIND_LABELS = {
+    "task_execution": "タスク実行",
+    "script_execution": "スクリプト実行",
+}
+
+
+def execute_script_approval(manager: ResearchManager, s: SessionState,
+                            approval: ApprovalRequest) -> str:
+    """承認済みスクリプトを実行し、結果を証拠と監査ログに記録して応答文を返す。"""
+    script = approval.payload.get("script", "")
+    res = manager.gateway.run_script(script)
+    s.evidence.append(Evidence(
+        source_type="script_execution",
+        claim=f"スクリプト実行（exit code {res['exit_code']}）: {approval.description}",
+        conditions={"approval_id": approval.approval_id},
+        evidence_type="computation",
+        limitations=["サンドボックス実行結果。再現性はスクリプト本文を参照"],
+    ))
+    s.audit("human", "script_executed", approval_id=approval.approval_id,
+            exit_code=res["exit_code"])
+    reply = f"スクリプトを実行しました（exit code {res['exit_code']}）。"
+    if res["stdout"].strip():
+        reply += f"\n\n出力:\n```\n{res['stdout'].strip()[-3000:]}\n```"
+    if res["stderr"].strip():
+        reply += f"\n\nstderr:\n```\n{res['stderr'].strip()[-2000:]}\n```"
+    reply += "\n\n実行結果は証拠タブに記録しました。"
+    return reply
+
+
+def pending_approval_summary(s: SessionState) -> str:
+    lines = []
+    for a in s.approvals:
+        if a.status == "pending":
+            kind = APPROVAL_KIND_LABELS.get(a.kind, a.kind)
+            lines.append(f"- [{kind}] {a.description}（{a.approval_id}）")
+    return "\n".join(lines)
 
 st.set_page_config(page_title="MI-HUB2 研究エージェント", layout="wide")
 
@@ -77,16 +116,19 @@ with chat_col:
     user_msg = st.chat_input("メッセージを入力（例: 実行を続けて / 一時停止 / 終了）")
     if user_msg:
         state.chat_history.append({"role": "user", "content": user_msg})
-        if "一時停止" in user_msg:
+        pending = [a for a in state.approvals if a.status == "pending"]
+        intent_info = llm.classify_intent(user_msg, bool(pending))
+        intent = intent_info["intent"]
+        if intent == "pause":
             m.pause(state)
             reply = "セッションを一時停止しました。"
-        elif "再開" in user_msg:
+        elif intent == "resume":
             m.resume(state)
             reply = "セッションを再開しました。"
-        elif "終了" in user_msg:
+        elif intent == "complete":
             m.complete(state)
             reply = "セッションを終了しました。"
-        elif any(k in user_msg for k in ("実行", "続けて", "進めて", "自動")):
+        elif intent == "run":
             result = m.run_auto(state)
             n = len(result["executed"])
             reply = (
@@ -94,15 +136,54 @@ with chat_col:
                 + (f"（{result['stop_reason']}）" if result["stop_reason"] else "")
             )
             if state.agent_state.value == "awaiting_approval":
-                reply += "\n\n承認待ちの操作があります。Agentタブで承認してください。"
+                reply += (
+                    "\n\n**承認待ちの操作:**\n" + pending_approval_summary(state)
+                    + "\n\nチャットで「承認」/「却下」と入力するか、承認タブから操作できます。"
+                )
             if state.evaluations and state.evaluations[-1].data_gaps:
                 gaps = "\n".join(f"- {g}" for g in state.evaluations[-1].data_gaps)
                 reply += f"\n\n**追加的に必要なデータ:**\n{gaps}"
+        elif intent in ("approve", "reject"):
+            if not pending:
+                reply = "現在、承認待ちの操作はありません。"
+            elif len(pending) > 1:
+                reply = (
+                    "承認待ちが複数あります。承認タブから個別に操作してください。\n\n"
+                    + pending_approval_summary(state)
+                )
+            else:
+                a = pending[0]
+                approve = intent == "approve"
+                m.resolve_approval(state, a.approval_id, approve)
+                kind = APPROVAL_KIND_LABELS.get(a.kind, a.kind)
+                if approve and a.kind == "script_execution":
+                    reply = f"[{kind}] {a.description} を承認しました。\n\n"
+                    reply += execute_script_approval(m, state, a)
+                elif approve:
+                    reply = (
+                        f"[{kind}] {a.description} を承認しました。"
+                        "\n\n「実行を続けて」で承認済みタスクを実行できます。"
+                    )
+                else:
+                    reply = f"[{kind}] {a.description} を却下しました。"
+        elif intent == "script" and intent_info.get("script"):
+            script = intent_info["script"]
+            req = ApprovalRequest(
+                kind="script_execution",
+                description=(intent_info.get("reason") or user_msg)[:80],
+                payload={"script": script},
+            )
+            state.approvals.append(req)
+            state.audit("human_chat", "script_proposed", approval_id=req.approval_id)
+            reply = (
+                "以下のスクリプトを提案します（未実行）。内容を確認の上、"
+                "チャットで「承認」と入力するか承認タブから承認すると実行されます。\n\n"
+                f"```bash\n{script}\n```"
+            )
         else:
-            # 自由対話（LLM）。実行や承認は行わず、説明・案内のみ。
+            # 自由対話（LLM）。実行や承認は行わず、議論・説明・案内のみ。
             obs = m.observe(state)
             context = {
-                "goal": state.goal.model_dump() if state.goal else None,
                 "agent_state": state.agent_state.value,
                 "observation": obs.model_dump(),
                 "plan": [
@@ -110,19 +191,12 @@ with chat_col:
                      "status": t.status.value, "description": t.description}
                     for t in (state.plan.tasks if state.plan else [])
                 ],
-                "hypotheses": [
-                    {"id": h.hypothesis_id, "statement": h.statement,
-                     "status": h.status.value,
-                     "falsification_conditions": h.falsification_conditions}
-                    for h in state.hypotheses
-                ],
                 "pending_approvals": [
-                    {"id": a.approval_id, "description": a.description}
+                    {"id": a.approval_id, "kind": a.kind, "description": a.description}
                     for a in state.approvals if a.status == "pending"
                 ],
-                "errors": [e.message for e in state.errors if not e.resolved],
-                "data_gaps": (state.evaluations[-1].data_gaps if state.evaluations else []),
                 "stop_reason": state.stop_reason,
+                **m.memory_context(state),
             }
             reply = llm.chat_reply(context, state.chat_history[:-1], user_msg)
             if reply is None:
@@ -150,6 +224,26 @@ with agent_col:
     c3.metric("証拠数", obs.evidence_count)
     if state.stop_reason:
         st.warning(f"停止理由: {state.stop_reason}")
+
+    pending_now = [a for a in state.approvals if a.status == "pending"]
+    if pending_now:
+        st.error(
+            f"承認待ち {len(pending_now)} 件 — 承認タブで内容を確認してください：\n\n"
+            + pending_approval_summary(state)
+        )
+
+    if state.evaluations:
+        with st.expander("記憶（短期: 直近評価 / 長期: 全体履歴）"):
+            mem = m.memory_context(state)
+            st.markdown("**短期記憶（直近の計算の妥当性）**")
+            last = mem["short_term_memory"]["last_evaluation"]
+            if last:
+                st.write(f"- 結果: {last['step_result']} / 品質: {last['result_quality']}")
+                st.write(f"- 進捗: {last['goal_progress_before']:.0%} → {last['goal_progress_after']:.0%}")
+            st.markdown("**長期記憶（全体としての妥当性の材料）**")
+            st.write(f"- 評価履歴: {len(mem['long_term_memory']['evaluation_history'])} 件")
+            st.write(f"- 証拠: {len(mem['long_term_memory']['evidence'])} 件 / "
+                     f"計画改訂: {mem['long_term_memory']['plan_versions']} 回")
 
     if state.evaluations and state.evaluations[-1].data_gaps:
         with st.container(border=True):
@@ -213,14 +307,36 @@ with agent_col:
         if not pending:
             st.caption("承認待ちはありません。")
         for a in pending:
-            st.write(f"{a.approval_id}: {a.description}（task: {a.task_id}）")
-            cols = st.columns(2)
-            if cols[0].button("承認", key=f"ok-{a.approval_id}"):
-                m.resolve_approval(state, a.approval_id, True)
-                st.rerun()
-            if cols[1].button("却下", key=f"ng-{a.approval_id}"):
-                m.resolve_approval(state, a.approval_id, False)
-                st.rerun()
+            with st.container(border=True):
+                kind = APPROVAL_KIND_LABELS.get(a.kind, a.kind)
+                st.markdown(f"**[{kind}]** {a.description}")
+                st.caption(
+                    f"{a.approval_id}"
+                    + (f" / task: {a.task_id}" if a.task_id else "")
+                    + f" / 要求: {time.strftime('%H:%M:%S', time.localtime(a.requested_at))}"
+                )
+                if a.kind == "script_execution" and a.payload.get("script"):
+                    st.code(a.payload["script"], language="bash")
+                cols = st.columns(2)
+                if cols[0].button("承認", key=f"ok-{a.approval_id}", type="primary"):
+                    m.resolve_approval(state, a.approval_id, True)
+                    if a.kind == "script_execution":
+                        reply = execute_script_approval(m, state, a)
+                        state.chat_history.append({"role": "assistant", "content": reply})
+                    m.store.save(state)
+                    st.rerun()
+                if cols[1].button("却下", key=f"ng-{a.approval_id}"):
+                    m.resolve_approval(state, a.approval_id, False)
+                    st.rerun()
+        resolved = [a for a in state.approvals if a.status != "pending"]
+        if resolved:
+            st.markdown("**承認履歴**")
+            for a in reversed(resolved):
+                kind = APPROVAL_KIND_LABELS.get(a.kind, a.kind)
+                mark = "承認" if a.status == "approved" else "却下"
+                when = (time.strftime("%m/%d %H:%M", time.localtime(a.resolved_at))
+                        if a.resolved_at else "-")
+                st.write(f"- [{mark}] [{kind}] {a.description}（{when} / {a.resolved_by}）")
 
     with tabs[3]:
         for e in state.evidence:

--- a/mi_hub2/tests/test_agent_acceptance.py
+++ b/mi_hub2/tests/test_agent_acceptance.py
@@ -304,3 +304,12 @@ def test_evaluation_lists_data_gaps(manager, session):
     assert any("組成点" in g for g in gaps)  # デフォルトは4組成点のため
     assert any("温度" in g for g in gaps)  # デフォルトは単一温度のため
     assert session.evaluations[-1].data_gaps == gaps
+
+
+def test_normalize_goal_property_vocabulary():
+    """LLM が日本語物性名を返してもレジストリ語彙に正規化される。"""
+    from mi_hub.agent.llm import _normalize_goal
+    out = _normalize_goal({"target_property": "相安定性", "success_criteria": ["a"]})
+    assert out["target_property"] == "phase_stability"
+    out = _normalize_goal({"target_property": "Formation Enthalpy"})
+    assert out["target_property"] == "formation_enthalpy"

--- a/mi_hub2/tests/test_agent_acceptance.py
+++ b/mi_hub2/tests/test_agent_acceptance.py
@@ -290,3 +290,17 @@ def test_full_cycle_end_to_end(manager, session):
     assert "最終判定は研究者が行う" in eval_task.result["note"]
     assert session.evaluations
     assert session.stop_reason and "正常終了" in session.stop_reason
+
+
+def test_evaluation_lists_data_gaps(manager, session):
+    """評価結果に追加的に必要なデータ（情報ギャップ）が含まれる。"""
+    manager.run_auto(session)
+    approval = next(a for a in session.approvals if a.status == "pending")
+    manager.resolve_approval(session, approval.approval_id, True)
+    manager.run_auto(session)
+    eval_task = next(t for t in session.plan.tasks if t.action == "evaluate_hypothesis")
+    gaps = eval_task.result["data_gaps"]
+    assert isinstance(gaps, list)
+    assert any("組成点" in g for g in gaps)  # デフォルトは4組成点のため
+    assert any("温度" in g for g in gaps)  # デフォルトは単一温度のため
+    assert session.evaluations[-1].data_gaps == gaps

--- a/mi_hub2/tests/test_agent_acceptance.py
+++ b/mi_hub2/tests/test_agent_acceptance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -323,6 +324,19 @@ def test_run_script_sandbox(manager):
     assert "err" in res["stderr"]
     res = manager.gateway.run_script("exit 3")
     assert res["exit_code"] == 3
+
+
+def test_export_case_report(manager, session):
+    session.chat_history.append({"role": "user", "content": "HEAの安定性を評価したい"})
+    manager.run_auto(session)
+    path = manager.export_case_report(session)
+    assert os.path.exists(path)
+    with open(path, encoding="utf-8") as f:
+        text = f.read()
+    assert "事例レポート" in text
+    assert "研究目標" in text
+    assert "会話ログ" in text
+    assert any(e.action == "case_report_exported" for e in session.audit_log)
 
 
 def test_run_script_workdir(manager, tmp_path):

--- a/mi_hub2/tests/test_agent_acceptance.py
+++ b/mi_hub2/tests/test_agent_acceptance.py
@@ -313,3 +313,52 @@ def test_normalize_goal_property_vocabulary():
     assert out["target_property"] == "phase_stability"
     out = _normalize_goal({"target_property": "Formation Enthalpy"})
     assert out["target_property"] == "formation_enthalpy"
+
+
+def test_run_script_sandbox(manager):
+    """承認ゲート後に呼ぶ run_script が exit code / stdout / stderr を返す。"""
+    res = manager.gateway.run_script("echo hello && echo err >&2")
+    assert res["exit_code"] == 0
+    assert "hello" in res["stdout"]
+    assert "err" in res["stderr"]
+    res = manager.gateway.run_script("exit 3")
+    assert res["exit_code"] == 3
+
+
+def test_classify_intent_fallback():
+    """LLM 不可時、明示的コマンドのみ操作意図になり、それ以外は question。"""
+    from mi_hub.agent.llm import classify_intent
+    assert classify_intent("一時停止", False)["intent"] == "pause"
+    assert classify_intent("実行を続けて", False)["intent"] == "run"
+    assert classify_intent("承認", True)["intent"] == "approve"
+    assert classify_intent("承認", False)["intent"] == "question"
+    assert classify_intent("HEAの安定性について教えて", False)["intent"] == "question"
+
+
+def test_knowledge_provider_registration(manager, session):
+    """登録したナレッジプロバイダ（MCP/GraphRAG差込口）が文献検索に併用される。"""
+    from mi_hub.agent.tools import KnowledgeProvider
+
+    class FakeGraphRAG(KnowledgeProvider):
+        def search(self, query, limit=10):
+            return [{"title": "GraphRAG hit", "claim": "外部ナレッジの主張",
+                     "evidence_type": "computation", "keywords": [], "limitations": []}]
+
+    manager.gateway.register_knowledge_provider(FakeGraphRAG("graphrag"))
+    docs = manager.gateway.search_knowledge("B2 NiAl", limit=10)
+    providers = {d.get("provider") for d in docs}
+    assert "graphrag" in providers
+    assert "mock_literature" in providers
+
+
+def test_memory_context_short_and_long_term(manager, session):
+    """短期記憶（直近評価）と長期記憶（全体履歴）が分離して取得できる。"""
+    manager.run_auto(session)
+    approval = next(a for a in session.approvals if a.status == "pending")
+    manager.resolve_approval(session, approval.approval_id, True)
+    manager.run_auto(session)
+    mem = manager.memory_context(session)
+    assert mem["short_term_memory"]["last_evaluation"] is not None
+    assert mem["short_term_memory"]["recent_tasks"]
+    assert mem["long_term_memory"]["evaluation_history"]
+    assert mem["long_term_memory"]["evidence"]

--- a/mi_hub2/tests/test_agent_acceptance.py
+++ b/mi_hub2/tests/test_agent_acceptance.py
@@ -325,6 +325,14 @@ def test_run_script_sandbox(manager):
     assert res["exit_code"] == 3
 
 
+def test_run_script_workdir(manager, tmp_path):
+    wd = str(tmp_path / "ws")
+    res = manager.gateway.run_script("echo data > result.csv", workdir=wd)
+    assert res["exit_code"] == 0
+    assert res["generated_files"] == ["result.csv"]
+    assert res["workdir"] == wd
+
+
 def test_classify_intent_fallback():
     """LLM 不可時、明示的コマンドのみ操作意図になり、それ以外は question。"""
     from mi_hub.agent.llm import classify_intent


### PR DESCRIPTION
## Summary
評価結果への情報ギャップ提示に加え、チャット/承認/実行系を研究伴走エージェントとして拡張:

- **意図分類チャット**: キーワード部分一致による誤実行をやめ、`classify_intent()`（LLM + 明示コマンドのみのフォールバック）で `run / pause / resume / complete / approve / reject / script / question` に分類。曖昧な入力は question として文脈付き自由対話へ。
- **承認プロセスの可視化**: 承認待ちバナー、承認タブのカード表示（種別・理由・要求時刻・スクリプト本文プレビュー）、承認履歴、チャットでの「承認」/「却下」操作。
- **承認ゲート付きスクリプト実行**: `ToolGateway.run_script(script, timeout_s, workdir)`。チャットの依頼から bash スクリプトを提案（未実行）→ 人間承認後にセッション作業ディレクトリ（`agent_sessions/workspaces/<sid>/`）で実行 → stdout/stderr/exit code と生成ファイル一覧を証拠・監査ログに記録。
- **成果物の可視化**: 証拠タブに実行出力（expander）と生成図（PNG等）をインライン表示。図・CSVは1回の実行で保存する方針をスクリプト生成プロンプトに明記。
- **短期/長期記憶の分離**: `ResearchManager.memory_context()` が短期（直近評価・直近タスク・未解決エラー）と長期（目標・仮説・全証拠・評価履歴・計画改訂数）を分けて返し、UI表示・チャット文脈・API `state.memory` に反映。
- **ナレッジ差込口**: `KnowledgeProvider`（MCP/GraphRAG等）を `ToolGateway.register_knowledge_provider()` で登録し、`search_knowledge()` がモック文献DBと横断検索（プロバイダ障害は隔離）。
- **LLM出力正規化**: `target_property` の日本語語彙（相安定性→phase_stability 等）を正規化し、適用モデル0件で空完了する問題を修正。

UIでの実例（HEA特徴量計算、Al-Mn-Al 距離掃引エネルギー曲線）で提案→承認→実行→図の証拠表示まで確認済み。テスト41件合格。

なお `run_script()` はタイムアウト付きの同一VM実行であり、OSレベルの隔離サンドボックスではない点に注意。

Link to Devin session: https://app.devin.ai/sessions/34d6cef6e2bf43a5a42921d909d237b3
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->