### PR TITLE
fix(mi_hub2): PR #470 の Devin Review 指摘対応（物性正規化・UI承認経路・LAMMPS要件検証・承認の単回化）

### DIFF
--- a/mi_hub2/src/mi_hub/agent/codes.py
+++ b/mi_hub2/src/mi_hub/agent/codes.py
@@ -175,6 +175,14 @@ def recommend_codes(req: CalcRequirements) -> list[CodeRecommendation]:
             reasons=reasons, cautions=cautions, resource=spec.resource,
         ))
     out.sort(key=lambda r: r.score, reverse=True)
+    if not out and props:
+        # 物性名が語彙と一致せず全コードが除外された場合のフォールバック:
+        # 物性条件を外して全候補を提示し、その旨を留意点に明記する
+        out = recommend_codes(req.model_copy(update={"properties": []}))
+        for r in out:
+            r.cautions.insert(
+                0, f"指定物性（{', '.join(props)}）はカタログ語彙と一致せず、"
+                   "物性条件を外して順位付けした")
     return out
 
 

--- a/mi_hub2/src/mi_hub/agent/llm.py
+++ b/mi_hub2/src/mi_hub/agent/llm.py
@@ -252,6 +252,12 @@ def structure_calc_requirements(hypothesis: str, goal: str = "",
         f"研究目標: {goal}\n仮説: {hypothesis}",
     )
     if out:
+        props_raw = out.get("properties")
+        if isinstance(props_raw, str):
+            props_raw = [props_raw]
+        if isinstance(props_raw, list):
+            normed = [_normalize_property(p) for p in props_raw if p]
+            out["properties"] = list(dict.fromkeys(p for p in normed if p))
         return out
     # フォールバック: キーワード抽出
     text = f"{goal} {hypothesis}"

--- a/mi_hub2/src/mi_hub/agent/loop.py
+++ b/mi_hub2/src/mi_hub/agent/loop.py
@@ -464,15 +464,20 @@ class ResearchManager:
         name = p.get("job_name", f"{code}_{'-'.join(elements).lower()}")
         workdir = os.path.join(self.session_workspace(state), "jobs", name)
         gen = scriptgen.generate_inputs(code, workdir, elements=elements, params=p)
+        desc = (description
+                or f"{code} 計算ジョブ投入: {name}（入力: {', '.join(gen['files'])}、"
+                   f"推定 {estimated_node_hours:.1f} ノード時間）")
+        if gen["missing_files"]:
+            desc += (f"【要配置ファイル】{', '.join(gen['missing_files'])} を "
+                     f"{workdir} に用意してから投入してください")
         job = self.propose_job(
             state, name=name, script=gen["sbatch"], kind=code,
-            description=description
-            or f"{code} 計算ジョブ投入: {name}（入力: {', '.join(gen['files'])}、"
-               f"推定 {estimated_node_hours:.1f} ノード時間）",
+            description=desc,
             estimated_node_hours=estimated_node_hours,
         )
         job.detail["generated_files"] = gen["files"]
         job.detail["command"] = gen["command"]
+        job.detail["missing_files"] = gen["missing_files"]
         self.store.save(state)
         return job
 
@@ -529,6 +534,10 @@ class ResearchManager:
             raise ValueError(f"解析の承認要求ではありません: {approval_id}（{req.kind}）")
         if req.status != "approved":
             raise ValueError(f"未承認の解析は実行できません: {approval_id}")
+        if req.payload.get("executed"):
+            raise ValueError(f"この承認は実行済みです（再実行は新しい提案・承認が必要）: "
+                             f"{approval_id}")
+        req.payload["executed"] = True
         purpose = str(req.payload.get("purpose", ""))
         script = str(req.payload.get("script", ""))
         workdir = str(req.payload.get("workdir") or self.session_workspace(state))
@@ -551,6 +560,8 @@ class ResearchManager:
             if not fixed or fixed == script:
                 break
             script = fixed
+            # 自動修正版は承認時のスクリプトと異なるため、監査用に全文を保存する
+            req.payload.setdefault("auto_fixed_scripts", []).append(script)
             state.audit("ResearchManager", "analysis_script_fixed",
                         approval_id=approval_id, attempt=attempt + 1)
         ok = result.get("exit_code") == 0
@@ -605,6 +616,15 @@ class ResearchManager:
         approval = state.approval(job.approval_id) if job.approval_id else None
         if approval is None or approval.status != "approved":
             raise ValueError(f"未承認のジョブは投入できません: {job_id}")
