### PR TITLE
fix(mi_hub2): バグ検証で見つかった6件の問題を修正

### DIFF
--- a/mi_hub2/src/mi_hub/agent/graphrag.py
+++ b/mi_hub2/src/mi_hub/agent/graphrag.py
@@ -301,7 +301,8 @@ class GraphRAGProvider(KnowledgeProvider):
                     continue
                 if entry.get("action") != "search":
                     continue
-                for tok in MaterialsTokenizer._segment(entry.get("query", "")):
+                # 名詞連続の複合語（例: 積層欠陥エネルギー）を候補として抽出する
+                for tok in self.tokenizer.extract_entities(entry.get("query", "")):
                     if len(tok) >= 3 and tok not in self.tokenizer.user_terms:
                         counts[tok] = counts.get(tok, 0) + 1
         new_terms = sorted(t for t, c in counts.items() if c >= min_count)

--- a/mi_hub2/src/mi_hub/agent/graphrag.py
+++ b/mi_hub2/src/mi_hub/agent/graphrag.py
@@ -292,7 +292,13 @@ class GraphRAGProvider(KnowledgeProvider):
         counts: dict[str, int] = {}
         with open(self.log_path, encoding="utf-8") as f:
             for line in f:
-                entry = json.loads(line)
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
                 if entry.get("action") != "search":
                     continue
                 for tok in MaterialsTokenizer._segment(entry.get("query", "")):

--- a/mi_hub2/src/mi_hub/agent/loop.py
+++ b/mi_hub2/src/mi_hub/agent/loop.py
@@ -455,6 +455,10 @@ class ResearchManager:
         req = state.approval(approval_id)
         if req is None:
             raise ValueError(f"承認要求が存在しません: {approval_id}")
+        if req.status != "pending":
+            raise ValueError(
+                f"承認要求は既に解決済みです: {approval_id}（{req.status}）"
+            )
         req.status = "approved" if approve else "rejected"
         req.resolved_at = _time.time()
         req.resolved_by = by

--- a/mi_hub2/src/mi_hub/agent/tools.py
+++ b/mi_hub2/src/mi_hub/agent/tools.py
@@ -145,7 +145,9 @@ class ToolGateway:
             if score > 0:
                 hits.append((score, doc))
         hits.sort(key=lambda x: -x[0])
-        return [d for _, d in hits[:limit]]
+        # 共有辞書の汚染を防ぐためコピーを返す
+        return [{**d, "conditions": dict(d.get("conditions", {}))}
+                for _, d in hits[:limit]]
 
     # --- t2ModelQuery ---
     def search_models(self, target_property: str, elements: list[str],
@@ -241,9 +243,10 @@ class ToolGateway:
                 "generated_files": generated,
             }
         except subprocess.TimeoutExpired:
+            generated = sorted(set(os.listdir(workdir)) - before) if workdir else []
             return {"exit_code": -1, "stdout": "",
                     "stderr": f"timeout: 実行が {timeout_s} 秒を超過",
-                    "workdir": workdir, "generated_files": []}
+                    "workdir": workdir, "generated_files": generated}
         finally:
             os.unlink(path)
 

--- a/mi_hub2/src/mi_hub/agent/ui_streamlit.py
+++ b/mi_hub2/src/mi_hub/agent/ui_streamlit.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import html
 import os
 import time
 
@@ -34,7 +35,9 @@ def execute_script_approval(manager: ResearchManager, s: SessionState,
         claim=f"スクリプト実行（exit code {res['exit_code']}）: {approval.description}",
         conditions={
             "approval_id": approval.approval_id,
+            "exit_code": res["exit_code"],
             "stdout": res["stdout"][-2000:],
+            "stderr": res["stderr"][-2000:],
             "workdir": workdir,
             "generated_files": res["generated_files"],
         },
@@ -78,12 +81,12 @@ def render_research_loop(s: SessionState) -> None:
             f'font-size:0.78rem;white-space:nowrap;">{stage}</span>'
         )
     arrow = '<span style="color:#bbb;font-size:0.75rem;">→</span>'
