### PR TITLE
feat(mi_hub2): Slurmジョブ投入・DFT入力生成・OQMD実データ接続・事例ナレッジ自動還元・NIMS proxy対応セットアップ

### DIFF
--- a/mi_hub2/scripts/setup_env.sh
+++ b/mi_hub2/scripts/setup_env.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# MI-HUB2 環境構築スクリプト（NIMS proxy 対応）
+#
+# 使い方:
+#   bash mi_hub2/scripts/setup_env.sh            # proxy 自動判別
+#   MI_HUB_PROXY=on  bash mi_hub2/scripts/setup_env.sh   # NIMS proxy を強制使用
+#   MI_HUB_PROXY=off bash mi_hub2/scripts/setup_env.sh   # proxy を使わない
+#
+# NIMS 内ネットワークでは wwwout.nims.go.jp:8888 経由で外部へ出る。
+# proxy の要否を自動判別し、apt / pip / curl の proxy 設定を切り替える。
+
+set -euo pipefail
+
+NIMS_PROXY="http://wwwout.nims.go.jp:8888"
+MI_HUB_PROXY="${MI_HUB_PROXY:-auto}"
+
+log() { echo "[setup_env] $*"; }
+
+# ---------- 1. proxy 判別 ----------
+use_proxy=""
+case "$MI_HUB_PROXY" in
+  on)  use_proxy="yes" ;;
+  off) use_proxy="no" ;;
+  auto)
+    # 既に環境変数で proxy が設定されていればそれを尊重
+    if [ -n "${https_proxy:-}${HTTPS_PROXY:-}" ]; then
+      use_proxy="preset"
+    # 直接外へ出られるか（5秒）
+    elif curl -s --max-time 5 -o /dev/null https://pypi.org; then
+      use_proxy="no"
+    # NIMS proxy 経由で外へ出られるか
+    elif curl -s --max-time 5 -x "$NIMS_PROXY" -o /dev/null https://pypi.org; then
+      use_proxy="yes"
+    else
+      log "エラー: 直接接続・NIMS proxy 経由のいずれでも外部へ接続できません。"
+      log "ネットワーク設定を確認するか、MI_HUB_PROXY=on/off を明示してください。"
+      exit 1
+    fi
+    ;;
+  *) log "エラー: MI_HUB_PROXY は auto / on / off のいずれかを指定してください。"; exit 1 ;;
+esac
+
+PIP_ARGS=()
+APT_ARGS=()
+if [ "$use_proxy" = "yes" ]; then
+  log "NIMS proxy（$NIMS_PROXY）を使用します。"
+  export http_proxy="$NIMS_PROXY" https_proxy="$NIMS_PROXY"
+  export HTTP_PROXY="$NIMS_PROXY" HTTPS_PROXY="$NIMS_PROXY"
+  export no_proxy="localhost,127.0.0.1,.nims.go.jp"
+  PIP_ARGS=(--proxy "$NIMS_PROXY")
+  APT_ARGS=(-o "Acquire::http::Proxy=$NIMS_PROXY" -o "Acquire::https::Proxy=$NIMS_PROXY")
+elif [ "$use_proxy" = "preset" ]; then
+  log "既存の proxy 設定（${https_proxy:-$HTTPS_PROXY}）を使用します。"
+else
+  log "proxy なし（直接接続）で進めます。"
+fi
+
+# ---------- 2. OS パッケージ ----------
+if command -v apt-get >/dev/null 2>&1; then
+  log "apt: 日本語フォント等をインストールします。"
+  sudo apt-get "${APT_ARGS[@]}" update -q
+  sudo apt-get "${APT_ARGS[@]}" install -y -q fonts-noto-cjk zstd
+else
+  log "警告: apt-get が無いため OS パッケージ（fonts-noto-cjk）はスキップします。"
+fi
+
+# ---------- 3. Python パッケージ ----------
+log "pip: エージェント基盤・GraphRAG・ML・MLIP を導入します。"
+pip install "${PIP_ARGS[@]}" -q --upgrade pip
+pip install "${PIP_ARGS[@]}" -q \
+  pydantic fastapi uvicorn streamlit httpx pytest ruff openai
+pip install "${PIP_ARGS[@]}" -q fugashi unidic-lite
+pip install "${PIP_ARGS[@]}" -q scikit-learn pycaret xgboost lightgbm
+pip install "${PIP_ARGS[@]}" -q chgnet
+# PyCaret(scikit-plot) が scipy>=1.12 で動かないためピン留め
+# （CHGNet / pymatgen は 1.11.4 で動作確認済み）
+pip install "${PIP_ARGS[@]}" -q "scipy==1.11.4"
+
+# ---------- 4. 動作確認 ----------
+log "動作確認: 主要モジュールの import を検証します。"
+python3 - <<'PY'
+import fastapi, streamlit, httpx, pydantic  # noqa: F401
+import fugashi  # noqa: F401
+import sklearn, xgboost, lightgbm  # noqa: F401
+import scipy
+from pycaret.classification import setup  # noqa: F401
+from chgnet.model import CHGNet  # noqa: F401
+print(f"OK: scipy {scipy.__version__} / 全モジュール import 成功")
+PY
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+(cd "$REPO_ROOT/mi_hub2" && PYTHONPATH=src python3 -m pytest tests -q)
+
+log "完了。UI 起動:"
+log "  (cd mi_hub2 && PYTHONPATH=src streamlit run src/mi_hub/agent/ui_streamlit.py --server.port 8501 --server.headless true)"
+log "Slurm を使う場合:"
+log "  export MI_HUB_SCHEDULER=slurm"
+log "  export MI_HUB_SLURM_SSH_HOST=<HPCログインノード>   # SSH経由の場合のみ"