+        still_missing = [
+            f for f in job.detail.get("missing_files", [])
+            if not os.path.isfile(os.path.join(job.workdir, f))
+            and not os.path.isfile(f)
+        ]
+        if still_missing:
+            raise ValueError(
+                f"必要ファイルが未配置のため投入できません: {', '.join(still_missing)}"
+                f"（{job.workdir} に配置してください）")
         remaining = state.budget.max_node_hours - state.budget.used_node_hours
         if job.estimated_node_hours > remaining:
             raise ValueError(

--- a/mi_hub2/src/mi_hub/agent/scriptgen.py
+++ b/mi_hub2/src/mi_hub/agent/scriptgen.py
@@ -122,11 +122,13 @@ def generate_inputs(code: str, workdir: str, *, elements: list[str],
     """コード別の入力一式を workdir に書き出す。
 
     返り値: {"files": 生成ファイル一覧, "command": 実行コマンド,
-             "sbatch": sbatch スクリプト本文}
+             "sbatch": sbatch スクリプト本文,
+             "missing_files": 利用者が別途用意すべき未配置ファイル一覧}
     """
     p = params or {}
     os.makedirs(workdir, exist_ok=True)
     files: list[str]
+    missing: list[str] = []
     if code == "vasp":
         if len(elements) == 2 and p.get("structure", "b2") == "b2":
             poscar = dft.format_poscar_b2(elements[0], elements[1],
@@ -146,13 +148,16 @@ def generate_inputs(code: str, workdir: str, *, elements: list[str],
         _write(workdir, "run_mlip.py", script)
         files = ["run_mlip.py"]
     elif code == "lammps":
+        potential_file = p.get("potential_file", "potential.eam.alloy")
         script = generate_lammps_input(
             elements, pair_style=p.get("pair_style", "eam/alloy"),
-            potential_file=p.get("potential_file", "potential.eam.alloy"),
+            potential_file=potential_file,
             temperature=float(p.get("temperature", 300.0)),
             n_steps=int(p.get("n_steps", 10000)))
         _write(workdir, "in.lammps", script)
         files = ["in.lammps"]
+        missing = [f for f in ("data.lammps", potential_file)
+                   if not os.path.isfile(os.path.join(workdir, f))]
     elif code == "pycalphad":
         if not p.get("tdb_file"):
             raise ValueError("pycalphad: params['tdb_file']（TDBパス）が必要です")
@@ -162,6 +167,10 @@ def generate_inputs(code: str, workdir: str, *, elements: list[str],
             t_max=float(p.get("t_max", 2000.0)))
         _write(workdir, "run_calphad.py", script)
         files = ["run_calphad.py"]
+        tdb = p["tdb_file"]
+        if not (os.path.isfile(tdb)
+                or os.path.isfile(os.path.join(workdir, tdb))):
+            missing = [tdb]
     else:
         raise ValueError(f"未対応の計算コード: {code}")
     command = p.get("command") or _RUN_COMMANDS[code]
@@ -171,7 +180,8 @@ def generate_inputs(code: str, workdir: str, *, elements: list[str],
         ntasks=int(p.get("ntasks", 1)),
         time_limit=p.get("time_limit", "01:00:00"),
         modules=p.get("modules"))
-    return {"files": files, "command": command, "sbatch": sbatch}
+    return {"files": files, "command": command, "sbatch": sbatch,
+            "missing_files": missing}
 
 
 def _write(workdir: str, name: str, content: str) -> None:

--- a/mi_hub2/src/mi_hub/agent/ui_streamlit.py
+++ b/mi_hub2/src/mi_hub/agent/ui_streamlit.py
@@ -22,8 +22,18 @@ from mi_hub.agent.states import HypothesisState
 APPROVAL_KIND_LABELS = {
     "task_execution": "タスク実行",
     "script_execution": "スクリプト実行",
+    "analysis_execution": "解析実行",
     "job_submission": "外部ジョブ投入",
 }
+
+
+def execute_analysis_approval(manager: ResearchManager, s: SessionState,
+                              approval: ApprovalRequest) -> str:
+    """承認済み解析を実行（失敗時は自動修正で再試行）し、応答文を返す。"""
+    out = manager.run_approved_analysis(s, approval.approval_id)
+    # 結果は run_approved_analysis が chat_history へ追記済み
+    return ("解析が完了しました。" if out["ok"]
+            else "解析は自動修正を含めて失敗しました。詳細は上記の結果を確認してください。")
 
 
 def execute_script_approval(manager: ResearchManager, s: SessionState,
@@ -324,6 +334,9 @@ with chat_col:
                 if approve and a.kind == "script_execution":
                     reply = f"[{kind}] {a.description} を承認しました。\n\n"
                     reply += execute_script_approval(m, state, a)
+                elif approve and a.kind == "analysis_execution":
+                    reply = f"[{kind}] {a.description} を承認しました。\n\n"
+                    reply += execute_analysis_approval(m, state, a)
                 elif approve:
                     reply = (
                         f"[{kind}] {a.description} を承認しました。"
@@ -537,7 +550,8 @@ with agent_col:
                     + (f" / task: {a.task_id}" if a.task_id else "")
                     + f" / 要求: {time.strftime('%H:%M:%S', time.localtime(a.requested_at))}"
                 )
-                if a.kind == "script_execution" and a.payload.get("script"):
+                if (a.kind in ("script_execution", "analysis_execution")
+                        and a.payload.get("script")):
                     if a.payload.get("summary"):
                         st.markdown(a.payload["summary"])
                     with st.expander("スクリプト本文（実行される内容）"):
@@ -548,6 +562,8 @@ with agent_col:
                     if a.kind == "script_execution":
                         reply = execute_script_approval(m, state, a)
                         state.chat_history.append({"role": "assistant", "content": reply})
+                    elif a.kind == "analysis_execution":
+                        execute_analysis_approval(m, state, a)
                     m.store.save(state)
                     st.rerun()
                 if cols[1].button("却下", key=f"ng-{a.approval_id}"):

--- a/mi_hub2/tests/test_agent_codes.py
+++ b/mi_hub2/tests/test_agent_codes.py
@@ -199,3 +199,32 @@ class TestAnalysisPipeline:
         assert out["ok"] is False
         assert any("自動修正でも解決できませんでした" in m["content"]
                    for m in session.chat_history)
+
+    def test_approval_single_use(self, manager, session):
+        req = manager.propose_analysis(session, "一回限り", script="echo once")
+        manager.resolve_approval(session, req.approval_id, approve=True)
+        assert manager.run_approved_analysis(session, req.approval_id)["ok"]
+        with pytest.raises(ValueError, match="実行済み"):
+            manager.run_approved_analysis(session, req.approval_id)
+
+
+class TestReviewFixes:
+    def test_unknown_property_falls_back(self):
+        req = CalcRequirements(properties=["formation enthalpy of B2"])
+        recs = recommend_codes(req)
+        assert recs
+        assert all("カタログ語彙と一致せず" in r.cautions[0] for r in recs)
+
+    def test_lammps_missing_files_block_submission(self, manager, session):
+        job = manager.propose_calculation_job(session, "lammps", ["Al", "Cu"])
+        assert set(job.detail["missing_files"]) == {"data.lammps",
+                                                    "potential.eam.alloy"}
+        approval = session.approval(job.approval_id)
+        assert approval is not None and "要配置ファイル" in approval.description
+        manager.resolve_approval(session, job.approval_id, approve=True)
+        with pytest.raises(ValueError, match="未配置"):
+            manager.submit_approved_job(session, job.job_id)
+        for f in ("data.lammps", "potential.eam.alloy"):
+            Path(job.workdir, f).write_text("dummy")
+        submitted = manager.submit_approved_job(session, job.job_id)
+        assert submitted.state in ("pending", "running", "completed", "failed")


### PR DESCRIPTION
## Summary
PR #470（マージ済み）への Devin Review 4件の指摘に対応。

1. **推薦が空になる問題**: `structure_calc_requirements` の LLM 出力 `properties` に `_normalize_property` を適用してカタログ語彙へ正規化。さらに `recommend_codes` に、物性が全コードで不一致のとき物性条件を外して全候補＋留意点（「カタログ語彙と一致せず」）を返すフォールバックを追加。
2. **チャット承認で解析が実行されない問題**: `ui_streamlit.py` に `analysis_execution` の承認経路を追加（`APPROVAL_KIND_LABELS`、チャット承認・承認タブ双方で `run_approved_analysis` を呼ぶ `execute_analysis_approval`、スクリプト本文の事前表示）。
3. **LAMMPS 必要ファイル不足で必ず失敗する問題**: `generate_inputs` が `missing_files`（`data.lammps`・ポテンシャル、pycalphad は TDB）を返し、提案説明に「要配置ファイル」を明記。`submit_approved_job` は投入時に再検証し、未配置なら予算消費前に `ValueError` で拒否。
4. **承認の使い回し・修正スクリプトの追跡**: `run_approved_analysis` は承認1件につき1回のみ実行可能（`payload["executed"]`）。LLM 自動修正版スクリプトは監査用に `payload["auto_fixed_scripts"]` へ全文保存。なお「エラー時に自動修正して再実行する」挙動自体はユーザ要求のため維持（サンドボックス実行・再承認なし）。

テスト3件追加（98件全合格）、ruff 新規指摘なし。

Link to Devin session: https://app.devin.ai/sessions/468f9dd00dbd4f7cb27423583362c32c
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->