### PR TITLE
feat(mi_hub2): 科学的返答必須化・短期/長期記憶・小/大サイクル研究ループ強化

### DIFF
--- a/mi_hub2/src/mi_hub/agent/api.py
+++ b/mi_hub2/src/mi_hub/agent/api.py
@@ -288,6 +288,14 @@ def generate_sqs(req: SQSRequest) -> dict[str, Any]:
         raise HTTPException(400, str(exc)) from exc
 
 
+# 大サイクル総括（推論→仮説→検証→反証事例→まとめ）
+@app.post("/api/agent/sessions/{session_id}/synthesis")
+def synthesize_cycle(session_id: str) -> dict[str, Any]:
+    m = get_manager()
+    state = _load(session_id)
+    return m.synthesize_cycle(state)
+
+
 # 計算ジョブ提案（入力生成 → 承認付き提案）
 @app.post("/api/agent/calculations/jobs")
 def propose_calculation_job(req: CalculationJobRequest) -> dict[str, Any]:

--- a/mi_hub2/src/mi_hub/agent/llm.py
+++ b/mi_hub2/src/mi_hub/agent/llm.py
@@ -415,9 +415,22 @@ def chat_reply(context: dict[str, Any], history: list[dict[str, str]], message: 
         return None
     try:
         client, model = _client_and_model()
+        context = dict(context)
+        short_term = context.pop("short_term_memory", None)
+        long_term = context.pop("long_term_memory", None)
         system = (
             "あなたは材料研究エージェント MI-HUB2 の対話アシスタントです。"
             "以下のセッション状態を踏まえ、研究者と議論を前進させる相棒として日本語で答えてください。"
+            "どんなコメントに対しても必ず科学的な返答を行うこと。すなわち応答には常に"
+            "(1) 科学的解釈（根拠となる物理・材料科学の知見や証拠IDを明示）"
+            "(2) 妥当性・限界（近似、データ・手法の限界）"
+            "(3) 推奨する次の一手、を含めること。雑談的なコメントであっても、"
+            "研究目標・仮説・証拠と結びつけて科学的観点から応答すること。\n"
+            "文脈は二層の記憶で与えられます。文脈維持のため両方を必ず参照すること。\n"
+            "【短期記憶】現在セッションの直近状態（直近の評価・タスク・会話・証拠・"
+            "未解決エラー）: 直前のやり取りとの一貫性維持に使うこと。\n"
+            "【長期記憶】セッション全体の蓄積（研究目標・仮説・全証拠・評価履歴）: "
+            "研究文脈全体との整合の維持に使うこと。\n"
             "できること: 状態・計画・仮説・証拠・エラーの説明、研究方針の議論"
             "（特徴量設計、SQS・MLIP・CALPHAD等の手法比較、Materials Project/OQMD等の"
             "データソース活用案など）、次の一手の具体的な提案、次の操作の案内"
@@ -435,7 +448,10 @@ def chat_reply(context: dict[str, Any], history: list[dict[str, str]], message: 
             "「〜という提案がありますが、実行しますか？」と明示的に確認してください。"
             "してはいけないこと: 仮説の最終判定、承認の代行、数値の捏造。"
             "最終的な科学判断は研究者に委ねる旨を必要に応じて添えてください。\n\n"
-            f"セッション状態:\n{json.dumps(context, ensure_ascii=False, default=str)}"
+            f"【短期記憶】\n{json.dumps(short_term, ensure_ascii=False, default=str)}\n\n"
+            f"【長期記憶】\n{json.dumps(long_term, ensure_ascii=False, default=str)}\n\n"
+            f"【現在の状態・計画・承認待ち】\n"
+            f"{json.dumps(context, ensure_ascii=False, default=str)}"
         )
         messages: list[dict[str, str]] = [{"role": "system", "content": system}]
         for msg in history[-10:]:

--- a/mi_hub2/src/mi_hub/agent/llm.py
+++ b/mi_hub2/src/mi_hub/agent/llm.py
@@ -345,7 +345,8 @@ def summarize_analysis_result(purpose: str, stdout: str,
     return None
 
 
-_INTENTS = {"run", "pause", "resume", "complete", "approve", "reject", "script", "question"}
+_INTENTS = {"run", "pause", "resume", "complete", "approve", "reject", "script",
+            "synthesize", "question"}
 
 
 def classify_intent(message: str, has_pending_approval: bool) -> dict[str, Any]:
@@ -355,7 +356,7 @@ def classify_intent(message: str, has_pending_approval: bool) -> dict[str, Any]:
     intent: run（タスク実行の継続指示）/ pause / resume / complete /
             approve / reject（承認待ち操作への回答）/
             script（シェルスクリプト実行の依頼: ライブラリのインストールや計算実行）/
-            question（質問・相談・その他）
+            synthesize（これまでの結果の総括依頼）/ question（質問・相談・その他）
     """
     out = _chat_json(
         "あなたは研究エージェントUIの意図分類器です。ユーザの発話を次のいずれかに分類し、"
@@ -381,7 +382,9 @@ def classify_intent(message: str, has_pending_approval: bool) -> dict[str, Any]:
         "Lennard-Jones 等の玩具的ペアポテンシャルは、ユーザが明示的に"
         "簡易計算を要求した場合を除き使用しないこと。"
         "手法の限界（MLIPはDFTの代替近似である等）を出力に明記すること\n"
-        "- question: 上記以外（質問・相談・要約依頼など）\n"
+        "- synthesize: これまでの結果の総括・まとめの依頼"
+        "（例: まとめて、総括して、仮説を見直して）\n"
+        "- question: 上記以外（質問・相談など）\n"
         "迷った場合は question を選ぶこと。実行してよいかの最終判断は人間が行う。",
         message,
     )
@@ -403,6 +406,8 @@ def classify_intent(message: str, has_pending_approval: bool) -> dict[str, Any]:
         return {"intent": "reject", "script": None, "reason": None}
     if any(k in stripped for k in ("実行を続けて", "続けて", "進めて", "自動で実行")):
         return {"intent": "run", "script": None, "reason": None}
+    if any(k in stripped for k in ("まとめて", "総括して")):
+        return {"intent": "synthesize", "script": None, "reason": None}
     return {"intent": "question", "script": None, "reason": None}
 
 
@@ -487,6 +492,70 @@ def science_comment(goal: str, kind: str, payload: dict[str, Any]) -> str | None
     )
     if out and out.get("comment"):
         return str(out["comment"])
+    return None
+
+
+def falsification_check(goal: str, hypotheses: list[dict[str, Any]],
+                        result_payload: dict[str, Any]) -> list[dict[str, Any]] | None:
+    """小サイクル: 新しい結果を各仮説の反証条件と照合し、反証事例候補を挙げる。
+
+    反証の確定は行わない（候補の提示まで。最終判定は研究者）。LLM 不可時は None。
+    """
+    if not hypotheses:
+        return None
+    out = _chat_json(
+        "あなたは材料科学の研究エージェントの反証チェッカーです。"
+        f"研究目標「{goal}」の下で、与えられた仮説群（反証条件付き）と"
+        "新しい計算・解析結果を照合し、"
+        'JSON {"checks": [{"hypothesis_id": str, "assessment": '
+        '"supports"|"contradicts"|"neutral", "counterexample": str|null, '
+        '"reason": str}]} を返してください。'
+        "contradicts の場合は counterexample に反証事例（どの結果のどの数値・挙動が"
+        "どの反証条件に該当するか）を具体的に記述すること。"
+        "与えられた数値のみを根拠とし、捏造しないこと。"
+        "反証・支持の確定はせず、候補の提示に徹すること（最終判定は研究者）。",
+        json.dumps({"hypotheses": hypotheses, "result": result_payload},
+                   ensure_ascii=False, default=str)[:6000],
+    )
+    checks = out.get("checks") if out else None
+    if not isinstance(checks, list):
+        return None
+    valid = ("supports", "contradicts", "neutral")
+    return [
+        {"hypothesis_id": str(c.get("hypothesis_id", "")),
+         "assessment": c["assessment"],
+         "counterexample": c.get("counterexample"),
+         "reason": str(c.get("reason", ""))}
+        for c in checks
+        if isinstance(c, dict) and c.get("assessment") in valid
+    ]
+
+
+def research_synthesis(goal: str, hypotheses: list[dict[str, Any]],
+                       evidence: list[dict[str, Any]],
+                       evaluations: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """大サイクル: 蓄積された証拠から仮説群を総括し、次サイクルの仮説・検証案を提示。
+
+    仮説の状態変更は提案まで（確定は研究者）。LLM 不可時は None。
+    """
+    out = _chat_json(
+        "あなたは材料科学の研究エージェントの総括役です。"
+        f"研究目標「{goal}」について、仮説群・全証拠・評価履歴を総合し、"
+        'JSON {"summary": str, "hypothesis_assessments": [{"hypothesis_id": str, '
+        '"suggested_status": "supported"|"falsified"|"conditionally_supported"|'
+        '"inconclusive", "rationale": str, "counterexamples": [str]}], '
+        '"new_hypotheses": [{"statement": str, "falsification_conditions": [str]}], '
+        '"next_steps": [str]} を返してください。'
+        "summary は日本語 Markdown で、科学的解釈・支持/反証事例・limitations を含めること。"
+        "new_hypotheses は証拠から導かれる次サイクルの検証可能な仮説"
+        "（反証条件付き）とすること。数値は与えられたものだけを使うこと。"
+        "状態変更は提案であり、確定は研究者が行うことを summary に明記すること。",
+        json.dumps({"hypotheses": hypotheses, "evidence": evidence,
+                    "evaluations": evaluations},
+                   ensure_ascii=False, default=str)[:12000],
+    )
+    if out and out.get("summary"):
+        return out
     return None
 
 

--- a/mi_hub2/src/mi_hub/agent/loop.py
+++ b/mi_hub2/src/mi_hub/agent/loop.py
@@ -829,6 +829,15 @@ class ResearchManager:
             "last_evaluation": state.evaluations[-1].model_dump() if state.evaluations else None,
             "recent_tasks": recent_tasks,
             "unresolved_errors": [e.message for e in state.errors if not e.resolved],
+            "recent_chat": [
+                {"role": msg["role"], "content": msg["content"][:400]}
+                for msg in state.chat_history[-6:]
+            ],
+            "recent_evidence": [
+                {"id": e.evidence_id, "type": e.evidence_type, "claim": e.claim,
+                 "limitations": e.limitations}
+                for e in state.evidence[-3:]
+            ],
         }
         long_term = {
             "goal": state.goal.model_dump() if state.goal else None,

--- a/mi_hub2/src/mi_hub/agent/loop.py
+++ b/mi_hub2/src/mi_hub/agent/loop.py
@@ -20,6 +20,7 @@ from .graphrag import GraphRAGProvider
 from .models import (
     ApprovalRequest,
     Evidence,
+    Hypothesis,
     JobRecord,
     Observation,
     Plan,
@@ -293,6 +294,7 @@ class ResearchManager:
             status = "completed" if task.status != TaskState.FAILED else "failed"
             if task.status != TaskState.FAILED:
                 self._add_science_comment(state, task)
+                self._micro_falsification_cycle(state, task)
         except Exception as exc:  # ツール層以外の予期しない失敗
             from .errors import record_error
 
@@ -330,6 +332,135 @@ class ResearchManager:
             state.audit("ResearchManager", "science_comment",
                         task_id=task.task_id, kind=kind)
 
+    def _micro_falsification_cycle(self, state: SessionState, task: Task) -> None:
+        """小サイクル: 各タスクの結果を仮説の反証条件と照合し、反証事例候補を記録する。
+
+        反証の確定は行わない（候補の提示まで。最終判定は研究者）。LLM 不可時は何もしない。
+        """
+        if task.agent not in ("ExecutionAgent", "EvaluationAgent") or not task.result:
+            return
+        active = [
+            h for h in state.hypotheses
+            if h.status in (HypothesisState.APPROVED_FOR_TESTING,
+                            HypothesisState.UNDER_EVALUATION)
+        ]
+        if not active:
+            return
+        goal = state.goal.statement if state.goal else ""
+        checks = llm.falsification_check(
+            goal,
+            [{"hypothesis_id": h.hypothesis_id, "statement": h.statement,
+              "falsification_conditions": h.falsification_conditions}
+             for h in active],
+            {"task": task.description, "result": task.result},
+        )
+        if not checks:
+            return
+        contradicted = [c for c in checks if c["assessment"] == "contradicts"]
+        for c in contradicted:
+            state.evidence.append(Evidence(
+                source_type="falsification_check",
+                claim=f"反証事例候補（{c['hypothesis_id']}）: "
+                      f"{c.get('counterexample') or c['reason']}",
+                conditions={"task_id": task.task_id, "check": c},
+                evidence_type="counterexample_candidate",
+                limitations=["自動照合による候補であり、反証の確定は研究者が行う"],
+            ))
+        state.audit("ResearchManager", "falsification_check",
+                    task_id=task.task_id, checks=checks)
+        if contradicted:
+            lines = ["【反証チェック（小サイクル）】反証事例候補を検出しました："]
+            lines += [f"- {c['hypothesis_id']}: "
+                      f"{c.get('counterexample') or c['reason']}"
+                      for c in contradicted]
+            lines.append("反証の確定は仮説タブから研究者が判定してください。")
+            state.chat_history.append(
+                {"role": "assistant", "content": "\n".join(lines)})
+
+    # ---------- 大サイクル: 総括と次仮説生成 ----------
+    def synthesize_cycle(self, state: SessionState) -> dict[str, Any]:
+        """大サイクル: 蓄積した証拠を総括し、次サイクルの仮説案を生成する。
+
+        推論→仮説→検証→反証事例→まとめのマクロループの「まとめ」に相当する。
+        仮説の状態変更は提案まで（確定は研究者）。新仮説は DRAFT として登録し、
+        次サイクルで研究者がレビューする。新しい証拠が無い限り同じ総括は繰り返さない。
+        """
+        plan_id = state.plan.plan_id if state.plan else None
+        n_facts = sum(1 for e in state.evidence if e.evidence_type != "synthesis")
+        last_syn = next(
+            (e for e in reversed(state.evidence)
+             if e.evidence_type == "synthesis"), None)
+        if last_syn is not None and last_syn.conditions.get("evidence_count") == n_facts:
+            return {"skipped": True, "reason": "前回の総括以降に新しい証拠がない"}
+        goal = state.goal.statement if state.goal else ""
+        out = llm.research_synthesis(
+            goal,
+            [{"hypothesis_id": h.hypothesis_id, "statement": h.statement,
+              "status": h.status.value,
+              "falsification_conditions": h.falsification_conditions}
+             for h in state.hypotheses],
+            [{"id": e.evidence_id, "type": e.evidence_type, "claim": e.claim,
+              "limitations": e.limitations} for e in state.evidence],
+            [{"result": ev.step_result, "quality": ev.result_quality,
+              "data_gaps": ev.data_gaps} for ev in state.evaluations],
+        )
+        if out is None:
+            # LLM 不可時の決定論的なミニ総括
+            counterexamples = [
+                e.claim for e in state.evidence
+                if e.evidence_type == "counterexample_candidate"
+            ]
+            out = {
+                "summary": (
+                    f"証拠 {len(state.evidence)} 件、仮説 {len(state.hypotheses)} 件、"
+                    f"評価 {len(state.evaluations)} 件。"
+                    f"反証事例候補 {len(counterexamples)} 件。"
+                    "（LLM 未接続のため機械的集計のみ。判断は研究者が行う）"
+                ),
+                "hypothesis_assessments": [],
+                "new_hypotheses": [],
+                "next_steps": [],
+            }
+        new_ids: list[str] = []
+        for nh in out.get("new_hypotheses") or []:
+            if not isinstance(nh, dict) or not nh.get("statement"):
+                continue
+            h = Hypothesis(
+                statement=str(nh["statement"]),
+                falsification_conditions=[
+                    str(c) for c in nh.get("falsification_conditions") or []],
+                status=HypothesisState.DRAFT,
+            )
+            state.hypotheses.append(h)
+            new_ids.append(h.hypothesis_id)
+        state.evidence.append(Evidence(
+            source_type="research_synthesis",
+            claim=f"総括（大サイクル）: {str(out['summary'])[:200]}",
+            conditions={"plan_id": plan_id, "synthesis": out,
+                        "evidence_count": n_facts,
+                        "new_hypothesis_ids": new_ids},
+            evidence_type="synthesis",
+            limitations=["仮説の状態変更は提案であり、確定は研究者が行う"],
+        ))
+        lines = ["【総括（大サイクル）】", str(out["summary"])]
+        for a in out.get("hypothesis_assessments") or []:
+            if isinstance(a, dict):
+                lines.append(
+                    f"- {a.get('hypothesis_id')}: 提案 "
+                    f"{a.get('suggested_status')}（{a.get('rationale', '')}）")
+        if new_ids:
+            lines.append(f"次サイクルの新仮説（DRAFT）: {', '.join(new_ids)}")
+        for s in out.get("next_steps") or []:
+            lines.append(f"- 次の一手: {s}")
+        lines.append("仮説の採否・反証の確定は研究者が行ってください。")
+        state.chat_history.append(
+            {"role": "assistant", "content": "\n".join(lines)})
+        state.audit("ResearchManager", "synthesis_cycle", plan_id=plan_id,
+                    new_hypotheses=new_ids)
+        self.store.save(state)
+        return {"skipped": False, "synthesis": out,
+                "new_hypothesis_ids": new_ids}
+
     def _wire_inputs(self, state: SessionState, task: Task) -> None:
         plan = state.plan
         assert plan is not None
@@ -356,6 +487,8 @@ class ResearchManager:
                 state.agent_state = AgentState.COMPLETED
             else:
                 state.agent_state = AgentState.BLOCKED
+            if stop.startswith("正常終了"):
+                self.synthesize_cycle(state)
         else:
             state.agent_state = AgentState.REPLANNING
 

--- a/mi_hub2/src/mi_hub/agent/ui_streamlit.py
+++ b/mi_hub2/src/mi_hub/agent/ui_streamlit.py
@@ -344,6 +344,20 @@ with chat_col:
                     )
                 else:
                     reply = f"[{kind}] {a.description} を却下しました。"
+        elif intent == "synthesize":
+            out = m.synthesize_cycle(state)
+            if out.get("skipped"):
+                reply = (
+                    f"総括は実行済みです（{out.get('reason')}）。"
+                    "新しいタスクの実行・証拠の追加後に再度依頼してください。"
+                )
+            else:
+                # synthesize_cycle が総括本文を chat_history に追記済みのため、
+                # ここでは案内のみ返す
+                reply = (
+                    "総括（大サイクル）を実行しました。上の【総括（大サイクル）】を"
+                    "確認し、仮説の採否・反証の確定は仮説タブから判定してください。"
+                )
         elif intent == "script" and intent_info.get("script"):
             script = intent_info["script"]
             req = ApprovalRequest(

--- a/mi_hub2/tests/test_agent_acceptance.py
+++ b/mi_hub2/tests/test_agent_acceptance.py
@@ -468,6 +468,15 @@ def test_memory_context_short_and_long_term(manager, session):
     assert mem["short_term_memory"]["recent_tasks"]
     assert mem["long_term_memory"]["evaluation_history"]
     assert mem["long_term_memory"]["evidence"]
+    session.chat_history.append({"role": "user", "content": "x" * 500})
+    mem = manager.memory_context(session)
+    recent = mem["short_term_memory"]["recent_chat"]
+    assert recent and len(recent[-1]["content"]) == 400
+    assert len(mem["short_term_memory"]["recent_evidence"]) <= 3
+    assert all(
+        "limitations" in e
+        for e in mem["short_term_memory"]["recent_evidence"]
+    )
 
 
 class TestLLMProviders:

--- a/mi_hub2/tests/test_agent_acceptance.py
+++ b/mi_hub2/tests/test_agent_acceptance.py
@@ -479,6 +479,48 @@ def test_memory_context_short_and_long_term(manager, session):
     )
 
 
+def test_synthesize_cycle_records_summary_and_guard(manager, session):
+    """大サイクル: 総括が証拠・会話に記録され、新しい証拠が無い限り繰り返さない。"""
+    while session.agent_state not in (AgentState.COMPLETED, AgentState.BLOCKED):
+        for a in session.approvals:
+            if a.status == "pending":
+                manager.resolve_approval(session, a.approval_id, True)
+        res = manager.run_auto(session)
+        if not res["executed"] and not any(
+            a.status == "pending" for a in session.approvals
+        ):
+            break
+    syntheses = [e for e in session.evidence if e.evidence_type == "synthesis"]
+    if not syntheses:  # 自動発火しなかった場合は手動総括
+        out = manager.synthesize_cycle(session)
+        assert out["skipped"] is False
+        syntheses = [e for e in session.evidence if e.evidence_type == "synthesis"]
+    assert syntheses
+    assert any("総括（大サイクル）" in msg["content"]
+               for msg in session.chat_history if msg["role"] == "assistant")
+    assert syntheses[-1].limitations
+    # 新しい証拠が無いままの再総括はスキップ
+    out2 = manager.synthesize_cycle(session)
+    assert out2["skipped"] is True
+    # 新しい証拠が加われば再総括できる（小→大サイクルの反復）
+    from mi_hub.agent.models import Evidence
+
+    session.evidence.append(
+        Evidence(claim="追加の計算結果", evidence_type="computation"))
+    out3 = manager.synthesize_cycle(session)
+    assert out3["skipped"] is False
+
+
+def test_classify_intent_fallback_synthesize(monkeypatch):
+    """LLM 不可時でも「まとめて」「総括して」が総括意図に解決される。"""
+    from mi_hub.agent import llm
+
+    monkeypatch.setattr(llm, "llm_available", lambda: False)
+    monkeypatch.setattr(llm, "_chat_json", lambda *a, **k: None)
+    assert llm.classify_intent("これまでの結果をまとめて", False)["intent"] == "synthesize"
+    assert llm.classify_intent("総括して", False)["intent"] == "synthesize"
+
+
 class TestLLMProviders:
     """複数LLMプロバイダの解決（実LLMは呼ばない）。"""
 


### PR DESCRIPTION
## Summary
ユーザコメントへの科学的返答の必須化、短期/長期記憶による文脈維持、および「推論→仮説→検証→反証事例→まとめ」を小サイクル・大サイクルで繰り返す研究ループ強化（#472 スタック上）。

### 科学的返答と二層記憶
- `llm.chat_reply`: どんなコメントにも (1) 科学的解釈（根拠知見・証拠ID） (2) 妥当性・限界 (3) 次の一手 を必ず含めるよう system プロンプトを再構成。文脈を `【短期記憶】/【長期記憶】/【現在の状態】` の三区画に分離注入（`context` は `dict(context)` でコピーしてから pop、呼び出し元を変異させない）
- `ResearchManager.memory_context`: 短期記憶に `recent_chat`（直近6発話・400字切詰め）と `recent_evidence`（直近3件・limitations付き）を追加

### 小サイクル（各タスク実行ごと）
- `ResearchManager._micro_falsification_cycle`: ExecutionAgent/EvaluationAgent の各結果を、検証中仮説の反証条件と `llm.falsification_check` で照合。`contradicts` は反証事例候補として `Evidence(evidence_type="counterexample_candidate")` に記録しチャットへ提示（反証の確定は研究者）

### 大サイクル（計画完了時 or 依頼時）
- `ResearchManager.synthesize_cycle`: `llm.research_synthesis` で全仮説・全証拠・評価履歴を総括し、状態変更提案・反証事例・次の一手を提示。新仮説を DRAFT で登録して次サイクルへ接続。`Evidence(evidence_type="synthesis")` として保存し、新しい証拠が無い限り同じ総括を繰り返さない（`evidence_count` ガード）。LLM 不可時は決定論的なミニ総括にフォールバック
- 自動発火: `_after_step` で計画が正常終了したとき
- 手動発火: `POST /api/agent/sessions/{id}/synthesis`、チャット intent `synthesize`（「まとめて」「総括して」— LLM不可時のフォールバックあり）

### テスト
- 総括の記録・limitations・再総括ガード・新証拠での再総括、synthesize intent フォールバック、recent_chat/recent_evidence（109 passed）

Link to Devin session: https://app.devin.ai/sessions/468f9dd00dbd4f7cb27423583362c32c
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->