--- a/mi_hub2/src/mi_hub/agent/dft.py
+++ b/mi_hub2/src/mi_hub/agent/dft.py
@@ -1,0 +1,82 @@
+"""DFT（VASP）入力の自動生成。
+
+vasp_inputs/ のB2生成パイプラインと同じ規約（INCAR / POSCAR / KPOINTS）で、
+エージェントの承認ゲート付きジョブ投入（scheduler.py）に接続するための
+最小限の入力生成を提供する。POTCAR は擬ポテンシャルのライセンス上
+生成せず、HPC 側の make_potcar.sh / VASP_PP_PATH に委ねる。
+"""
+
+from __future__ import annotations
+
+import os
+
+DEFAULT_INCAR = {
+    "PREC": "Accurate",
+    "ENCUT": 520,
+    "EDIFF": 1e-6,
+    "ISMEAR": 1,
+    "SIGMA": 0.2,
+    "IBRION": 2,
+    "ISIF": 3,
+    "NSW": 60,
+    "ISPIN": 2,
+    "LREAL": ".FALSE.",
+    "LWAVE": ".FALSE.",
+    "LCHARG": ".FALSE.",
+}
+
+
+def format_incar(overrides: dict[str, object] | None = None) -> str:
+    params: dict[str, object] = dict(DEFAULT_INCAR)
+    params.update(overrides or {})
+    return "\n".join(f"{k} = {v}" for k, v in params.items()) + "\n"
+
+
+def format_kpoints(mesh: tuple[int, int, int] = (11, 11, 11)) -> str:
+    return (
+        "Automatic mesh\n0\nGamma\n"
+        f"{mesh[0]} {mesh[1]} {mesh[2]}\n0 0 0\n"
+    )
+
+
+def format_poscar_b2(elem_a: str, elem_b: str, a0: float) -> str:
+    """B2（CsCl型）2原子セルの POSCAR。Aがコーナー、Bが体心。"""
+    return (
+        f"B2 {elem_a}{elem_b}\n"
+        f"{a0:.6f}\n"
+        "1.0 0.0 0.0\n0.0 1.0 0.0\n0.0 0.0 1.0\n"
+        f"{elem_a} {elem_b}\n1 1\nDirect\n"
+        "0.0 0.0 0.0\n0.5 0.5 0.5\n"
+    )
+
+
+def format_poscar(comment: str, a0: float,
+                  lattice: list[list[float]],
+                  species: list[str], counts: list[int],
+                  positions: list[list[float]]) -> str:
+    """任意構造（Direct座標）の POSCAR。"""
+    if len(species) != len(counts):
+        raise ValueError("species と counts の長さが一致しません")
+    if sum(counts) != len(positions):
+        raise ValueError("counts の合計と positions の数が一致しません")
+    lines = [comment, f"{a0:.6f}"]
+    lines += [" ".join(f"{x:.10f}" for x in row) for row in lattice]
+    lines += [" ".join(species), " ".join(str(c) for c in counts), "Direct"]
+    lines += [" ".join(f"{x:.10f}" for x in p) for p in positions]
+    return "\n".join(lines) + "\n"
+
+
+def write_vasp_inputs(workdir: str, poscar: str,
+                      incar_overrides: dict[str, object] | None = None,
+                      kmesh: tuple[int, int, int] = (11, 11, 11)) -> list[str]:
+    """INCAR / POSCAR / KPOINTS を workdir に書き出し、ファイル名一覧を返す。"""
+    os.makedirs(workdir, exist_ok=True)
+    files = {
+        "INCAR": format_incar(incar_overrides),
+        "POSCAR": poscar,
+        "KPOINTS": format_kpoints(kmesh),
+    }
+    for name, content in files.items():
+        with open(os.path.join(workdir, name), "w", encoding="utf-8") as f:
+            f.write(content)
+    return sorted(files)

--- a/mi_hub2/src/mi_hub/agent/graphrag.py
+++ b/mi_hub2/src/mi_hub/agent/graphrag.py
@@ -172,6 +172,23 @@ class GraphRAGProvider(KnowledgeProvider):
             json.dump({"docs": self.docs, "edges": self.edges}, f,
                       ensure_ascii=False, indent=1)
 
