### PR TITLE
feat(mlip_sqs_relaxation): 二元系SQS(BCC/FCC 4x4x4)生成とMACEによる構造緩和パイプライン

### DIFF
--- a/mlip_sqs_relaxation/README.md
+++ b/mlip_sqs_relaxation/README.md
@@ -1,0 +1,58 @@
+# MLIPによる二元系SQS安定構造探索
+
+BCC / FCC の 4×4×4 supercell（BCC: 128原子, FCC: 256原子）に対し、
+HEAでよく用いられる23元素の二元系SQS構造を生成し、
+MLIP（MACE-MP-0）でエネルギー・力を最小化して構造緩和するパイプライン。
+
+## 対象
+
+- 元素（23種）: Ag, Al, Au, Co, Cr, Cu, Fe, Hf, Ir, Mn, Mo, Nb, Ni, Pd, Pt, Re, Rh, Ru, Ta, Ti, V, W, Zr
+- 組成: B元素 0 / 25 / 50 / 75 / 100 at.% の5通り
+  - 0, 100 at.%（純元素）は理想supercellを1構造
+  - 25, 50, 75 at.% は乱数シードを変えたSQSを各3構造
+- 格子: BCC, FCC（--lattice で指定）
+
+## セットアップ
+
+```bash
+sudo apt-get install python3-dev   # icetのビルドに必要
+pip install ase icet mace-torch
+```
+
+## 使い方
+
+### 1. SQS構造生成
+
+```bash
+# 全23元素・全253ペア（時間がかかるためペア指定・元素サブセットも可能）
+python generate_sqs_structures.py --lattice bcc --outdir structures
+python generate_sqs_structures.py --lattice fcc --outdir structures
+
+# サブセット例
+python generate_sqs_structures.py --lattice bcc --pairs "Fe-Ni,Nb-Ta"
+python generate_sqs_structures.py --lattice bcc --elements "Fe,Ni,Cr"
+```
+
+出力: `structures/<lattice>/<A>-<B>/A75B25_seed1.extxyz` など、
+および構造一覧 `structures/<lattice>/manifest.csv`。
+
+SQSは icet の `generate_sqs_from_supercells`（MCアニーリング）で生成。
+初期格子定数は金属半径からVegard則で補間（緩和で最適化されるため初期値の役割のみ）。
+
+### 2. MLIP構造緩和
+
+```bash
+python relax_mlip.py --manifest structures/bcc/manifest.csv
+python relax_mlip.py --manifest structures/fcc/manifest.csv --device cuda
+```
+
+- MACE-MP-0（既定: medium, float64）+ FrechetCellFilter + FIRE で
+  原子位置とセルを同時に緩和（既定 fmax = 0.02 eV/Å）。
+- 出力: `relaxed/<name>_relaxed.extxyz` と `relaxed/results.csv`
+  （全エネルギー, eV/atom, 最大力, 体積, 収束状況など）。
+- `--limit N` で先頭N構造のみ（動作確認用）、`--model small` で高速化。
+
+## 計算規模の目安
+
+全253ペア × 3組成 × 3シード × 2格子 ≒ 4,554構造の緩和となるため、
+GPU（`--device cuda`）の利用、またはペア分割による並列実行を推奨。