-    html = ('<div style="display:flex;gap:4px;align-items:center;'
-            'flex-wrap:wrap;margin-bottom:8px;">' + arrow.join(pills) + "</div>")
+    block = ('<div style="display:flex;gap:4px;align-items:center;'
+             'flex-wrap:wrap;margin-bottom:8px;">' + arrow.join(pills) + "</div>")
     if current is None:
-        html += (f'<div style="font-size:0.8rem;color:#888;">現在の状態: '
-                 f'<b>{s.agent_state.value}</b>（ループ外）</div>')
-    st.markdown(html, unsafe_allow_html=True)
+        block += (f'<div style="font-size:0.8rem;color:#888;">現在の状態: '
+                  f'<b>{s.agent_state.value}</b>（ループ外）</div>')
+    st.markdown(block, unsafe_allow_html=True)
 
 
 AUDIT_ACTION_LABELS = {
@@ -128,6 +131,8 @@ def render_timeline(s: SessionState) -> None:
         return
     for ts, icon, label, detail in events:
         t = time.strftime("%m/%d %H:%M:%S", time.localtime(ts))
+        label = html.escape(label)
+        detail = html.escape(detail)
         st.markdown(
             f'<div style="border-left:3px solid #ddd;padding:2px 0 2px 10px;'
             f'margin-left:4px;"><span style="color:#999;font-size:0.75rem;">{t}</span>'
@@ -191,8 +196,9 @@ with st.sidebar:
         m.generate_plan(state)
         st.session_state["sid"] = state.session_id
         st.rerun()
-    if selected != "(新規)":
+    if selected != "(新規)" and selected != st.session_state.get("last_selected"):
         st.session_state["sid"] = selected
+    st.session_state["last_selected"] = selected
     if st.session_state.get("sid"):
         cur = m.store.load(st.session_state["sid"])
         if cur is not None and st.button("事例レポートを書き出す"):

--- a/mi_hub2/tests/test_agent_acceptance.py
+++ b/mi_hub2/tests/test_agent_acceptance.py
@@ -231,7 +231,7 @@ class TestHumanInTheLoop:
         assert exec_task.status == TaskState.AWAITING_APPROVAL
 
     def test_approval_then_execution(self, manager, session):
-        result = manager.run_auto(session)
+        manager.run_auto(session)
         approval = next(a for a in session.approvals if a.status == "pending")
         manager.resolve_approval(session, approval.approval_id, True)
         manager.run_auto(session)
@@ -491,3 +491,52 @@ class TestLLMProviders:
         assert _parse_json_text('```json\n{"a": 1}\n```') == {"a": 1}
         assert _parse_json_text('{"a": 1}') == {"a": 1}
         assert _parse_json_text("not json") is None
+
+
+class TestBugRegressions:
+    """バグ検証で見つかった問題の回帰試験。"""
+
+    def test_resolve_approval_rejects_double_resolution(self, manager, session):
+        from mi_hub.agent.models import ApprovalRequest
+
+        req = ApprovalRequest(kind="script_execution", description="test",
+                              payload={"script": "echo ok"})
+        session.approvals.append(req)
+        manager.resolve_approval(session, req.approval_id, True)
+        with pytest.raises(ValueError):
+            manager.resolve_approval(session, req.approval_id, False)
+        assert req.status == "approved"
+
+    def test_search_literature_returns_copies(self, manager):
+        gw = manager.gateway
+        docs = gw.search_literature("NiAl antisite")
+        assert docs
+        docs[0]["claim"] = "改変"
+        docs[0]["conditions"]["injected"] = True
+        again = gw.search_literature("NiAl antisite")
+        assert again[0]["claim"] != "改変"
+        assert "injected" not in again[0]["conditions"]
+
+    def test_search_knowledge_does_not_pollute_registry(self, manager):
+        gw = manager.gateway
+        gw.search_knowledge("NiAl antisite")
+        assert all("provider" not in d for d in gw.literature)
+
+    def test_run_script_timeout_reports_generated_files(self, manager, tmp_path):
+        wd = str(tmp_path / "ws-timeout")
+        res = manager.gateway.run_script(
+            "echo x > out.txt\nsleep 5", timeout_s=1, workdir=wd,
+        )
+        assert res["exit_code"] == -1
+        assert "out.txt" in res["generated_files"]
+
+    def test_update_from_logs_skips_corrupt_lines(self, tmp_path):
+        from mi_hub.agent.graphrag import build_default_provider
+
+        provider = build_default_provider(str(tmp_path / "graphrag"))
+        with open(provider.log_path, "a", encoding="utf-8") as f:
+            f.write("{broken json\n\n")
+        provider.search("ナノ結晶粒微細化 の文献")
+        provider.search("ナノ結晶粒微細化 を調べたい")
+        added = provider.update_from_logs(min_count=2)
+        assert isinstance(added, list)

--- a/mi_hub2/tests/test_agent_acceptance.py
+++ b/mi_hub2/tests/test_agent_acceptance.py
@@ -540,3 +540,13 @@ class TestBugRegressions:
         provider.search("ナノ結晶粒微細化 を調べたい")
         added = provider.update_from_logs(min_count=2)
         assert isinstance(added, list)
+
+    def test_update_from_logs_adds_compound_terms(self, tmp_path):
+        from mi_hub.agent.graphrag import build_default_provider
+
+        provider = build_default_provider(str(tmp_path / "graphrag"))
+        provider.search("積層欠陥エネルギー と 相安定性 の関係")
+        provider.search("積層欠陥エネルギー の文献を調べたい")
+        added = provider.update_from_logs(min_count=2)
+        assert "積層欠陥エネルギー" in added
+        assert provider.tokenizer.tokenize("積層欠陥エネルギーの評価")[0] == "積層欠陥エネルギー"


### PR DESCRIPTION
## Summary
mi_hub2 全モジュールのバグ検証（状態遷移・永続化・例外経路・境界条件の観点）で見つかった問題の修正。

- **承認の二重解決を禁止**（`ResearchManager.resolve_approval`）: 解決済み承認を再度 approve/reject でき、判断の上書き（rejected→approved）やスクリプトの二重実行が可能だった → pending 以外は `ValueError`
- **モック文献レジストリの汚染防止**（`ToolGateway.search_literature`）: 共有 dict への参照をそのまま返しており、`search_knowledge` の `setdefault("provider", ...)` や呼出し側の変更がレジストリ本体を書き換えていた → `conditions` を含めコピーを返す
- **timeout 時に生成物が失われる**（`ToolGateway.run_script`）: `TimeoutExpired` 分岐で `generated_files: []` 固定だった → timeout 前に保存されたファイルも報告（「1回の実行で成果物を保存する」方針との整合）
- **利用ログの破損行でクラッシュ**（`GraphRAGProvider.update_from_logs`）: JSONL に不正行・空行があると `json.JSONDecodeError` で辞書更新が失敗 → スキップして継続
- **UI: 新規セッション作成直後に旧選択で上書き**（サイドバー）: selectbox の選択が rerun ごとに `sid` を上書きし、既存セッション選択後に「セッション開始」しても直前のセッションへ戻ってしまう → 選択が変化した時のみ `sid` を更新
- **UI: タイムラインの HTML 注入**: 監査ログ・承認説明・エラーメッセージを `unsafe_allow_html=True` で未エスケープ描画 → `html.escape` を適用。また証拠の `conditions` に `stderr` / `exit_code` を保存（失敗時の情報が事例レポートに残るように）

回帰テスト5件を `TestBugRegressions` として追加（計58件合格）。PR #464 の上に積んだスタックPR。


Link to Devin session: https://app.devin.ai/sessions/34d6cef6e2bf43a5a42921d909d237b3
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->