### PR TITLE
fix: Be-Co E–V入力でPOSCARのスケール係数を無視していた潜在バグ（PR #478 Review指摘）

### DIFF
--- a/vasp_inputs/generate_beco_magmom_ev.py
+++ b/vasp_inputs/generate_beco_magmom_ev.py
@@ -140,6 +140,17 @@ def write_incar(path: Path, system: str, magmom: str | None, isif: int) -> None:
     path.write_text("\n".join(lines))
 
 
+def verify_poscar_volume(path: Path, target_volume: float) -> None:
+    """Fail loudly if a written POSCAR does not hold the requested volume."""
+    _, scale, vectors, _ = read_poscar(path)
+    actual = cell_volume(scale, vectors)
+    if abs(actual - target_volume) > 1e-6 * target_volume:
+        raise ValueError(
+            f"{path} has volume {actual:.8f} A^3, expected "
+            f"{target_volume:.8f} A^3"
+        )
+
+
 def write_case(
     name: str,
     title: str,
@@ -264,6 +275,7 @@ def main() -> None:
             3,
             (source_scale, source_vectors, coords),
         )
+        verify_poscar_volume(OUTPUT / name / "POSCAR", source_volume)
         cases.append((name, elements))
 
     # Fixed-volume E--V runs use the recalc reference cell at factor 1.00.
@@ -272,14 +284,15 @@ def main() -> None:
             label = f"{ratio:.2f}".replace(".", "p")
             name = f"EV/{config}/V{label}"
             target = REFERENCE_CELL_VOLUME * ratio
-            _, vectors = scaled_vectors(ref_scale, ref_vectors, target)
+            scale, vectors = scaled_vectors(ref_scale, ref_vectors, target)
             write_case(
                 name,
                 f"Be8Co8 E-V {config} V/Vref={ratio:.2f} (ISIF=4)",
                 magmom,
                 4,
-                (1.0, vectors, coords),
+                (scale, vectors, coords),
             )
+            verify_poscar_volume(OUTPUT / name / "POSCAR", target)
             cases.append((name, elements))
 
     write_shell_scripts(cases)

--- a/vasp_inputs/generate_beco_magmom_ev.py
+++ b/vasp_inputs/generate_beco_magmom_ev.py
@@ -51,6 +51,13 @@ def read_poscar(path: Path) -> tuple[list[str], float, list[list[float]], list[s
         raise ValueError(f"POSCAR is unexpectedly short: {path}")
     scale = float(lines[1].split()[0])
     vectors = [[float(x) for x in lines[i].split()[:3]] for i in range(2, 5)]
+    if scale == 0:
+        raise ValueError(f"POSCAR scale factor must not be zero: {path}")
+    if scale < 0:
+        determinant = abs(lattice_determinant(vectors))
+        if determinant == 0:
+            raise ValueError(f"POSCAR lattice vectors have zero volume: {path}")
+        scale = (abs(scale) / determinant) ** (1.0 / 3.0)
     elements = lines[5].split()
     counts = [int(x) for x in lines[6].split()]
     if elements != ["Be", "Co"] or counts != [8, 8]:
@@ -62,14 +69,17 @@ def read_poscar(path: Path) -> tuple[list[str], float, list[list[float]], list[s
     return elements, scale, vectors, coords
 
 
-def cell_volume(scale: float, vectors: list[list[float]]) -> float:
+def lattice_determinant(vectors: list[list[float]]) -> float:
     a, b, c = vectors
-    det = (
+    return (
         a[0] * (b[1] * c[2] - b[2] * c[1])
         - a[1] * (b[0] * c[2] - b[2] * c[0])
         + a[2] * (b[0] * c[1] - b[1] * c[0])
     )
-    return abs(det) * abs(scale) ** 3
+
+
+def cell_volume(scale: float, vectors: list[list[float]]) -> float:
+    return abs(lattice_determinant(vectors)) * abs(scale) ** 3
 
 
 def scaled_vectors(


### PR DESCRIPTION
## Summary

PR #478 に付いたReview指摘の修正。`scaled_vectors()` は `cell_volume(scale, vectors)`（体積に `|scale|**3` を掛ける）を基準に係数を求めるため、返るベクトルは**そのscaleと組み合わせて**目標体積になる。ところが書き出し時にscaleを1.0で上書きしていたため、実際の体積は `target / source_scale**3` になっていた。

```diff
-            _, vectors = scaled_vectors(ref_scale, ref_vectors, target)
-            write_case(..., (1.0, vectors, coords))
+            scale, vectors = scaled_vectors(ref_scale, ref_vectors, target)
+            write_case(..., (scale, vectors, coords))
+            verify_poscar_volume(OUTPUT / name / "POSCAR", target)
```

さらに本PRへのReview指摘（負のスケール係数）も取り込んだ。POSCARの2行目が負値のときその絶対値は**セル全体積(Å³)**を意味するため、線形倍率として扱う `cell_volume()` では誤解釈になり、`verify_poscar_volume()` が同じ関数で読み直す構造上その誤解釈は自己無撞着となって検査をすり抜ける。`read_poscar()` の入口で1回だけ正のスケールへ正規化し、以降は単一の規約だけを扱う:

```python
if scale == 0:
    raise ValueError(...)
if scale < 0:                      # |scale| = total cell volume in A^3
    scale = (abs(scale) / abs(lattice_determinant(vectors))) ** (1.0 / 3.0)
```

現行の参照POSCAR（`SQS_RECALC_2x2x2/BCC_HIGHDEV/Be8Co8/POSCAR`）は `scale = 1.0` なのでコミット済み19ケースの体積は正しく、**再生成してもバイト単位で不変**。しかしscale≠1のVASP慣用形式に差し替えた瞬間に無言で誤った体積の入力ができる潜在バグだった。

### 検証

- 参照POSCARを等価な `scale = 2.0` 形式（ベクトル1/2、同一体積）に書き換えて生成 → E–V 7点すべてが目標体積と一致（修正前は 1/8 の体積になる）
- 負値形式 `-152.2592747556695` でも正規化後スケール1.0となり、E–V 7点（141.257 / 144.263 / 147.268 / 150.274 / 153.279 / 156.285 / 159.290 Å³）が目標体積と一致
- `scale = 0.0` は明示的に拒否（`POSCAR scale factor must not be zero`）
- 格子ベクトルを故意に変えたPOSCARで `verify_poscar_volume()` が例外を投げることを確認（`volume 85.54 A^3, expected 152.26 A^3`）
- 既存19ケースの再生成でPOSCAR/INCAR/KPOINTS/シェルスクリプトすべて差分ゼロ、`bash -n` も通過


Link to Devin session: https://app.devin.ai/sessions/3fd8fc4791c84687a3daf026214784b6
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->