### PR TITLE
fix(run_parallel): SQS生成を耐障害化（逐次manifest + エラー行スキップ）

### DIFF
--- a/mlip_sqs_relaxation/run_parallel.py
+++ b/mlip_sqs_relaxation/run_parallel.py
@@ -91,29 +91,39 @@ def generate_sqs(lattice, elem_a, elem_b, frac_b, seed, n_steps):
     )
 
 
-def generate_one(lattice, elem_a, elem_b, comp, seed, outroot, n_steps):
-    frac_b = comp / 100.0
-    if comp == 0 or comp == 100:
-        elem = elem_a if comp == 0 else elem_b
-        atoms = generate_pure(lattice, elem)
-        name = f'pure_{elem}'
-    else:
-        atoms = generate_sqs(lattice, elem_a, elem_b, frac_b, seed, n_steps)
-        name = f'{elem_a}{100 - comp}{elem_b}{comp}_seed{seed}'
-
-    pair_dir = os.path.join(outroot, f'{elem_a}-{elem_b}')
-    os.makedirs(pair_dir, exist_ok=True)
-    fname = os.path.join(pair_dir, f'{name}.extxyz')
-    ase_write(fname, atoms)
-    return {
+def generate_one(args):
+    lattice, elem_a, elem_b, comp, seed, outroot, n_steps = args
+    base = {
         'lattice': lattice,
         'element_a': elem_a,
         'element_b': elem_b,
         'at_percent_b': comp,
         'seed': seed,
-        'file': os.path.relpath(fname, outroot),
-        'n_atoms': len(atoms),
+        'file': '',
+        'n_atoms': '',
+        'error': '',
     }
+    try:
+        frac_b = comp / 100.0
+        if comp == 0 or comp == 100:
+            elem = elem_a if comp == 0 else elem_b
+            atoms = generate_pure(lattice, elem)
+            name = f'pure_{elem}'
+        else:
+            atoms = generate_sqs(lattice, elem_a, elem_b, frac_b, seed, n_steps)
+            name = f'{elem_a}{100 - comp}{elem_b}{comp}_seed{seed}'
+
+        pair_dir = os.path.join(outroot, f'{elem_a}-{elem_b}')
+        os.makedirs(pair_dir, exist_ok=True)
+        fname = os.path.join(pair_dir, f'{name}.extxyz')
+        ase_write(fname, atoms)
+        return {
+            **base,
+            'file': os.path.relpath(fname, outroot),
+            'n_atoms': len(atoms),
+        }
+    except Exception as e:
+        return {**base, 'error': f'generate failed: {e}'}
 
 
 def all_tasks(lattice, elements, outroot, n_steps, n_seeds):
@@ -131,12 +141,16 @@ def all_tasks(lattice, elements, outroot, n_steps, n_seeds):
     return tasks
 
 
+MANIFEST_FIELDS = [
+    'lattice', 'element_a', 'element_b', 'at_percent_b',
+    'seed', 'file', 'n_atoms', 'error',
+]
+
+
 def write_manifest(outroot, rows):
     manifest_path = os.path.join(outroot, 'manifest.csv')
     with open(manifest_path, 'w', newline='') as f:
-        writer = csv.DictWriter(f, fieldnames=[
-            'lattice', 'element_a', 'element_b', 'at_percent_b',
-            'seed', 'file', 'n_atoms'])
+        writer = csv.DictWriter(f, fieldnames=MANIFEST_FIELDS)
         writer.writeheader()
         writer.writerows(rows)
     return manifest_path
@@ -148,11 +162,24 @@ def generate_lattice(lattice, elements, workdir, n_steps, n_seeds, workers):
     tasks = all_tasks(lattice, elements, outroot, n_steps, n_seeds)
 
     ctx = get_context('spawn')
-    with ctx.Pool(workers) as pool:
-        rows = pool.starmap(generate_one, tasks)
+    manifest_path = os.path.join(outroot, 'manifest.csv')
+    with open(manifest_path, 'w', newline='') as f, ctx.Pool(workers) as pool:
+        writer = csv.DictWriter(f, fieldnames=MANIFEST_FIELDS)
+        writer.writeheader()
+        f.flush()
+        n = len(tasks)
+        for i, row in enumerate(pool.imap_unordered(generate_one, tasks), 1):
+            writer.writerow(row)
+            f.flush()
+            pair = f"{row['element_a']}-{row['element_b']}"
+            if row.get('error'):
+                print(f'[{i}/{n}] ERROR generating {pair} {row["at_percent_b"]}% '
+                      f'seed {row["seed"]}: {row["error"]}', flush=True)
+            else:
+                print(f'[{i}/{n}] generated {pair} {row["at_percent_b"]}% '
+                      f'seed {row["seed"]} (n_atoms={row["n_atoms"]})', flush=True)
 
-    manifest_path = write_manifest(outroot, rows)
-    print(f'[{lattice}] Generated {len(rows)} structures in {outroot}')
+    print(f'[{lattice}] Generated {n} structures; manifest at {manifest_path}')
     return manifest_path
 
 
@@ -200,7 +227,12 @@ def _relax_one(args):
         'relaxed_file': '',
     }
 
+    if entry.get('error'):
+        return {**base, 'error': f'skipped: {entry["error"]}'}
+
     src = entry['file']
+    if not src:
+        return {**base, 'error': 'skipped: no file in manifest'}
     if not os.path.isabs(src):
         src = os.path.join(manifest_dir, src)
     try:


### PR DESCRIPTION
## Summary

`run_parallel.py` の SQS 生成工程を all-or-nothing から耐障害な実装に変更し、1件の失敗が全体を止めないようにしました。

- `generate_one` を `try/except` で囲み、失敗時も `error` 列を含む manifest 行を返すようにしました。
- `generate_lattice` を `pool.starmap` から `imap_unordered` + 逐次 `writer.writerow` + `flush` に変更。1件ずつ manifest に追記し、進捗 `[i/n]` を出力します。
- manifest に `error` 列を追加。
- 緩和側 `_relax_one` で `error` 行または `file` が空の行をスキップするようにしました。

これにより、253×3 ペアの大規模 SQS 生成で一部の組み合わせが例外を投げても、他の構造は引き続き生成・緩和され、一覧 CSV も途中まで保持されます。


Link to Devin session: https://app.devin.ai/sessions/5af6073681de4de59b1f72b3df6bc61b
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->