+    def ingest_case_report(self, session_id: str, goal_statement: str,
+                           report_text: str) -> list[str]:
+        """事例レポートを事例ナレッジとしてグラフへ取り込む。
+
+        同一セッションの再取込は上書き扱い。過去事例の手法・結果が
+        検索・仮説候補・プロセス改善提案の根拠に使われるようになる。
+        """
+        entities = self.add_document(
+            doc_id=f"case:{session_id}",
+            title=f"事例: {goal_statement[:60]}",
+            text=report_text,
+            source=f"case_report/{session_id}",
+        )
+        self._log("case_ingested", session_id=session_id,
+                  entities=len(entities))
+        return entities
+
     # ---------- 検索（KnowledgeProvider インターフェイス） ----------
     def search(self, query: str, limit: int = 10) -> list[dict[str, Any]]:
         q_ents = [e for e in self.tokenizer.extract_entities(query)

--- a/mi_hub2/src/mi_hub/agent/loop.py
+++ b/mi_hub2/src/mi_hub/agent/loop.py
@@ -14,7 +14,11 @@ from pathlib import Path
 from typing import Any
 
 from . import llm
+from .graphrag import GraphRAGProvider
 from .models import (
+    ApprovalRequest,
+    Evidence,
+    JobRecord,
     Observation,
     Plan,
     PlanChange,
@@ -31,6 +35,11 @@ from .roles import (
     ModelSelectionAgent,
     SafetyApprovalAgent,
     VerificationPlanningAgent,
+)
+from .scheduler import (
+    SchedulerError,
+    SchedulerGateway,
+    resolve_scheduler_from_env,
 )
 from .states import AgentState, HypothesisState, TaskState
 from .tools import ToolGateway
@@ -77,9 +86,11 @@ class ResearchManager:
     """研究セッション全体を統括する（§5.1）。"""
 
     def __init__(self, gateway: ToolGateway | None = None,
-                 store: SessionStore | None = None):
+                 store: SessionStore | None = None,
+                 scheduler: SchedulerGateway | None = None):
         self.gateway = gateway or ToolGateway()
         self.store = store or SessionStore()
+        self.scheduler = scheduler or resolve_scheduler_from_env()
         self.safety = SafetyApprovalAgent()
         self._roles = {
             "EvidenceAgent": EvidenceAgent(),
@@ -340,6 +351,99 @@ class ResearchManager:
         d.mkdir(parents=True, exist_ok=True)
         return str(d)
 
+    # ---------- 外部ジョブ（Slurm等、承認必須） ----------
+    def propose_job(self, state: SessionState, name: str, script: str,
+                    kind: str = "dft", description: str = "",
+                    estimated_node_hours: float = 1.0) -> JobRecord:
+        """外部ジョブを提案し、承認要求を登録する（投入は承認後のみ）。"""
+        job = JobRecord(
+            scheduler=self.scheduler.name, name=name, kind=kind, script=script,
+            workdir=os.path.join(self.session_workspace(state), "jobs", name),
+            estimated_node_hours=estimated_node_hours,
+        )
+        req = ApprovalRequest(
+            kind="job_submission",
+            description=description or f"外部ジョブ投入: {name}（{kind}、"
+                        f"推定 {estimated_node_hours:.1f} ノード時間）",
+            payload={"job_id": job.job_id, "script": script,
+                     "estimated_node_hours": estimated_node_hours},
+        )
+        job.approval_id = req.approval_id
+        state.jobs.append(job)
+        state.approvals.append(req)
+        state.audit("ResearchManager", "job_proposed", job_id=job.job_id,
+                    approval_id=req.approval_id, name=name, kind=kind)
+        self.store.save(state)
+        return job
+
+    def submit_approved_job(self, state: SessionState, job_id: str) -> JobRecord:
+        """承認済みジョブをスケジューラへ投入する。"""
+        import time as _time
+
+        job = state.job(job_id)
+        if job is None:
+            raise ValueError(f"ジョブが存在しません: {job_id}")
+        if job.state != "proposed":
+            raise ValueError(f"ジョブは投入済みです: {job_id}（{job.state}）")
+        approval = state.approval(job.approval_id) if job.approval_id else None
+        if approval is None or approval.status != "approved":
+            raise ValueError(f"未承認のジョブは投入できません: {job_id}")
+        remaining = state.budget.max_node_hours - state.budget.used_node_hours
+        if job.estimated_node_hours > remaining:
+            raise ValueError(
+                f"ノード時間予算不足: 残 {remaining:.1f}h < 推定 {job.estimated_node_hours:.1f}h"
+            )
+        job.scheduler_job_id = self.scheduler.submit(job.script, job.workdir, job.name)
+        job.state = self.scheduler.status(job.scheduler_job_id)
+        job.submitted_at = _time.time()
+        state.budget.used_node_hours += job.estimated_node_hours
+        state.audit("ResearchManager", "job_submitted", job_id=job.job_id,
+                    scheduler_job_id=job.scheduler_job_id, state=job.state)
+        if job.state in ("completed", "failed", "cancelled"):
+            self._finalize_job(state, job)
+        self.store.save(state)
+        return job
+
+    def poll_jobs(self, state: SessionState) -> list[JobRecord]:
+        """未完了ジョブの状態をポーリングし、完了したものを証拠化する。"""
+        updated = []
+        for job in state.jobs:
+            if job.state not in ("pending", "running") or not job.scheduler_job_id:
+                continue
+            try:
+                new_state = self.scheduler.status(job.scheduler_job_id)
+            except SchedulerError as exc:
+                state.audit("ResearchManager", "job_poll_failed",
+                            job_id=job.job_id, error=str(exc))
+                continue
+            if new_state != job.state:
+                job.state = new_state
+                if new_state in ("completed", "failed", "cancelled"):
+                    self._finalize_job(state, job)
+                updated.append(job)
+        if updated:
+            self.store.save(state)
+        return updated
+
+    def _finalize_job(self, state: SessionState, job: JobRecord) -> None:
+        import time as _time
+
+        job.finished_at = _time.time()
+        generated = sorted(os.listdir(job.workdir)) if os.path.isdir(job.workdir) else []
+        state.evidence.append(Evidence(
+            source_type="external_job",
+            claim=f"外部ジョブ {job.name}（{job.kind}）が {job.state} で終了",
+            conditions={"job_id": job.job_id,
+                        "scheduler": job.scheduler,
+                        "scheduler_job_id": job.scheduler_job_id,
+                        "workdir": job.workdir,
+                        "generated_files": generated},
+            evidence_type="computation",
+            limitations=["外部計算の終了状態。科学的妥当性は出力の検証が必要"],
+        ))
+        state.audit("ResearchManager", "job_finished", job_id=job.job_id,
+                    state=job.state)
+
     # ---------- Case report (事例の蓄積) ----------
     def export_case_report(self, state: SessionState) -> str:
         """セッションを事例レポート（Markdown）として作業ディレクトリに書き出す。
@@ -403,9 +507,19 @@ class ResearchManager:
                 for e in state.errors
             ] + [""]
         path = os.path.join(self.session_workspace(state), "case_report.md")
+        report_text = "\n".join(lines)
         with open(path, "w", encoding="utf-8") as f:
-            f.write("\n".join(lines))
+            f.write(report_text)
         state.audit("ResearchManager", "case_report_exported", path=path)
+        # 事例ナレッジの自動還元: GraphRAG が登録済みなら事例として取り込む
+        for provider in self.gateway.knowledge_providers:
+            if isinstance(provider, GraphRAGProvider):
+                provider.ingest_case_report(
+                    state.session_id,
+                    state.goal.statement if state.goal else state.session_id,
+                    report_text)
+                state.audit("ResearchManager", "case_knowledge_ingested",
+                            provider=provider.name)
         self.store.save(state)
         return path
 

--- a/mi_hub2/src/mi_hub/agent/models.py
+++ b/mi_hub2/src/mi_hub/agent/models.py
@@ -134,11 +134,14 @@ class Budget(BaseModel):
     used_model_runs: int = 0
     max_gpu_hours: float = 10.0
     used_gpu_hours: float = 0.0
+    max_node_hours: float = 24.0  # 外部ジョブ（DFT等）のノード時間上限
+    used_node_hours: float = 0.0
 
     def exceeded(self) -> bool:
         return (
             self.used_model_runs >= self.max_model_runs
             or self.used_gpu_hours >= self.max_gpu_hours
+            or self.used_node_hours >= self.max_node_hours
         )
 
 
@@ -194,6 +197,24 @@ class Observation(BaseModel):
     iterations_remaining: int = 0
 
 
+class JobRecord(BaseModel):
+    """外部スケジューラ（Slurm等）へ投入したジョブの記録。"""
+
+    job_id: str = Field(default_factory=lambda: _uid("JOB"))
+    scheduler_job_id: str | None = None
+    scheduler: str = "local_mock"
+    name: str = ""
+    kind: str = "dft"
+    state: str = "proposed"  # proposed / pending / running / completed / failed / cancelled
+    workdir: str = ""
+    script: str = ""
+    approval_id: str | None = None
+    estimated_node_hours: float = 0.0
+    submitted_at: float | None = None
+    finished_at: float | None = None
+    detail: dict[str, Any] = Field(default_factory=dict)
+
+
 class SessionState(BaseModel):
     """研究セッションの作業記憶（§7.1、§15）。"""
 
@@ -214,6 +235,13 @@ class SessionState(BaseModel):
     next_action_candidates: list[str] = Field(default_factory=list)
     stop_reason: str | None = None
     chat_history: list[dict[str, str]] = Field(default_factory=list)
+    jobs: list[JobRecord] = Field(default_factory=list)
+
+    def job(self, jid: str) -> JobRecord | None:
+        for j in self.jobs:
+            if j.job_id == jid:
+                return j
+        return None
 
     def hypothesis(self, hid: str) -> Hypothesis | None:
         for h in self.hypotheses:

--- a/mi_hub2/src/mi_hub/agent/oqmd.py
+++ b/mi_hub2/src/mi_hub/agent/oqmd.py
@@ -1,0 +1,86 @@
+"""OQMD（Open Quantum Materials Database）実データ接続。
+
+oqmdapi（https://oqmd.org/oqmdapi）から生成エネルギー・安定性を取得し、
+KnowledgeProvider として ToolGateway に登録すると文献検索と併せて
+実データが証拠収集へ流れる。プロキシは httpx が環境変数
+（http_proxy / https_proxy）から自動適用する。
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import httpx
+
+from .tools import KnowledgeProvider, ToolError
+
+_BASE_URL = "https://oqmd.org/oqmdapi"
+_COMPOSITION_RE = re.compile(r"^(?:[A-Z][a-z]?\d*)+$")
+
+
+class OQMDProvider(KnowledgeProvider):
+    """OQMD の生成エネルギーデータを検索結果（文書スキーマ）として返す。"""
+
+    def __init__(self, base_url: str = _BASE_URL, timeout_s: float = 30.0):
+        super().__init__("oqmd")
+        self.base_url = base_url.rstrip("/")
+        self.timeout_s = timeout_s
+
+    def get_formation_energies(self, composition: str,
+                               limit: int = 10) -> list[dict[str, Any]]:
+        """組成（例: 'Al2O3'、'Al-Mn'）の生成エネルギーエントリを取得する。"""
+        if not _COMPOSITION_RE.match(composition.replace("-", "")):
+            raise ToolError(f"不正な組成指定: {composition!r}")
+        try:
+            resp = httpx.get(
+                f"{self.base_url}/formationenergy",
+                params={
+                    "composition": composition,
+                    "limit": limit,
+                    "fields": "name,entry_id,spacegroup,delta_e,stability,"
+                              "band_gap,prototype",
+                },
+                timeout=self.timeout_s,
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            raise ToolError(f"OQMD API 呼出し失敗: {exc}") from exc
+        return payload.get("data", [])
+
+    def search(self, query: str, limit: int = 10) -> list[dict[str, Any]]:
+        """query から組成らしき語を抽出して OQMD を照会する。"""
+        compositions = [
+            tok for tok in re.split(r"[\s,、。]+", query)
+            if len(tok) >= 2 and _COMPOSITION_RE.match(tok.replace("-", ""))
+            and any(c.islower() or c.isdigit() or c == "-" for c in tok)
+        ]
+        docs: list[dict[str, Any]] = []
+        for comp in compositions[:2]:
+            for entry in self.get_formation_energies(comp, limit=limit):
+                delta_e = entry.get("delta_e")
+                stability = entry.get("stability")
+                docs.append({
+                    "title": f"OQMD entry {entry.get('entry_id')}: {entry.get('name')}",
+                    "source_type": "database",
+                    "claim": (
+                        f"{entry.get('name')} の DFT 生成エネルギーは "
+                        f"{delta_e if delta_e is not None else '不明'} eV/atom"
+                        + (f"、convex hull からの距離は {stability} eV/atom"
+                           if stability is not None else "")
+                    ),
+                    "evidence_type": "computation",
+                    "conditions": {
+                        "entry_id": entry.get("entry_id"),
+                        "spacegroup": entry.get("spacegroup"),
+                        "prototype": entry.get("prototype"),
+                        "band_gap": entry.get("band_gap"),
+                        "database": "OQMD",
+                    },
+                    "keywords": [str(entry.get("name")), "OQMD", "formation energy"],
+                    "limitations": [
+                        "OQMD の DFT (PBE) 計算値。実験値・他汎関数との差に注意",
+                    ],
+                })
+        return docs[:limit]

--- a/mi_hub2/src/mi_hub/agent/scheduler.py
+++ b/mi_hub2/src/mi_hub/agent/scheduler.py
@@ -1,0 +1,212 @@
+"""外部計算資源へのジョブ投入層（Slurm / ローカルモック）。
+
+DFT等の長時間計算を「投入→ポーリング→結果回収」の非同期モデルで扱う。
+投入は必ず人間承認後（submit_dft_job は承認必須アクション）。
+SlurmScheduler はログインノード上での直接実行と SSH 経由の両方に対応する。
+"""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+
+#: Slurm→内部状態の対応。内部状態は pending / running / completed / failed / cancelled
+_SLURM_STATE_MAP = {
+    "PENDING": "pending",
+    "CONFIGURING": "pending",
+    "RUNNING": "running",
+    "COMPLETING": "running",
+    "COMPLETED": "completed",
+    "FAILED": "failed",
+    "TIMEOUT": "failed",
+    "OUT_OF_MEMORY": "failed",
+    "NODE_FAIL": "failed",
+    "CANCELLED": "cancelled",
+}
+
+
+class SchedulerError(RuntimeError):
+    pass
+
+
+class SchedulerGateway:
+    """ジョブスケジューラの差し込み口。
+
+    submit / status / cancel を実装すれば Slurm 以外（PBS 等）にも差し替え可能。
+    """
+
+    name: str = "scheduler"
+
+    def submit(self, script: str, workdir: str, job_name: str) -> str:
+        """ジョブスクリプトを投入し、スケジューラのジョブIDを返す。"""
+        raise NotImplementedError
+
+    def status(self, scheduler_job_id: str) -> str:
+        """pending / running / completed / failed / cancelled のいずれかを返す。"""
+        raise NotImplementedError
+
+    def cancel(self, scheduler_job_id: str) -> None:
+        raise NotImplementedError
+
+
+class SlurmScheduler(SchedulerGateway):
+    """Slurm（sbatch / squeue / sacct / scancel）によるジョブ投入。
+
+    ssh_host を指定すると HPC ログインノードへ SSH 経由でコマンドを送る
+    （鍵認証を前提とし、パスワードは扱わない）。
+    """
+
+    name = "slurm"
+
+    def __init__(self, ssh_host: str | None = None, timeout_s: int = 60):
+        self.ssh_host = ssh_host
+        self.timeout_s = timeout_s
+
+    def _run(self, args: list[str]) -> subprocess.CompletedProcess[str]:
+        if self.ssh_host:
+            cmd = ["ssh", self.ssh_host, " ".join(shlex.quote(a) for a in args)]
+        else:
+            cmd = args
+        return subprocess.run(cmd, capture_output=True, text=True,
+                              timeout=self.timeout_s, check=False)
+
+    def submit(self, script: str, workdir: str, job_name: str) -> str:
+        script_path = f"{workdir}/{job_name}.sbatch"
+        if self.ssh_host:
+            proc = subprocess.run(
+                ["ssh", self.ssh_host,
+                 f"mkdir -p {shlex.quote(workdir)} && cat > {shlex.quote(script_path)}"],
+                input=script, capture_output=True, text=True,
+                timeout=self.timeout_s, check=False)
+            if proc.returncode != 0:
+                raise SchedulerError(f"スクリプト転送失敗: {proc.stderr[-500:]}")
+        else:
+            import os
+            os.makedirs(workdir, exist_ok=True)
+            with open(script_path, "w", encoding="utf-8") as f:
+                f.write(script)
+        proc = self._run(["sbatch", "--parsable", "--chdir", workdir, script_path])
+        if proc.returncode != 0:
+            raise SchedulerError(f"sbatch 失敗: {proc.stderr[-500:]}")
+        return proc.stdout.strip().split(";")[0]
+
+    def status(self, scheduler_job_id: str) -> str:
+        proc = self._run(["squeue", "-h", "-j", scheduler_job_id, "-o", "%T"])
+        raw = proc.stdout.strip()
+        if proc.returncode == 0 and raw:
+            return _SLURM_STATE_MAP.get(raw, "running")
+        # キューに無い場合は sacct で終了状態を確認
+        proc = self._run(["sacct", "-n", "-X", "-j", scheduler_job_id,
+                          "-o", "State", "--parsable2"])
+        raw = proc.stdout.strip().splitlines()[0].strip() if proc.stdout.strip() else ""
+        raw = raw.split(" ")[0]  # "CANCELLED by ..." 対策
+        if not raw:
+            raise SchedulerError(f"ジョブ状態を取得できません: {scheduler_job_id}")
+        return _SLURM_STATE_MAP.get(raw, "failed")
+
+    def cancel(self, scheduler_job_id: str) -> None:
+        proc = self._run(["scancel", scheduler_job_id])
+        if proc.returncode != 0:
+            raise SchedulerError(f"scancel 失敗: {proc.stderr[-500:]}")
+
+
+class LocalMockScheduler(SchedulerGateway):
+    """HPC の無い環境で全経路を検証するためのモック。
+
+    submit 時に bash で即時実行し、終了状態を保持する。
+    Slurm と同じインターフェイスなので、承認・予算・ポーリングの
+    ワークフローをローカルでそのまま試験できる。
+    """
+
+    name = "local_mock"
+
+    def __init__(self, timeout_s: int = 600):
+        self.timeout_s = timeout_s
+        self._jobs: dict[str, str] = {}
+        self._seq = 0
+
+    def submit(self, script: str, workdir: str, job_name: str) -> str:
+        import os
+        os.makedirs(workdir, exist_ok=True)
+        script_path = f"{workdir}/{job_name}.sbatch"
+        with open(script_path, "w", encoding="utf-8") as f:
+            f.write(script)
+        self._seq += 1
+        job_id = f"mock-{self._seq}"
+        try:
+            proc = subprocess.run(["bash", script_path], capture_output=True,
+                                  text=True, timeout=self.timeout_s,
+                                  cwd=workdir, check=False)
+            with open(f"{workdir}/{job_name}.out", "w", encoding="utf-8") as f:
+                f.write(proc.stdout)
+            with open(f"{workdir}/{job_name}.err", "w", encoding="utf-8") as f:
+                f.write(proc.stderr)
+            self._jobs[job_id] = "completed" if proc.returncode == 0 else "failed"
+        except subprocess.TimeoutExpired:
+            self._jobs[job_id] = "failed"
+        return job_id
+
+    def status(self, scheduler_job_id: str) -> str:
+        if scheduler_job_id not in self._jobs:
+            raise SchedulerError(f"ジョブ状態を取得できません: {scheduler_job_id}")
+        return self._jobs[scheduler_job_id]
+
+    def cancel(self, scheduler_job_id: str) -> None:
+        self._jobs[scheduler_job_id] = "cancelled"
+
+
+def make_sbatch_script(command: str, job_name: str,
+                       partition: str | None = None,
+                       nodes: int = 1, ntasks: int = 1,
+                       time_limit: str = "01:00:00",
+                       modules: list[str] | None = None) -> str:
+    """VASP/QE 等の実行コマンドから sbatch スクリプトを組み立てる。"""
+    lines = [
+        "#!/bin/bash",
+        f"#SBATCH --job-name={job_name}",
+        f"#SBATCH --nodes={nodes}",
+        f"#SBATCH --ntasks={ntasks}",
+        f"#SBATCH --time={time_limit}",
+        f"#SBATCH --output={job_name}.out",
+        f"#SBATCH --error={job_name}.err",
+    ]
+    if partition:
+        lines.append(f"#SBATCH --partition={partition}")
+    lines.append("")
+    for mod in modules or []:
+        lines.append(f"module load {mod}")
+    lines += ["", command, ""]
+    return "\n".join(lines)
+
+
+def estimate_node_hours(nodes: int, time_limit: str) -> float:
+    """time_limit（HH:MM:SS または D-HH:MM:SS）からノード時間上限を見積もる。"""
+    days = 0
+    if "-" in time_limit:
+        d, time_limit = time_limit.split("-", 1)
+        days = int(d)
+    parts = [int(p) for p in time_limit.split(":")]
+    while len(parts) < 3:
+        parts.insert(0, 0)
+    h, m, s = parts
+    return nodes * (days * 24 + h + m / 60 + s / 3600)
+
+
+def build_scheduler(kind: str = "local_mock",
+                    ssh_host: str | None = None) -> SchedulerGateway:
+    if kind == "slurm":
+        return SlurmScheduler(ssh_host=ssh_host)
+    if kind == "local_mock":
+        return LocalMockScheduler()
+    raise ValueError(f"未対応のスケジューラ種別: {kind}")
+
+
+def resolve_scheduler_from_env() -> SchedulerGateway:
+    """環境変数からスケジューラを解決する。
+
+    MI_HUB_SCHEDULER: slurm / local_mock（既定 local_mock）
+    MI_HUB_SLURM_SSH_HOST: SSH 経由で Slurm を使う場合のホスト名
+    """
+    import os
+    kind = os.environ.get("MI_HUB_SCHEDULER", "local_mock")
+    return build_scheduler(kind, ssh_host=os.environ.get("MI_HUB_SLURM_SSH_HOST"))

--- a/mi_hub2/src/mi_hub/agent/ui_streamlit.py
+++ b/mi_hub2/src/mi_hub/agent/ui_streamlit.py
@@ -16,11 +16,13 @@ from mi_hub.agent import llm
 from mi_hub.agent.graphrag import GraphRAGProvider, build_default_provider
 from mi_hub.agent.loop import ResearchManager
 from mi_hub.agent.models import ApprovalRequest, Evidence, SessionState
+from mi_hub.agent.oqmd import OQMDProvider
 from mi_hub.agent.states import HypothesisState
 
 APPROVAL_KIND_LABELS = {
     "task_execution": "タスク実行",
     "script_execution": "スクリプト実行",
+    "job_submission": "外部ジョブ投入",
 }
 
 
@@ -99,6 +101,10 @@ AUDIT_ACTION_LABELS = {
     "approval_resolved": ("\U0001f44d", "承認判断"),
     "script_executed": ("\U0001f4bb", "スクリプト実行"),
     "case_report_exported": ("\U0001f4c4", "事例レポート出力"),
+    "case_knowledge_ingested": ("\U0001f9e0", "事例ナレッジ取込"),
+    "job_proposed": ("\U0001f4e6", "ジョブ提案"),
+    "job_submitted": ("\U0001f680", "ジョブ投入"),
+    "job_finished": ("\U0001f3c1", "ジョブ終了"),
 }
 
 
@@ -174,6 +180,7 @@ def get_manager() -> ResearchManager:
     manager = ResearchManager()
     graphrag_dir = os.path.join(str(manager.store.base_dir), "graphrag")
     manager.gateway.register_knowledge_provider(build_default_provider(graphrag_dir))
+    manager.gateway.register_knowledge_provider(OQMDProvider())
     return manager
 
 
@@ -400,7 +407,7 @@ with agent_col:
             for gap in state.evaluations[-1].data_gaps:
                 st.write(f"- {gap}")
 
-    tabs = st.tabs(["計画", "仮説", "承認", "証拠", "エラー", "履歴", "タイムライン"])
+    tabs = st.tabs(["計画", "仮説", "承認", "証拠", "エラー", "履歴", "タイムライン", "ジョブ"])
 
     with tabs[0]:
         if state.plan:
@@ -572,3 +579,34 @@ with agent_col:
 
     with tabs[6]:
         render_timeline(state)
+
+    with tabs[7]:
+        st.caption(
+            f"スケジューラ: {m.scheduler.name}（MI_HUB_SCHEDULER で切替） / "
+            f"ノード時間: {state.budget.used_node_hours:.1f}"
+            f" / {state.budget.max_node_hours:.1f} h"
+        )
+        if st.button("ジョブ状態を更新（ポーリング）"):
+            updated = m.poll_jobs(state)
+            if updated:
+                st.success(f"{len(updated)} 件のジョブ状態を更新しました")
+            st.rerun()
+        if state.jobs:
+            st.dataframe(pd.DataFrame([
+                {"job": j.job_id, "name": j.name, "kind": j.kind,
+                 "state": j.state, "scheduler_job_id": j.scheduler_job_id,
+                 "推定ノード時間": j.estimated_node_hours,
+                 "workdir": j.workdir}
+                for j in state.jobs
+            ]), use_container_width=True)
+            for j in state.jobs:
+                if j.state == "proposed":
+                    approval = state.approval(j.approval_id) if j.approval_id else None
+                    if approval and approval.status == "approved":
+                        if st.button(f"投入: {j.name}", key=f"submit-{j.job_id}"):
+                            m.submit_approved_job(state, j.job_id)
+                            st.rerun()
+                    else:
+                        st.info(f"{j.name}: 承認待ち（承認タブで判断してください）")
+        else:
+            st.write("外部ジョブはまだありません。")

--- a/mi_hub2/tests/test_agent_jobs.py
+++ b/mi_hub2/tests/test_agent_jobs.py
@@ -1,0 +1,190 @@
+"""外部ジョブ投入（Slurm/モック）・DFT入力生成・OQMD・事例還元の試験。"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from mi_hub.agent.dft import format_poscar, format_poscar_b2, write_vasp_inputs
+from mi_hub.agent.graphrag import build_default_provider
+from mi_hub.agent.loop import ResearchManager, SessionStore
+from mi_hub.agent.oqmd import OQMDProvider
+from mi_hub.agent.scheduler import (
+    LocalMockScheduler,
+    SchedulerError,
+    SlurmScheduler,
+    build_scheduler,
+    estimate_node_hours,
+    make_sbatch_script,
+)
+from mi_hub.agent.tools import ToolError, ToolGateway
+
+
+@pytest.fixture()
+def manager(tmp_path):
+    return ResearchManager(gateway=ToolGateway(),
+                           store=SessionStore(str(tmp_path)),
+                           scheduler=LocalMockScheduler())
+
+
+@pytest.fixture()
+def session(manager):
+    return manager.create_session("Al-Mn B2構造の生成エネルギーをDFTで検証する")
+
+
+class TestScheduler:
+    def test_sbatch_script_format(self):
+        script = make_sbatch_script("srun vasp_std", "b2_almn",
+                                    partition="regular", nodes=2,
+                                    time_limit="02:00:00",
+                                    modules=["vasp/6.4"])
+        assert "#SBATCH --job-name=b2_almn" in script
+        assert "#SBATCH --nodes=2" in script
+        assert "#SBATCH --partition=regular" in script
+        assert "module load vasp/6.4" in script
+        assert script.rstrip().endswith("srun vasp_std")
+
+    def test_estimate_node_hours(self):
+        assert estimate_node_hours(2, "02:30:00") == pytest.approx(5.0)
+        assert estimate_node_hours(1, "1-00:00:00") == pytest.approx(24.0)
+        assert estimate_node_hours(1, "30:00") == pytest.approx(0.5)
+
+    def test_local_mock_lifecycle(self, tmp_path):
+        sched = LocalMockScheduler()
+        jid = sched.submit("echo hello > result.txt", str(tmp_path / "wd"), "job1")
+        assert sched.status(jid) == "completed"
+        assert (tmp_path / "wd" / "result.txt").read_text().strip() == "hello"
+        jid2 = sched.submit("exit 3", str(tmp_path / "wd"), "job2")
+        assert sched.status(jid2) == "failed"
+        with pytest.raises(SchedulerError):
+            sched.status("unknown-id")
+
+    def test_slurm_status_mapping(self, monkeypatch):
+        sched = SlurmScheduler()
+        outputs = {}
+
+        def fake_run(args):
+            return subprocess.CompletedProcess(args, 0,
+                                               stdout=outputs[args[0]], stderr="")
+
+        monkeypatch.setattr(sched, "_run", fake_run)
+        outputs.update({"squeue": "RUNNING\n"})
+        assert sched.status("123") == "running"
+        outputs.update({"squeue": "", "sacct": "COMPLETED\n"})
+        assert sched.status("123") == "completed"
+        outputs.update({"sacct": "CANCELLED by 1000\n"})
+        assert sched.status("123") == "cancelled"
+        outputs.update({"sacct": ""})
+        with pytest.raises(SchedulerError):
+            sched.status("123")
+
+    def test_build_scheduler(self):
+        assert build_scheduler("local_mock").name == "local_mock"
+        assert build_scheduler("slurm", ssh_host="hpc").ssh_host == "hpc"
+        with pytest.raises(ValueError):
+            build_scheduler("pbs")
+
+
+class TestJobWorkflow:
+    def test_unapproved_job_cannot_be_submitted(self, manager, session):
+        job = manager.propose_job(session, "b2_almn", "echo dft",
+                                  estimated_node_hours=1.0)
+        assert job.state == "proposed"
+        with pytest.raises(ValueError, match="未承認"):
+            manager.submit_approved_job(session, job.job_id)
+
+    def test_approved_job_runs_and_records_evidence(self, manager, session):
+        job = manager.propose_job(session, "b2_almn",
+                                  "echo -8.21 > energy.txt",
+                                  estimated_node_hours=0.5)
+        manager.resolve_approval(session, job.approval_id, True)
+        job = manager.submit_approved_job(session, job.job_id)
+        assert job.state == "completed"
+        assert session.budget.used_node_hours == pytest.approx(0.5)
+        ev = [e for e in session.evidence if e.source_type == "external_job"]
+        assert ev and "energy.txt" in ev[0].conditions["generated_files"]
+        # 再投入は拒否される
+        with pytest.raises(ValueError, match="投入済み"):
+            manager.submit_approved_job(session, job.job_id)
+
+    def test_budget_limit_blocks_submission(self, manager, session):
+        session.budget.max_node_hours = 1.0
+        job = manager.propose_job(session, "big", "echo x",
+                                  estimated_node_hours=5.0)
+        manager.resolve_approval(session, job.approval_id, True)
+        with pytest.raises(ValueError, match="予算不足"):
+            manager.submit_approved_job(session, job.job_id)
+
+    def test_session_persists_jobs(self, manager, session):
+        manager.propose_job(session, "b2_almn", "echo dft")
+        loaded = manager.store.load(session.session_id)
+        assert loaded.jobs and loaded.jobs[0].name == "b2_almn"
+
+
+class TestDFTInputs:
+    def test_write_vasp_inputs(self, tmp_path):
+        poscar = format_poscar_b2("Al", "Mn", 2.95)
+        files = write_vasp_inputs(str(tmp_path / "b2"), poscar)
+        assert files == ["INCAR", "KPOINTS", "POSCAR"]
+        text = (tmp_path / "b2" / "POSCAR").read_text()
+        assert "Al Mn" in text and "0.5 0.5 0.5" in text
+        assert "ENCUT = 520" in (tmp_path / "b2" / "INCAR").read_text()
+
+    def test_format_poscar_validates(self):
+        with pytest.raises(ValueError):
+            format_poscar("bad", 4.0, [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+                          ["Al"], [2], [[0, 0, 0]])
+
+
+class TestOQMD:
+    def test_search_extracts_composition_and_maps_schema(self, monkeypatch):
+        def fake_get(url, params=None, timeout=None):
+            assert params["composition"] == "Al2O3"
+            return httpx.Response(
+                200,
+                json={"data": [{"name": "Al2O3", "entry_id": 14842,
+                                "delta_e": -3.2536, "stability": 0.0115,
+                                "spacegroup": "R-3c", "band_gap": 5.8,
+                                "prototype": "corundum"}]},
+                request=httpx.Request("GET", url),
+            )
+
+        monkeypatch.setattr(httpx, "get", fake_get)
+        docs = OQMDProvider().search("Al2O3 の生成エネルギーを知りたい")
+        assert docs and docs[0]["source_type"] == "database"
+        assert "-3.2536 eV/atom" in docs[0]["claim"]
+        assert docs[0]["conditions"]["entry_id"] == 14842
+
+    def test_invalid_composition_rejected(self):
+        with pytest.raises(ToolError, match="不正な組成"):
+            OQMDProvider().get_formation_energies("../etc")
+
+    def test_api_error_becomes_tool_error(self, monkeypatch):
+        def fake_get(url, params=None, timeout=None):
+            raise httpx.ConnectError("proxy required")
+
+        monkeypatch.setattr(httpx, "get", fake_get)
+        with pytest.raises(ToolError, match="OQMD API"):
+            OQMDProvider().get_formation_energies("Al2O3")
+
+
+class TestCaseKnowledge:
+    def test_case_report_auto_ingested_into_graphrag(self, manager, session,
+                                                     tmp_path):
+        provider = build_default_provider(str(tmp_path / "graphrag"))
+        manager.gateway.register_knowledge_provider(provider)
+        session.chat_history.append(
+            {"role": "user", "content": "中距離秩序の安定性をMLIPで評価した"})
+        manager.export_case_report(session)
+        doc_id = f"case:{session.session_id}"
+        assert doc_id in provider.docs
+        hits = provider.search("中距離秩序 の過去事例")
+        assert any(h.get("doc_id") == doc_id for h in hits)
+        assert any(a.action == "case_knowledge_ingested"
+                   for a in session.audit_log)


### PR DESCRIPTION
## Summary
研究環境を外部計算資源・実データベースへ拡張する4機能＋環境構築スクリプト。

**1. Slurmジョブ投入基盤（`agent/scheduler.py` / `loop.py` / `models.py`）**
- `SchedulerGateway` 抽象層（submit / status / cancel）に `SlurmScheduler`（sbatch/squeue/sacct、SSH経由のHPCログインノード対応）と `LocalMockScheduler`（HPCなしで全経路を検証できる即時bash実行）を実装。`MI_HUB_SCHEDULER` / `MI_HUB_SLURM_SSH_HOST` で切替
- ジョブは承認必須: `propose_job()` → 承認要求（kind=`job_submission`、推定ノード時間つき） → `submit_approved_job()`（未承認・再投入・予算超過は拒否） → `poll_jobs()` で状態追跡、終了時に証拠・監査ログへ自動記録
- `Budget` に `max_node_hours` / `used_node_hours` を追加、`SessionState.jobs`（`JobRecord`）で永続化。UIに「ジョブ」タブ（一覧・ポーリング・投入ボタン）を追加

**2. DFT入力の自動生成（`agent/dft.py`）**
- `vasp_inputs/` と同じ規約で INCAR / POSCAR / KPOINTS を生成（B2 2原子セル＋任意構造）。POTCAR はライセンス上 HPC 側の `VASP_PP_PATH` に委ねる。`make_sbatch_script()` で sbatch スクリプトを組み立て

**3. OQMD実データ接続（`agent/oqmd.py`）**
- `OQMDProvider(KnowledgeProvider)`: oqmdapi から生成エネルギー・hull距離を取得し文書スキーマへ変換、UIの検索経路に登録済み。組成の入力検証・接続エラーの `ToolError` 化。実APIで MnAl（Δe=-0.268 eV/atom）等の取得を確認済み

**4. 事例ナレッジの自動還元（`agent/graphrag.py` / `loop.py`）**
- `export_case_report()` 時に GraphRAG が登録済みなら `ingest_case_report()` で事例（doc_id=`case:<session_id>`）として知識グラフへ自動取込。過去事例の手法・結果が検索・仮説候補・プロセス改善提案の根拠に使われる（「同じ計算を繰り返さない」の仕組み化）

**5. NIMS proxy対応セットアップ（`scripts/setup_env.sh`）**
- proxy 自動判別（直接接続 → NIMS proxy `wwwout.nims.go.jp:8888` の順に疎通確認、`MI_HUB_PROXY=on/off/auto` で強制可）し、apt / pip の proxy 設定を切替。全依存（agent基盤・fugashi・ML・PyCaret用 scipy==1.11.4 ピン・CHGNet・fonts-noto-cjk）を導入し、import検証と pytest まで実行。本VM（proxyなし経路）で完走確認済み

テスト15件追加（Slurm状態マッピング・承認/予算/再投入ガード・DFT入力・OQMDスキーマ変換・事例取込）、全74件合格。PR #464 の上のスタックPR。


Link to Devin session: https://app.devin.ai/sessions/34d6cef6e2bf43a5a42921d909d237b3
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->