### PR TITLE
feat(mi_hub2): icet による SQS 超格子生成（VASP/LAMMPS 入力接続、API/Manager 統合）

### DIFF
--- a/mi_hub2/src/mi_hub/agent/api.py
+++ b/mi_hub2/src/mi_hub/agent/api.py
@@ -65,6 +65,16 @@ class PlanCalculationRequest(BaseModel):
     hypothesis_text: str | None = None
 
 
+class SQSRequest(BaseModel):
+    session_id: str
+    elements: list[str]
+    concentrations: dict[str, float] | None = None
+    prototype: str = "fcc"
+    a0: float = 3.6
+    max_size: int = 16
+    n_steps: int = 10000
+
+
 class CalculationJobRequest(BaseModel):
     session_id: str
     code: str
@@ -261,6 +271,20 @@ def plan_calculation(req: PlanCalculationRequest) -> dict[str, Any]:
         return m.plan_calculation(state, hypothesis_id=req.hypothesis_id,
                                   hypothesis_text=req.hypothesis_text)
     except ValueError as exc:
+        raise HTTPException(400, str(exc)) from exc
+
+
+# SQS 構造生成（icet）
+@app.post("/api/agent/structures/sqs")
+def generate_sqs(req: SQSRequest) -> dict[str, Any]:
+    m = get_manager()
+    state = _load(req.session_id)
+    try:
+        return m.generate_sqs(
+            state, req.elements, concentrations=req.concentrations,
+            prototype=req.prototype, a0=req.a0,
+            max_size=req.max_size, n_steps=req.n_steps)
+    except (ValueError, RuntimeError) as exc:
         raise HTTPException(400, str(exc)) from exc
 
 

--- a/mi_hub2/src/mi_hub/agent/loop.py
+++ b/mi_hub2/src/mi_hub/agent/loop.py
@@ -15,7 +15,7 @@ from typing import Any, ClassVar
 
 from pydantic import ValidationError
 
-from . import codes, llm, scriptgen
+from . import codes, llm, scriptgen, sqs
 from .graphrag import GraphRAGProvider
 from .models import (
     ApprovalRequest,
@@ -414,6 +414,49 @@ class ResearchManager:
         })
         self.store.save(state)
         return job
