### PR TITLE
fix(mi_hub2): ジョブ投入直後に永続化し状態確認失敗時の二重投入を防止

### DIFF
--- a/mi_hub2/src/mi_hub/agent/loop.py
+++ b/mi_hub2/src/mi_hub/agent/loop.py
@@ -394,11 +394,20 @@ class ResearchManager:
                 f"ノード時間予算不足: 残 {remaining:.1f}h < 推定 {job.estimated_node_hours:.1f}h"
             )
         job.scheduler_job_id = self.scheduler.submit(job.script, job.workdir, job.name)
-        job.state = self.scheduler.status(job.scheduler_job_id)
+        # 投入直後にまず永続化する（直後の状態確認が失敗しても二重投入を防ぐ）
+        job.state = "pending"
         job.submitted_at = _time.time()
         state.budget.used_node_hours += job.estimated_node_hours
         state.audit("ResearchManager", "job_submitted", job_id=job.job_id,
                     scheduler_job_id=job.scheduler_job_id, state=job.state)
+        self.store.save(state)
+        try:
+            job.state = self.scheduler.status(job.scheduler_job_id)
+        except SchedulerError as exc:
+            state.audit("ResearchManager", "job_poll_failed",
+                        job_id=job.job_id, error=str(exc))
+            self.store.save(state)
+            return job
         if job.state in ("completed", "failed", "cancelled"):
             self._finalize_job(state, job)
         self.store.save(state)

--- a/mi_hub2/tests/test_agent_jobs.py
+++ b/mi_hub2/tests/test_agent_jobs.py
@@ -113,6 +113,28 @@ class TestJobWorkflow:
         with pytest.raises(ValueError, match="投入済み"):
             manager.submit_approved_job(session, job.job_id)
 
+    def test_status_failure_after_submit_persists_job(self, manager, session,
+                                                      monkeypatch):
+        """投入直後の状態確認が失敗しても投入済みとして永続化される（二重投入防止）。"""
+        job = manager.propose_job(session, "flaky", "echo x",
+                                  estimated_node_hours=0.5)
+        manager.resolve_approval(session, job.approval_id, True)
+
+        def flaky_status(scheduler_job_id):
+            raise SchedulerError("job not visible yet")
+
+        monkeypatch.setattr(manager.scheduler, "status", flaky_status)
+        job = manager.submit_approved_job(session, job.job_id)
+        assert job.state == "pending"
+        assert job.scheduler_job_id is not None
+        loaded = manager.store.load(session.session_id)
+        assert loaded.jobs[0].state == "pending"
+        assert loaded.jobs[0].scheduler_job_id == job.scheduler_job_id
+        assert loaded.budget.used_node_hours == pytest.approx(0.5)
+        # 再投入はガードされる
+        with pytest.raises(ValueError, match="投入済み"):
+            manager.submit_approved_job(session, job.job_id)
+
     def test_budget_limit_blocks_submission(self, manager, session):
         session.budget.max_node_hours = 1.0
         job = manager.propose_job(session, "big", "echo x",


### PR DESCRIPTION
## Summary
PR #466 のレビュー指摘（Devin Review）の修正。`submit_approved_job()` で `scheduler.submit()` 成功直後の `scheduler.status()` が `SchedulerError` を送出すると（Slurmでsqueue/sacctにまだ現れない過渡状態で起こりうる）、`scheduler_job_id`・予算消費が保存される前に例外が伝播し、UIからの再投入で同じ計算がHPCへ二重投入される恐れがあった。

修正: submit 直後にまず `state="pending"`・`scheduler_job_id`・ノード時間を永続化してから status を確認し、失敗時は `job_poll_failed` を監査ログに記録して pending のまま返す（以後は `poll_jobs()` が追跡）。

```python
job.scheduler_job_id = self.scheduler.submit(...)
job.state = "pending"; store.save(state)      # 先に永続化
try: job.state = self.scheduler.status(...)   # 失敗しても二重投入されない
except SchedulerError: audit + return job
```

回帰テスト追加（status失敗後も pending で永続化・再投入ガード）。全75件合格。


Link to Devin session: https://app.devin.ai/sessions/34d6cef6e2bf43a5a42921d909d237b3
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->