--- a/mlip_sqs_relaxation/generate_sqs_structures.py
+++ b/mlip_sqs_relaxation/generate_sqs_structures.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Generate binary SQS supercells (BCC/FCC 4x4x4) for MLIP relaxation.
+
+For each unordered pair of the 23 HEA elements:
+  - Compositions 0/25/50/75/100 at.% of the second element.
+  - Pure endpoints (0, 100 at.%) are generated once as ideal supercells.
+  - Mixed compositions (25, 50, 75 at.%) are generated as SQS
+    (Special Quasi-random Structures) via icet, with N_SEEDS independent
+    random seeds per composition.
+
+Supercell sizes (conventional cubic cells):
+  - BCC 4x4x4 -> 128 atoms
+  - FCC 4x4x4 -> 256 atoms
+
+Output: extxyz files under <outdir>/<lattice>/<A>-<B>/, plus a manifest CSV.
+
+Usage:
+    python generate_sqs_structures.py --lattice bcc --outdir structures
+    python generate_sqs_structures.py --lattice fcc --elements "Fe,Ni,Cr"
+    python generate_sqs_structures.py --lattice bcc --pairs "Fe-Ni,Nb-Ta"
+"""
+
+import argparse
+import csv
+import itertools
+import math
+import os
+
+from ase import Atoms
+from ase.build import bulk
+from ase.io import write as ase_write
+
+HEA_ELEMENTS = sorted([
+    'Al', 'Ag', 'Au', 'Co', 'Cr', 'Cu', 'Fe', 'Hf', 'Ir', 'Mn', 'Mo',
+    'Nb', 'Ni', 'Pd', 'Pt', 'Re', 'Rh', 'Ru', 'Ta', 'Ti', 'V', 'W', 'Zr',
+])
+
+# Metallic (12-coordinate) radii in Angstrom, used only to build a
+# reasonable initial lattice constant via Vegard's law; the MLIP
+# relaxation optimizes the cell afterwards.
+METALLIC_RADIUS = {
+    'Ag': 1.445, 'Al': 1.432, 'Au': 1.442, 'Co': 1.251, 'Cr': 1.249,
+    'Cu': 1.278, 'Fe': 1.241, 'Hf': 1.580, 'Ir': 1.357, 'Mn': 1.350,
+    'Mo': 1.363, 'Nb': 1.429, 'Ni': 1.246, 'Pd': 1.376, 'Pt': 1.387,
+    'Re': 1.375, 'Rh': 1.345, 'Ru': 1.339, 'Ta': 1.430, 'Ti': 1.462,
+    'V': 1.316, 'W': 1.367, 'Zr': 1.603,
+}
+
+COMPOSITIONS = [0, 25, 50, 75, 100]  # at.% of element B
+N_SEEDS = 3
+SUPERCELL = 4  # 4x4x4 conventional cells
+
+
+def lattice_constant(lattice: str, elements, fractions) -> float:
+    """Vegard-interpolated cubic lattice constant from metallic radii."""
+    r = sum(f * METALLIC_RADIUS[e] for e, f in zip(elements, fractions))
+    if lattice == 'bcc':
+        return 4.0 * r / math.sqrt(3.0)
+    return 2.0 * math.sqrt(2.0) * r
+
+
+def make_supercell(lattice: str, element: str, a: float) -> Atoms:
+    prim = bulk(element, lattice, a=a, cubic=True)
+    return prim.repeat((SUPERCELL, SUPERCELL, SUPERCELL))
+
+
+def generate_pure(lattice: str, element: str) -> Atoms:
+    a = lattice_constant(lattice, [element], [1.0])
+    return make_supercell(lattice, element, a)
+
+
+def generate_sqs(lattice: str, elem_a: str, elem_b: str, frac_b: float,
+                 seed: int, n_steps: int) -> Atoms:
+    from icet import ClusterSpace
+    from icet.tools.structure_generation import generate_sqs_from_supercells
+
+    a = lattice_constant(lattice, [elem_a, elem_b], [1.0 - frac_b, frac_b])
+    prim = bulk(elem_a, lattice, a=a)
+    cutoffs = [1.6 * a, 1.2 * a]  # pair and triplet cutoffs
+    cs = ClusterSpace(prim, cutoffs, [[elem_a, elem_b]])
+    supercell = make_supercell(lattice, elem_a, a)
+    sqs = generate_sqs_from_supercells(
+        cluster_space=cs,
+        supercells=[supercell],
+        target_concentrations={elem_a: 1.0 - frac_b, elem_b: frac_b},
+        n_steps=n_steps,
+        random_seed=seed,
+    )
+    return sqs
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--lattice', choices=['bcc', 'fcc'], required=True)
+    parser.add_argument('--outdir', default='structures')
+    parser.add_argument('--elements', default=None,
+                        help='Comma-separated subset of elements')
+    parser.add_argument('--pairs', default=None,
+                        help='Comma-separated pairs, e.g. "Fe-Ni,Nb-Ta"')
+    parser.add_argument('--n-steps', type=int, default=10000,
+                        help='MC steps for SQS annealing')
+    args = parser.parse_args()
+
+    if args.pairs:
+        pairs = []
+        for p in args.pairs.split(','):
+            a, b = sorted(p.strip().split('-'))
+            pairs.append((a, b))
+    else:
+        elements = (sorted(args.elements.replace(' ', '').split(','))
+                    if args.elements else HEA_ELEMENTS)
+        for e in elements:
+            if e not in METALLIC_RADIUS:
+                raise ValueError(f'Unknown element: {e}')
+        pairs = list(itertools.combinations(elements, 2))
+
+    outroot = os.path.join(args.outdir, args.lattice)
+    os.makedirs(outroot, exist_ok=True)
+    manifest_path = os.path.join(outroot, 'manifest.csv')
+    rows = []
+
+    pure_done = {}
+    for elem_a, elem_b in pairs:
+        pair_dir = os.path.join(outroot, f'{elem_a}-{elem_b}')
+        os.makedirs(pair_dir, exist_ok=True)
+        for comp in COMPOSITIONS:
+            frac_b = comp / 100.0
+            if comp in (0, 100):
+                elem = elem_a if comp == 0 else elem_b
+                if elem in pure_done:
+                    continue
+                atoms = generate_pure(args.lattice, elem)
+                fname = os.path.join(outroot, f'pure_{elem}.extxyz')
+                ase_write(fname, atoms)
+                pure_done[elem] = fname
+                rows.append([args.lattice, elem, elem, 0, 0, fname,
+                             len(atoms)])
+                continue
+            for seed in range(1, N_SEEDS + 1):
+                atoms = generate_sqs(args.lattice, elem_a, elem_b, frac_b,
+                                     seed, args.n_steps)
+                fname = os.path.join(
+                    pair_dir,
+                    f'{elem_a}{100 - comp}{elem_b}{comp}_seed{seed}.extxyz')
+                ase_write(fname, atoms)
+                rows.append([args.lattice, elem_a, elem_b, comp, seed,
+                             fname, len(atoms)])
+                print(f'Generated {fname} ({len(atoms)} atoms)')
+
+    with open(manifest_path, 'w', newline='') as f:
+        writer = csv.writer(f)
+        writer.writerow(['lattice', 'element_a', 'element_b',
+                         'at_percent_b', 'seed', 'file', 'n_atoms'])
+        writer.writerows(rows)
+    print(f'Manifest written to {manifest_path} ({len(rows)} structures)')
+
+
+if __name__ == '__main__':
+    main()

--- a/mlip_sqs_relaxation/relax_mlip.py
+++ b/mlip_sqs_relaxation/relax_mlip.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Relax SQS supercells with a machine-learning interatomic potential (MACE).
+
+Reads the manifest produced by generate_sqs_structures.py, relaxes each
+structure (atomic positions and cell) by minimizing energy and forces with
+MACE-MP-0, and writes relaxed structures plus a results CSV.
+
+Usage:
+    python relax_mlip.py --manifest structures/bcc/manifest.csv
+    python relax_mlip.py --manifest structures/fcc/manifest.csv \
+        --fmax 0.02 --max-steps 500 --device cuda
+"""
+
+import argparse
+import csv
+import os
+
+from ase.filters import FrechetCellFilter
+from ase.io import read as ase_read
+from ase.io import write as ase_write
+from ase.optimize import FIRE
+
+
+def relax(atoms, calc, fmax: float, max_steps: int, logfile=None):
+    atoms.calc = calc
+    ecf = FrechetCellFilter(atoms)
+    opt = FIRE(ecf, logfile=logfile)
+    converged = opt.run(fmax=fmax, steps=max_steps)
+    energy = atoms.get_potential_energy()
+    forces = atoms.get_forces()
+    max_force = float(abs(forces).max())
+    return atoms, energy, max_force, bool(converged), opt.get_number_of_steps()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--manifest', required=True,
+                        help='manifest.csv from generate_sqs_structures.py')
+    parser.add_argument('--outdir', default=None,
+                        help='Output dir (default: <manifest dir>/relaxed)')
+    parser.add_argument('--fmax', type=float, default=0.02,
+                        help='Force convergence criterion (eV/A)')
+    parser.add_argument('--max-steps', type=int, default=500)
+    parser.add_argument('--model', default='medium',
+                        help='MACE-MP-0 model size (small/medium/large)')
+    parser.add_argument('--device', default='cpu', help='cpu or cuda')
+    parser.add_argument('--limit', type=int, default=None,
+                        help='Only relax the first N structures (for testing)')
+    args = parser.parse_args()
+
+    from mace.calculators import mace_mp
+    calc = mace_mp(model=args.model, device=args.device,
+                   default_dtype='float64', dispersion=False)
+
+    manifest_dir = os.path.dirname(os.path.abspath(args.manifest))
+    outdir = args.outdir or os.path.join(manifest_dir, 'relaxed')
+    os.makedirs(outdir, exist_ok=True)
+
+    with open(args.manifest, newline='') as f:
+        entries = list(csv.DictReader(f))
+    if args.limit:
+        entries = entries[:args.limit]
+
+    results_path = os.path.join(outdir, 'results.csv')
+    fieldnames = ['lattice', 'element_a', 'element_b', 'at_percent_b',
+                  'seed', 'n_atoms', 'energy_eV', 'energy_per_atom_eV',
+                  'max_force_eV_A', 'volume_A3', 'volume_per_atom_A3',
+                  'converged', 'n_opt_steps', 'relaxed_file']
+    with open(results_path, 'w', newline='') as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for entry in entries:
+            src = entry['file']
+            if not os.path.isabs(src):
+                src = os.path.join(os.path.dirname(manifest_dir) if
+                                   os.path.dirname(src) else manifest_dir,
+                                   src)
+                if not os.path.exists(src):
+                    src = entry['file']
+            atoms = ase_read(src)
+            name = os.path.splitext(os.path.basename(src))[0]
+            print(f'Relaxing {name} ({len(atoms)} atoms) ...', flush=True)
+            atoms, energy, max_force, converged, n_steps = relax(
+                atoms, calc, args.fmax, args.max_steps)
+            relaxed_file = os.path.join(outdir, f'{name}_relaxed.extxyz')
+            ase_write(relaxed_file, atoms)
+            volume = atoms.get_volume()
+            n_atoms = len(atoms)
+            writer.writerow({
+                'lattice': entry['lattice'],
+                'element_a': entry['element_a'],
+                'element_b': entry['element_b'],
+                'at_percent_b': entry['at_percent_b'],
+                'seed': entry['seed'],
+                'n_atoms': n_atoms,
+                'energy_eV': f'{energy:.6f}',
+                'energy_per_atom_eV': f'{energy / n_atoms:.6f}',
+                'max_force_eV_A': f'{max_force:.6f}',
+                'volume_A3': f'{volume:.4f}',
+                'volume_per_atom_A3': f'{volume / n_atoms:.4f}',
+                'converged': converged,
+                'n_opt_steps': n_steps,
+                'relaxed_file': relaxed_file,
+            })
+            f.flush()
+            print(f'  E = {energy:.4f} eV ({energy / n_atoms:.4f} eV/atom), '
+                  f'fmax = {max_force:.4f} eV/A, '
+                  f'converged = {converged} in {n_steps} steps')
+    print(f'Results written to {results_path}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
MLIPによる安定構造探索のためのパイプライン `mlip_sqs_relaxation/` を新規追加。

- `generate_sqs_structures.py`: HEAでよく用いられる23元素（Ag, Al, Au, Co, Cr, Cu, Fe, Hf, Ir, Mn, Mo, Nb, Ni, Pd, Pt, Re, Rh, Ru, Ta, Ti, V, W, Zr）の二元系について、BCC/FCC 4×4×4 supercell（128 / 256原子）を生成。組成はB元素 0/25/50/75/100 at.%の5通りで、25/50/75 at.%は icet の `generate_sqs_from_supercells`（MCアニーリング）により乱数シードを変えたSQSを各3構造、0/100 at.%（純元素）は理想supercellを1構造。初期格子定数は金属半径からVegard則で補間。出力は extxyz + `manifest.csv`。
  - `--pairs "Fe-Ni,Nb-Ta"` / `--elements "Fe,Ni,Cr"` でサブセット実行可能（全体は253ペア×2格子で約4,554構造）。
- `relax_mlip.py`: manifestを読み、MACE-MP-0（float64）+ `FrechetCellFilter` + FIRE で原子位置とセルを同時緩和（既定 fmax=0.02 eV/Å）。緩和後構造と `results.csv`（全エネルギー, eV/atom, 最大力, 体積/原子, 収束状況）を出力。`--device cuda` / `--model small` / `--limit N` に対応。

動作確認: Fe-Ni BCCでSQS生成（シードごとに異なる配置になることを確認）→ MACE-smallで純Fe・Fe75Ni25の緩和が正常終了。

依存: `ase`, `icet`（ビルドに `python3-dev` が必要）, `mace-torch`（詳細は `mlip_sqs_relaxation/README.md`）。

Link to Devin session: https://app.devin.ai/sessions/5af6073681de4de59b1f72b3df6bc61b
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->