+
+    # ---------- SQS 構造生成（icet） ----------
+    def generate_sqs(self, state: SessionState, elements: list[str],
+                     concentrations: dict[str, float] | None = None,
+                     prototype: str = "fcc", a0: float = 3.6,
+                     max_size: int = 16,
+                     n_steps: int = 10000) -> dict[str, Any]:
+        """icet で SQS 超格子を生成し、POSCAR / data.lammps / extxyz を
+        セッション作業領域に書き出す。生成は決定論的な後処理のみで承認不要。"""
+        atoms = sqs.generate_sqs_structure(
+            elements, concentrations, prototype=prototype, a0=a0,
+            max_size=max_size, n_steps=n_steps)
+        name = f"sqs_{'-'.join(elements).lower()}_{len(atoms)}at"
+        workdir = os.path.join(self.session_workspace(state),
+                               "structures", name)
+        files = sqs.write_sqs_files(atoms, workdir)
+        formula = atoms.get_chemical_formula()
+        state.evidence.append(Evidence(
+            source_type="structure_generation",
+            claim=f"SQS 生成: {formula}（{prototype}, a0={a0}, "
+                  f"{len(atoms)} 原子）",
+            conditions={"workdir": workdir, "files": files,
+                        "elements": elements,
+                        "concentrations": concentrations,
+                        "prototype": prototype, "a0": a0,
+                        "max_size": max_size, "n_steps": n_steps},
+            evidence_type="computation",
+            limitations=[("SQS は有限セルでランダム合金を近似した構造であり、"
+                          "短距離秩序の完全な再現ではない")],
+        ))
+        state.chat_history.append({
+            "role": "assistant",
+            "content": f"SQS 構造を生成しました: {formula}"
+                       f"（{prototype}, {len(atoms)} 原子）\n"
+                       f"出力: {', '.join(files)}（{workdir}）\n"
+                       "この構造は VASP（structure='sqs'）や LAMMPS の "
+                       "data.lammps としてジョブ提案に利用できます。",
+        })
+        state.audit("ResearchManager", "sqs_generated", formula=formula,
+                    n_atoms=len(atoms), workdir=workdir)
+        self.store.save(state)
+        return {"formula": formula, "n_atoms": len(atoms),
+                "workdir": workdir, "files": files}
 
     # ---------- 計算コード選択（仮説 → コード推薦 → 入力生成 → 承認付き提案） ----------
     def plan_calculation(self, state: SessionState,

--- a/mi_hub2/src/mi_hub/agent/loop.py
+++ b/mi_hub2/src/mi_hub/agent/loop.py
@@ -429,7 +429,7 @@ class ResearchManager:
         name = f"sqs_{'-'.join(elements).lower()}_{len(atoms)}at"
         workdir = os.path.join(self.session_workspace(state),
                                "structures", name)
-        files = sqs.write_sqs_files(atoms, workdir)
+        files = sqs.write_sqs_files(atoms, workdir, specorder=list(elements))
         formula = atoms.get_chemical_formula()
         state.evidence.append(Evidence(
             source_type="structure_generation",

--- a/mi_hub2/src/mi_hub/agent/scriptgen.py
+++ b/mi_hub2/src/mi_hub/agent/scriptgen.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from . import dft
+from . import dft, sqs
 from .scheduler import make_sbatch_script
 
 _RUN_COMMANDS = {
@@ -130,7 +130,15 @@ def generate_inputs(code: str, workdir: str, *, elements: list[str],
     files: list[str]
     missing: list[str] = []
     if code == "vasp":
-        if len(elements) == 2 and p.get("structure", "b2") == "b2":
+        if p.get("structure") == "sqs":
+            atoms = sqs.generate_sqs_structure(
+                elements, p.get("concentrations"),
+                prototype=p.get("prototype", "fcc"),
+                a0=float(p.get("a0", 3.6)),
+                max_size=int(p.get("max_size", 16)),
+                n_steps=int(p.get("sqs_steps", 10000)))
+            poscar = sqs.atoms_to_poscar(atoms)
+        elif len(elements) == 2 and p.get("structure", "b2") == "b2":
             poscar = dft.format_poscar_b2(elements[0], elements[1],
                                           float(p.get("a0", 2.9)))
         else:
@@ -156,6 +164,14 @@ def generate_inputs(code: str, workdir: str, *, elements: list[str],
             n_steps=int(p.get("n_steps", 10000)))
         _write(workdir, "in.lammps", script)
         files = ["in.lammps"]
+        if p.get("structure") == "sqs":
+            atoms = sqs.generate_sqs_structure(
+                elements, p.get("concentrations"),
+                prototype=p.get("prototype", "fcc"),
+                a0=float(p.get("a0", 3.6)),
+                max_size=int(p.get("max_size", 32)),
+                n_steps=int(p.get("sqs_steps", 10000)))
+            files += sqs.write_sqs_files(atoms, workdir, formats=["lammps"])
         missing = [f for f in ("data.lammps", potential_file)
                    if not os.path.isfile(os.path.join(workdir, f))]
     elif code == "pycalphad":

--- a/mi_hub2/src/mi_hub/agent/scriptgen.py
+++ b/mi_hub2/src/mi_hub/agent/scriptgen.py
@@ -171,7 +171,8 @@ def generate_inputs(code: str, workdir: str, *, elements: list[str],
                 a0=float(p.get("a0", 3.6)),
                 max_size=int(p.get("max_size", 32)),
                 n_steps=int(p.get("sqs_steps", 10000)))
-            files += sqs.write_sqs_files(atoms, workdir, formats=["lammps"])
+            files += sqs.write_sqs_files(atoms, workdir, formats=["lammps"],
+                                         specorder=list(elements))
         missing = [f for f in ("data.lammps", potential_file)
                    if not os.path.isfile(os.path.join(workdir, f))]
     elif code == "pycalphad":

--- a/mi_hub2/src/mi_hub/agent/sqs.py
+++ b/mi_hub2/src/mi_hub/agent/sqs.py
@@ -1,0 +1,103 @@
+"""SQS（Special Quasi-random Structure）生成。
+
+icet のクラスタ空間＋焼きなましでランダム合金を模す超格子を生成し、
+VASP（POSCAR）/ LAMMPS（data.lammps）/ MLIP（extxyz）の各入力に接続する。
+icet は任意依存: 未導入環境では generate_sqs_structure が明示的なエラーを返す。
+"""
+
+from __future__ import annotations
+
+import io
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ase import Atoms
+
+_PROTOTYPES = {"fcc", "bcc", "hcp"}
+
+
+def normalize_concentrations(elements: list[str],
+                             concentrations: dict[str, float] | None = None,
+                             ) -> dict[str, float]:
+    """組成を正規化する（未指定は等モル）。合計は1に規格化。"""
+    if not elements:
+        raise ValueError("elements が空です")
+    if concentrations:
+        missing = [e for e in elements if e not in concentrations]
+        if missing:
+            raise ValueError(f"組成が未指定の元素があります: {', '.join(missing)}")
+        total = sum(float(concentrations[e]) for e in elements)
+        if total <= 0:
+            raise ValueError("組成の合計が正ではありません")
+        return {e: float(concentrations[e]) / total for e in elements}
+    return {e: 1.0 / len(elements) for e in elements}
+
+
+def generate_sqs_structure(elements: list[str],
+                           concentrations: dict[str, float] | None = None,
+                           *, prototype: str = "fcc", a0: float = 3.6,
+                           max_size: int = 16,
+                           cutoffs: list[float] | None = None,
+                           n_steps: int = 10000) -> Atoms:
+    """icet で SQS 超格子を生成して ASE Atoms を返す。
+
+    max_size は超格子の最大原子数（プリミティブセルの倍数から探索）。
+    組成は max_size 以下のセルで実現可能な有理数に丸められる点に注意。
+    """
+    try:
+        from icet import ClusterSpace
+        from icet.tools.structure_generation import generate_sqs
+    except ImportError as exc:
+        raise RuntimeError(
+            "icet が見つかりません。`pip install icet`（要 python3-dev）を"
+            "実行してください") from exc
+    from ase.build import bulk
+
+    if prototype not in _PROTOTYPES:
+        raise ValueError(f"未対応のプロトタイプ: {prototype}"
+                         f"（対応: {', '.join(sorted(_PROTOTYPES))}）")
+    conc = normalize_concentrations(elements, concentrations)
+    prim = bulk(elements[0], prototype, a=a0)
+    cs = ClusterSpace(prim, cutoffs or [a0 * 1.3, a0 * 0.9],
+                      [list(elements)] * len(prim))
+    return generate_sqs(cluster_space=cs, max_size=max_size,
+                        target_concentrations=conc, n_steps=n_steps)
+
+
+def atoms_to_poscar(atoms: Atoms) -> str:
+    """ASE Atoms を POSCAR 文字列（Direct座標）へ変換する。"""
+    from ase.io import write as ase_write
+
+    buf = io.StringIO()
+    ase_write(buf, atoms, format="vasp", direct=True)
+    return buf.getvalue()
+
+
+def write_sqs_files(atoms: Atoms, workdir: str,
+                    formats: list[str] | None = None) -> list[str]:
+    """SQS 構造を各計算コード向けファイルとして書き出す。
+
+    formats: "poscar"（POSCAR）/ "lammps"（data.lammps）/ "xyz"（sqs.extxyz）
+    """
+    from ase.io import write as ase_write
+
+    os.makedirs(workdir, exist_ok=True)
+    written: list[str] = []
+    for fmt in formats or ["poscar", "lammps", "xyz"]:
+        if fmt == "poscar":
+            with open(os.path.join(workdir, "POSCAR"), "w",
+                      encoding="utf-8") as f:
+                f.write(atoms_to_poscar(atoms))
+            written.append("POSCAR")
+        elif fmt == "lammps":
+            ase_write(os.path.join(workdir, "data.lammps"), atoms,
+                      format="lammps-data", masses=True)
+            written.append("data.lammps")
+        elif fmt == "xyz":
+            ase_write(os.path.join(workdir, "sqs.extxyz"), atoms,
+                      format="extxyz")
+            written.append("sqs.extxyz")
+        else:
+            raise ValueError(f"未対応の出力形式: {fmt}")
+    return written

--- a/mi_hub2/src/mi_hub/agent/sqs.py
+++ b/mi_hub2/src/mi_hub/agent/sqs.py
@@ -70,15 +70,19 @@ def atoms_to_poscar(atoms: Atoms) -> str:
     from ase.io import write as ase_write
 
     buf = io.StringIO()
-    ase_write(buf, atoms, format="vasp", direct=True)
+    # sort=True: 同一元素をまとめて種別行を POTCAR と整合させる
+    ase_write(buf, atoms, format="vasp", direct=True, sort=True)
     return buf.getvalue()
 
 
 def write_sqs_files(atoms: Atoms, workdir: str,
-                    formats: list[str] | None = None) -> list[str]:
+                    formats: list[str] | None = None,
+                    specorder: list[str] | None = None) -> list[str]:
     """SQS 構造を各計算コード向けファイルとして書き出す。
 
     formats: "poscar"（POSCAR）/ "lammps"（data.lammps）/ "xyz"（sqs.extxyz）
+    specorder: LAMMPS の原子タイプ番号に対応させる元素順
+    （pair_coeff の元素並びと一致させること）
     """
     from ase.io import write as ase_write
 
@@ -92,7 +96,8 @@ def write_sqs_files(atoms: Atoms, workdir: str,
             written.append("POSCAR")
         elif fmt == "lammps":
             ase_write(os.path.join(workdir, "data.lammps"), atoms,
-                      format="lammps-data", masses=True)
+                      format="lammps-data", masses=True,
+                      specorder=specorder)
             written.append("data.lammps")
         elif fmt == "xyz":
             ase_write(os.path.join(workdir, "sqs.extxyz"), atoms,

--- a/mi_hub2/tests/test_agent_codes.py
+++ b/mi_hub2/tests/test_agent_codes.py
@@ -255,6 +255,26 @@ class TestSQS:
         for f in files:
             assert (tmp_path / f).is_file()
 
+    def test_poscar_species_grouped(self):
+        atoms = sqs.generate_sqs_structure(
+            ["Al", "Cu"], prototype="fcc", a0=3.9, max_size=8, n_steps=300)
+        lines = sqs.atoms_to_poscar(atoms).splitlines()
+        species = lines[5].split()
+        assert len(species) == len(set(species))  # 元素はまとめて1回ずつ
+
+    def test_lammps_data_respects_specorder(self, tmp_path):
+        atoms = sqs.generate_sqs_structure(
+            ["Ni", "Fe"], prototype="fcc", a0=3.6, max_size=8, n_steps=300)
+        sqs.write_sqs_files(atoms, str(tmp_path), formats=["lammps"],
+                            specorder=["Ni", "Fe"])
+        data = (tmp_path / "data.lammps").read_text()
+        # タイプ1=Ni, タイプ2=Fe の順で質量が割り当てられる
+        masses = [ln.split() for ln in
+                  data.split("Masses")[1].split("Atoms")[0].splitlines()
+                  if ln.strip()]
+        assert masses[0][0] == "1" and masses[0][1].startswith("58.69")
+        assert masses[1][0] == "2" and masses[1][1].startswith("55.84")
+
     def test_generate_inputs_vasp_sqs(self, tmp_path):
         out = scriptgen.generate_inputs(
             "vasp", str(tmp_path), elements=["Al", "Cu"],

--- a/mi_hub2/tests/test_agent_codes.py
+++ b/mi_hub2/tests/test_agent_codes.py
@@ -9,6 +9,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
+from mi_hub.agent import scriptgen, sqs
 from mi_hub.agent.codes import (
     CODE_CATALOG,
     CalcRequirements,
@@ -228,3 +229,52 @@ class TestReviewFixes:
             Path(job.workdir, f).write_text("dummy")
         submitted = manager.submit_approved_job(session, job.job_id)
         assert submitted.state in ("pending", "running", "completed", "failed")
+
+
+class TestSQS:
+    def test_normalize_concentrations_default_equimolar(self):
+        conc = sqs.normalize_concentrations(["Al", "Cu"])
+        assert conc == {"Al": 0.5, "Cu": 0.5}
+
+    def test_normalize_concentrations_missing_element(self):
+        with pytest.raises(ValueError, match="未指定"):
+            sqs.normalize_concentrations(["Al", "Cu"], {"Al": 1.0})
+
+    def test_generate_sqs_structure(self):
+        atoms = sqs.generate_sqs_structure(
+            ["Al", "Cu"], prototype="fcc", a0=3.9, max_size=8, n_steps=300)
+        assert len(atoms) <= 8
+        symbols = set(atoms.get_chemical_symbols())
+        assert symbols == {"Al", "Cu"}
+
+    def test_write_sqs_files(self, tmp_path):
+        atoms = sqs.generate_sqs_structure(
+            ["Fe", "Ni"], prototype="bcc", a0=2.9, max_size=8, n_steps=300)
+        files = sqs.write_sqs_files(atoms, str(tmp_path))
+        assert set(files) == {"POSCAR", "data.lammps", "sqs.extxyz"}
+        for f in files:
+            assert (tmp_path / f).is_file()
+
+    def test_generate_inputs_vasp_sqs(self, tmp_path):
+        out = scriptgen.generate_inputs(
+            "vasp", str(tmp_path), elements=["Al", "Cu"],
+            params={"structure": "sqs", "a0": 3.9, "max_size": 8,
+                    "sqs_steps": 300})
+        assert "POSCAR" in out["files"]
+        poscar = (tmp_path / "POSCAR").read_text()
+        assert "Al" in poscar and "Cu" in poscar
+
+    def test_generate_inputs_lammps_sqs_provides_data(self, tmp_path):
+        out = scriptgen.generate_inputs(
+            "lammps", str(tmp_path), elements=["Al", "Cu"],
+            params={"structure": "sqs", "a0": 3.9, "max_size": 8,
+                    "sqs_steps": 300})
+        assert "data.lammps" in out["files"]
+        assert out["missing_files"] == ["potential.eam.alloy"]
+
+    def test_manager_generate_sqs(self, manager, session):
+        out = manager.generate_sqs(session, ["Al", "Cu"], a0=3.9,
+                                   max_size=8, n_steps=300)
+        assert out["n_atoms"] <= 8
+        assert set(out["files"]) == {"POSCAR", "data.lammps", "sqs.extxyz"}
+        assert any(e.claim.startswith("SQS 生成") for e in session.evidence)


### PR DESCRIPTION
## Summary
OptiMat-Alloys の SQS（Special Quasi-random Structure）生成機能を icet ベースで mi_hub2 に実装（#471 の上に積むスタックPR）。

- 新規 `agent/sqs.py`:
  - `generate_sqs_structure(elements, concentrations, prototype=fcc|bcc|hcp, a0, max_size, n_steps)` — icet の `ClusterSpace` + `generate_sqs` で SQS を生成（組成未指定は等モル、合計1に規格化）。icet 未導入環境では明示的な `RuntimeError`。
  - `write_sqs_files(atoms, workdir)` — POSCAR / data.lammps / sqs.extxyz を書き出し。
- `scriptgen.generate_inputs` 統合:
  - vasp: `params["structure"]=="sqs"` で SQS から POSCAR を生成（従来の B2/明示 POSCAR は不変）。
  - lammps: `params["structure"]=="sqs"` で `data.lammps` を自動生成 → `missing_files` はポテンシャルのみに縮小。
- `ResearchManager.generate_sqs()` — セッション作業領域 `structures/sqs_<系>_<N>at/` に書き出し、Evidence（SQS の近似性を limitations に明記）・監査・チャット返信を記録。
- API: `POST /api/agent/structures/sqs`（`SQSRequest`）。

テスト7件追加（等モル正規化・組成不足エラー・SQS生成・ファイル出力・vasp/lammps 統合・Manager 経由）、105件全合格。icet はローカルで実際にビルド・実行確認済み（`python3-dev` が必要）。

Link to Devin session: https://app.devin.ai/sessions/468f9dd00dbd4f7cb27423583362c32c
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->