### PR TITLE
paper: HEA検証対象元素スコープの明示と感度分析（Be除外の影響ゼロを定量）

### DIFF
--- a/paper/element_scope_analysis.py
+++ b/paper/element_scope_analysis.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Reproducible metrics for the paper's validation-element scope.
+
+This script deliberately delegates all Omega_sf, q, and lattice-constant
+calculations to the repository's existing single-source functions.
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+PAPER = Path(__file__).resolve().parent
+ROOT = PAPER.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(PAPER))
+
+from chen2023_lattice_screening import load_stable  # noqa: E402
+from generate_all_figures import (  # noqa: E402
+    EXCLUDE_ELEMENTS,
+    compute_omega_sf_pairwise,
+    load_compounds,
+    load_sqs_data,
+    optimize_gamma,
+)
+from hea_lattice_xgboost import (  # noqa: E402
+    ALONSO_TABLE2,
+    INDEPENDENT_TEST,
+    compute_eq10_scaled,
+    compute_vegard,
+)
+
+
+PRACTICAL_ELEMENTS = {
+    "Al", "Ti", "V", "Cr", "Mn", "Fe", "Co", "Ni", "Cu", "Zn",
+    "Zr", "Nb", "Mo", "Hf", "Ta", "W",
+}
+SCOPE_EXCLUDED_ELEMENTS = {"Si"}
+
+
+def element_set(hea):
+    return set(hea["comp"])
+
+
+def pair_set(db):
+    return set(db)
+
+
+def all_pairs(elements):
+    return {
+        tuple(sorted(pair))
+        for pair in itertools.combinations(sorted(elements), 2)
+    }
+
+
+def filtered_db(db, elements):
+    return {pair: value for pair, value in db.items() if set(pair) <= elements}
+
+
+def rmse(rows, struct, omega, gamma):
+    values = [
+        compute_eq10_scaled(
+            hea["comp"], struct, omega, gamma
+        ) - hea["a_exp"]
+        for hea in rows
+        if hea["struct"] == struct
+    ]
+    return float(np.sqrt(np.mean(np.square(values)))) if values else None
+
+
+def rmse_all(rows, bcc_omega, fcc_omega, q_bcc, q_fcc):
+    values = []
+    for hea in rows:
+        omega = bcc_omega if hea["struct"] == "BCC" else fcc_omega
+        gamma = q_bcc if hea["struct"] == "BCC" else q_fcc
+        values.append(
+            compute_eq10_scaled(hea["comp"], hea["struct"], omega, gamma)
+            - hea["a_exp"]
+        )
+    return float(np.sqrt(np.mean(np.square(values)))) if values else None
+
+
+def test_rmse(rows, bcc_omega, fcc_omega, q_bcc, q_fcc):
+    return {
+        "BCC": rmse(
+            rows, "BCC", bcc_omega, q_bcc
+        ),
+        "FCC": rmse(
+            rows, "FCC", fcc_omega, q_fcc
+        ),
+        "ALL": rmse_all(rows, bcc_omega, fcc_omega, q_bcc, q_fcc),
+    }
+
+
+def chen_scope_metrics(elements, sqs_bcc, l12, q_fcc):
+    """Count stable Chen quinaries and their adopted-model corrections."""
+    _, stable = load_stable()
+    output = {}
+    for struct in ("BCC", "FCC"):
+        omega = sqs_bcc if struct == "BCC" else l12
+        in_scope = 0
+        covered = 0
+        corrections = []
+        for _, row in stable[stable.phase == struct].iterrows():
+            row_elements = set(row.elements)
+            if not row_elements <= elements:
+                continue
+            in_scope += 1
+            if not all_pairs(row_elements) <= pair_set(omega):
+                continue
+            covered += 1
+            comp = {element: 1.0 / len(row_elements) for element in row_elements}
+            q = 1.0 if struct == "BCC" else q_fcc
+            a_vegard = compute_vegard(comp, struct)
+            a_pred = compute_eq10_scaled(comp, struct, omega, q)
+            corrections.append(100.0 * (a_pred - a_vegard) / a_vegard)
+        output[struct] = {
+            "stable_all_elements_in_scope": in_scope,
+            "stable_10_pair_covered": covered,
+            "median_abs_correction_percent": (
+                float(np.median(np.abs(corrections))) if corrections else None
+            ),
+            "n_abs_correction_gt_1percent": int(
+                sum(abs(value) > 1.0 for value in corrections)
+            ),
+        }
+    return output
+
+
+def scope_metrics(label, elements, sqs, ob2, ol12):
+    calibration = [
+        hea for hea in ALONSO_TABLE2 if element_set(hea) <= elements
+    ]
+    independent = [
+        hea for hea in INDEPENDENT_TEST if element_set(hea) <= elements
+    ]
+    ob2_scope = filtered_db(ob2, elements)
+    ol12_scope = filtered_db(ol12, elements)
+    sqs_bcc_scope = filtered_db(sqs["omega_dft"], elements)
+    sqs_fcc_dft_scope = filtered_db(sqs["fcc_omega_dft"], elements)
+    sqs_fcc_king_scope = filtered_db(sqs["fcc_omega_king"], elements)
+    q_bcc, q_fcc = optimize_gamma(calibration, ob2_scope, ol12_scope)
+    return {
+        "label": label,
+        "elements": sorted(elements),
+        "n_elements": len(elements),
+        "sqs_pairs": {
+            "BCC": len(sqs_bcc_scope),
+            "FCC_DFT_reference": len(sqs_fcc_dft_scope),
+            "FCC_King_reference": len(sqs_fcc_king_scope),
+        },
+        "ordered_pairs": {
+            "B2": len(ob2_scope),
+            "L1_2": len(ol12_scope),
+        },
+        "calibration_all_elements_in_scope": {
+            "BCC": sum(hea["struct"] == "BCC" for hea in calibration),
+            "FCC": sum(hea["struct"] == "FCC" for hea in calibration),
+        },
+        "independent_test_all_elements_in_scope": {
+            "BCC": sum(hea["struct"] == "BCC" for hea in independent),
+            "FCC": sum(hea["struct"] == "FCC" for hea in independent),
+        },
+        "q_optimized": {"BCC": float(q_bcc), "FCC": float(q_fcc)},
+        "independent_test_rmse_q1": test_rmse(
+            independent, ob2_scope, ol12_scope, 1.0, 1.0
+        ),
+        "independent_test_rmse_q_optimized": test_rmse(
+            independent, ob2_scope, ol12_scope, q_bcc, q_fcc
+        ),
+        "chen": chen_scope_metrics(elements, sqs["omega_dft"], ol12_scope, q_fcc),
+    }
+
+
+def main():
+    sqs = load_sqs_data()
+    ob2, ol12 = compute_omega_sf_pairwise(load_compounds())
+    data_elements = {
+        element
+        for hea in ALONSO_TABLE2 + INDEPENDENT_TEST
+        for element in element_set(hea)
+    } - SCOPE_EXCLUDED_ELEMENTS
+    scopes = {
+        "all_elements": set().union(
+            *(set(pair) for pair in ob2)
+        ) - SCOPE_EXCLUDED_ELEMENTS,
+        "candidate_A_practical_16": PRACTICAL_ELEMENTS,
+        "candidate_B_data_driven_23": data_elements,
+    }
+    results = {
+        label: scope_metrics(label, elements, sqs, ob2, ol12)
+        for label, elements in scopes.items()
+    }
+    q_bcc_all, q_fcc_all = optimize_gamma(ALONSO_TABLE2, ob2, ol12)
+    output = {
+        "scope_definition": {
+            "candidate_A": sorted(PRACTICAL_ELEMENTS),
+            "scope_excluded_elements": sorted(SCOPE_EXCLUDED_ELEMENTS),
+            "candidate_B_derived_from": [
+                "ALONSO_TABLE2",
+                "INDEPENDENT_TEST",
+            ],
+            "candidate_B": sorted(data_elements),
+        },
+        "exclude_elements": sorted(EXCLUDE_ELEMENTS),
+        "full_database_pair_counts": {
+            "SQS_BCC": len(sqs["omega_dft"]),
+            "SQS_FCC_DFT_reference_raw": len(sqs["fcc_omega_dft"]),
+            "SQS_FCC_King_reference_raw": len(sqs["fcc_omega_king"]),
+            "B2": len(ob2),
+            "L1_2": len(ol12),
+        },
+        "full_ordered_q": {
+            "BCC": float(q_bcc_all),
+            "FCC": float(q_fcc_all),
+        },
+        "results": results,
+        "be": {
+            "BCC_SQS_pairs": sum("Be" in pair for pair in sqs["omega_dft"]),
+            "FCC_SQS_pairs": sum("Be" in pair for pair in sqs["fcc_omega_dft"]),
+            "B2_pairs": sum("Be" in pair for pair in ob2),
+            "L1_2_pairs": sum("Be" in pair for pair in ol12),
+            "ALONSO_BCC_alloys": sum(
+                hea["struct"] == "BCC" and "Be" in element_set(hea)
+                for hea in ALONSO_TABLE2
+            ),
+            "ALONSO_FCC_alloys": sum(
+                hea["struct"] == "FCC" and "Be" in element_set(hea)
+                for hea in ALONSO_TABLE2
+            ),
+            "INDEPENDENT_BCC_alloys": sum(
+                hea["struct"] == "BCC" and "Be" in element_set(hea)
+                for hea in INDEPENDENT_TEST
+            ),
+            "INDEPENDENT_FCC_alloys": sum(
+                hea["struct"] == "FCC" and "Be" in element_set(hea)
+                for hea in INDEPENDENT_TEST
+            ),
+        },
+    }
+    path = PAPER / "element_scope_metrics.json"
+    path.write_text(json.dumps(output, ensure_ascii=False, indent=2) + "\n")
+    print(f"Wrote {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/paper/element_scope_metrics.json
+++ b/paper/element_scope_metrics.json
@@ -1,0 +1,317 @@
+{
+  "scope_definition": {
+    "candidate_A": [
+      "Al",
+      "Co",
+      "Cr",
+      "Cu",
+      "Fe",
+      "Hf",
+      "Mn",
+      "Mo",
+      "Nb",
+      "Ni",
+      "Ta",
+      "Ti",
+      "V",
+      "W",
+      "Zn",
+      "Zr"
+    ],
+    "scope_excluded_elements": [
+      "Si"
+    ],
+    "candidate_B_derived_from": [
+      "ALONSO_TABLE2",
+      "INDEPENDENT_TEST"
+    ],
+    "candidate_B": [
+      "Al",
+      "Au",
+      "Co",
+      "Cr",
+      "Cu",
+      "Fe",
+      "Hf",
+      "Ir",
+      "Mn",
+      "Mo",
+      "Nb",
+      "Ni",
+      "Os",
+      "Pd",
+      "Pt",
+      "Rh",
+      "Ru",
+      "Ta",
+      "Ti",
+      "V",
+      "W",
+      "Zn",
+      "Zr"
+    ]
+  },
+  "exclude_elements": [
+    "Ce",
+    "Dy",
+    "Er",
+    "Eu",
+    "Gd",
+    "Ho",
+    "La",
+    "Lu",
+    "Nd",
+    "Pr",
+    "Sm",
+    "Tb",
+    "Tm",
+    "Y",
+    "Yb"
+  ],
+  "full_database_pair_counts": {
+    "SQS_BCC": 445,
+    "SQS_FCC_DFT_reference_raw": 120,
+    "SQS_FCC_King_reference_raw": 112,
+    "B2": 465,
+    "L1_2": 441
+  },
+  "full_ordered_q": {
+    "BCC": 0.4860687238190625,
+    "FCC": 0.13339949219488767
+  },
+  "results": {
+    "all_elements": {
+      "label": "all_elements",
+      "elements": [
+        "Ag",
+        "Al",
+        "Au",
+        "Be",
+        "Ca",
+        "Co",
+        "Cr",
+        "Cu",
+        "Fe",
+        "Hf",
+        "Ir",
+        "Mg",
+        "Mn",
+        "Mo",
+        "Nb",
+        "Ni",
+        "Os",
+        "Pb",
+        "Pd",
+        "Pt",
+        "Re",
+        "Rh",
+        "Ru",
+        "Sc",
+        "Sn",
+        "Ta",
+        "Ti",
+        "V",
+        "W",
+        "Zn",
+        "Zr"
+      ],
+      "n_elements": 31,
+      "sqs_pairs": {
+        "BCC": 445,
+        "FCC_DFT_reference": 111,
+        "FCC_King_reference": 112
+      },
+      "ordered_pairs": {
+        "B2": 465,
+        "L1_2": 441
+      },
+      "calibration_all_elements_in_scope": {
+        "BCC": 29,
+        "FCC": 35
+      },
+      "independent_test_all_elements_in_scope": {
+        "BCC": 17,
+        "FCC": 14
+      },
+      "q_optimized": {
+        "BCC": 0.4860687238190625,
+        "FCC": 0.13339949219488767
+      },
+      "independent_test_rmse_q1": {
+        "BCC": 0.014009735459751163,
+        "FCC": 0.023514648531552662,
+        "ALL": 0.018903641420808644
+      },
+      "independent_test_rmse_q_optimized": {
+        "BCC": 0.015728249847714197,
+        "FCC": 0.015231342548259107,
+        "ALL": 0.015505812101918202
+      },
+      "chen": {
+        "BCC": {
+          "stable_all_elements_in_scope": 14897,
+          "stable_10_pair_covered": 14887,
+          "median_abs_correction_percent": 0.39554419099796484,
+          "n_abs_correction_gt_1percent": 1238
+        },
+        "FCC": {
+          "stable_all_elements_in_scope": 1555,
+          "stable_10_pair_covered": 1555,
+          "median_abs_correction_percent": 0.045026689949614604,
+          "n_abs_correction_gt_1percent": 0
+        }
+      }
+    },
+    "candidate_A_practical_16": {
+      "label": "candidate_A_practical_16",
+      "elements": [
+        "Al",
+        "Co",
+        "Cr",
+        "Cu",
+        "Fe",
+        "Hf",
+        "Mn",
+        "Mo",
+        "Nb",
+        "Ni",
+        "Ta",
+        "Ti",
+        "V",
+        "W",
+        "Zn",
+        "Zr"
+      ],
+      "n_elements": 16,
+      "sqs_pairs": {
+        "BCC": 120,
+        "FCC_DFT_reference": 29,
+        "FCC_King_reference": 30
+      },
+      "ordered_pairs": {
+        "B2": 120,
+        "L1_2": 120
+      },
+      "calibration_all_elements_in_scope": {
+        "BCC": 29,
+        "FCC": 31
+      },
+      "independent_test_all_elements_in_scope": {
+        "BCC": 17,
+        "FCC": 5
+      },
+      "q_optimized": {
+        "BCC": 0.4860687238190625,
+        "FCC": 0.13181219165035962
+      },
+      "independent_test_rmse_q1": {
+        "BCC": 0.014009735459751163,
+        "FCC": 0.029742777412100813,
+        "ALL": 0.018780792570912863
+      },
+      "independent_test_rmse_q_optimized": {
+        "BCC": 0.015728249847714197,
+        "FCC": 0.010491633331568771,
+        "ALL": 0.014702806141325065
+      },
+      "chen": {
+        "BCC": {
+          "stable_all_elements_in_scope": 1506,
+          "stable_10_pair_covered": 1506,
+          "median_abs_correction_percent": 0.5147142821660149,
+          "n_abs_correction_gt_1percent": 134
+        },
+        "FCC": {
+          "stable_all_elements_in_scope": 33,
+          "stable_10_pair_covered": 33,
+          "median_abs_correction_percent": 0.1133682712616328,
+          "n_abs_correction_gt_1percent": 0
+        }
+      }
+    },
+    "candidate_B_data_driven_23": {
+      "label": "candidate_B_data_driven_23",
+      "elements": [
+        "Al",
+        "Au",
+        "Co",
+        "Cr",
+        "Cu",
+        "Fe",
+        "Hf",
+        "Ir",
+        "Mn",
+        "Mo",
+        "Nb",
+        "Ni",
+        "Os",
+        "Pd",
+        "Pt",
+        "Rh",
+        "Ru",
+        "Ta",
+        "Ti",
+        "V",
+        "W",
+        "Zn",
+        "Zr"
+      ],
+      "n_elements": 23,
+      "sqs_pairs": {
+        "BCC": 253,
+        "FCC_DFT_reference": 81,
+        "FCC_King_reference": 82
+      },
+      "ordered_pairs": {
+        "B2": 253,
+        "L1_2": 253
+      },
+      "calibration_all_elements_in_scope": {
+        "BCC": 29,
+        "FCC": 35
+      },
+      "independent_test_all_elements_in_scope": {
+        "BCC": 17,
+        "FCC": 14
+      },
+      "q_optimized": {
+        "BCC": 0.4860687238190625,
+        "FCC": 0.13339949219488767
+      },
+      "independent_test_rmse_q1": {
+        "BCC": 0.014009735459751163,
+        "FCC": 0.023514648531552662,
+        "ALL": 0.018903641420808644
+      },
+      "independent_test_rmse_q_optimized": {
+        "BCC": 0.015728249847714197,
+        "FCC": 0.015231342548259107,
+        "ALL": 0.015505812101918202
+      },
+      "chen": {
+        "BCC": {
+          "stable_all_elements_in_scope": 9438,
+          "stable_10_pair_covered": 9438,
+          "median_abs_correction_percent": 0.34357761759471406,
+          "n_abs_correction_gt_1percent": 321
+        },
+        "FCC": {
+          "stable_all_elements_in_scope": 1322,
+          "stable_10_pair_covered": 1322,
+          "median_abs_correction_percent": 0.04501655377858084,
+          "n_abs_correction_gt_1percent": 0
+        }
+      }
+    }
+  },
+  "be": {
+    "BCC_SQS_pairs": 30,
+    "FCC_SQS_pairs": 0,
+    "B2_pairs": 30,
+    "L1_2_pairs": 6,
+    "ALONSO_BCC_alloys": 0,
+    "ALONSO_FCC_alloys": 0,
+    "INDEPENDENT_BCC_alloys": 0,
+    "INDEPENDENT_FCC_alloys": 0
+  }
+}

--- a/paper/hea_lattice_prediction.tex
+++ b/paper/hea_lattice_prediction.tex
@@ -201,13 +201,65 @@ VASP（本研究） & 1,483 & 2,808 & 4,291 \\
 \end{tabular}
 \par\smallskip
 {\scriptsize 収束後のユニークペア数: B2 465、L1$_2$ 441。
-31ターゲット元素間で完全カバレッジ。Si・Ge・Bは安定構造がBCC/FCCでなくKing体積との乖離が15--29\%に達するため除外。$4f$希土類14元素（La, Ce, Pr, Nd, Sm, Eu, Gd, Tb, Dy, Ho, Er, Tm, Yb, Lu）およびYは、GGA-PBEが$4f$局在電子を正しく扱えず格子定数が非物理的に膨張・未収束となるため除外（付録~\ref{sec:appendix_gdce}参照）。上記に加えBCC SQS計算（A$_8$B$_8$超格子）674件収束・445ペア、FCC SQS計算 141件収束・112ペア、SQS純元素（A$_8$A$_8$）33元素、DFT自己整合参照用純元素（B2: 35元素、L1$_2$: 39元素）を使用。DFT計算総数は約6,000件超。}
+31ターゲット元素間で完全カバレッジ。Si・Ge・Bは安定構造がBCC/FCCでなくKing体積との乖離が15--29\%に達するため除外。$4f$希土類14元素（La, Ce, Pr, Nd, Sm, Eu, Gd, Tb, Dy, Ho, Er, Tm, Yb, Lu）およびYは、GGA-PBEが$4f$局在電子を正しく扱えず格子定数が非物理的に膨張・未収束となるため除外（付録~\ref{sec:appendix_gdce}参照）。上記に加えBCC SQS計算（A$_8$B$_8$超格子）674件収束・445ペア、FCC SQS計算 141件収束・112ペア（King参照；DFT-Vegard参照では120ペア）、SQS純元素（A$_8$A$_8$）33元素、DFT自己整合参照用純元素（B2: 35元素、L1$_2$: 39元素）を使用。DFT計算総数は約6,000件超。}
 \end{table}
 
 収束判定と物理的格子定数範囲（2.0--8.0~\AA）でのフィルタリング後、B2で465・L1$_2$で441のユニーク元素ペアを得た。同一ペアに複数データソースがある場合は中央値を採用し外れ値の影響を緩和した。3ソース間の$\Omega_\text{sf}$は高い整合性を示し（B2 $r = 0.990$、L1$_2$ $r = 0.990$）、統合前後の平均変化量は$|\Delta\Omega| < 0.006$であった。
 
 \subsubsection{HEA検証データ}
 主検証セットはAlonso~\cite{Alonso2021} Table~2の64個の立方晶HEA（BCC 29、FCC 35、$a = 2.883$--$3.856$~\AA、22元素）である。独立テストセットとしてAlonsoデータ外の31 HEA（BCC 17、FCC 14）を14文献~\cite{Senkov2012,Senkov2013_ActaMat,Otto2013,Niu2017,Stepanov2015,Dirras2016,Yao2016,Freudenberger2017,Wang2019,Tseng2019,Reget2020,Chen2022,Kantelis2025,Chen2023}から収集した。19元素をカバーし、耐火金属系BCC（Tseng 2019、Reget 2020）、貴金属系FCC（Freudenberger 2017）、三元系BCC（Chen 2022: HfNbZr）、CALPHAD予測＋合成検証（Chen 2023: AlCoMnNiV, CoFeMnNiZn）を含む。ただしBCC 17合金はHf-Mo-Nb-Ta-Ti-Zrの系統的サブセットが主体であり、FCC 14合金もAu-Cu-Ni-Pd-Pt系とCoCrFeMnNi派生に偏る。実効的な化学多様性は合金数より限定的である点に留意が必要である。
+
+\subsection{検証対象元素スコープ}
+\label{sec:element_scope}
+
+本研究の基礎データベースは31元素を対象とする一方、HEA格子定数の校正・独立テストが実際に依拠する元素スコープは、Alonso~\cite{Alonso2021} Table~2の
+`ALONSO\_TABLE2`と独立テスト集合`INDEPENDENT\_TEST`に出現する元素の和集合として定義した。このデータ駆動の検証対象は次の23元素である：
+\[
+\{\mathrm{Al,Au,Co,Cr,Cu,Fe,Hf,Ir,Mn,Mo,Nb,Ni,Os,Pd,Pt,Rh,Ru,Ta,Ti,V,W,Zn,Zr}\}.
+\]
+SiはKing原子体積を持たず、安定構造もBCC/FCCではないため、全スコープの集計から一貫して除外した。したがってFCC-SQSの生のDFT-Vegard参照は120ペア（Siを含む9ペアを含む）であるが、検証スコープでは111ペアとなる。King参照のFCC-SQSは112ペアであり、両者は参照体積の違いによる別の集計である。
+
+実用HEA構成元素を意図した感度分析として、Siを除いた16元素
+\[
+\{\mathrm{Al,Ti,V,Cr,Mn,Fe,Co,Ni,Cu,Zn,Zr,Nb,Mo,Hf,Ta,W}\}
+\]
+も比較した。表~\ref{tab:element_scope}の$q$とRMSEは、既存のB2/L1$_2$ペアデータベースを`compute\_eq10\_scaled`に渡して再計算した値であり、SQS-BCCの採用モデル（DFT Vegard参照、$q=1$）とは区別する。$q_\text{BCC}$は両スコープで完全に不変、$q_\text{FCC}$も0.133399から0.131812への変化に留まる。一方、実用16元素スコープではFCC独立テストが14合金から5合金へ減少し、FCC検証の化学的多様性が失われるため、主範囲には採用しない。
+
+\begin{table}[H]
+\centering
+\caption{検証対象元素スコープの定量比較。FCC-SQSはDFT-Vegard参照ペア数を示し、括弧内にKing参照ペア数を示す。RMSEの単位は\AA{}。}
+\label{tab:element_scope}
+\scriptsize
+\begin{tabular}{@{}lrrr@{}}
+\toprule
+指標 & 全31元素 & 実用16元素 & データ駆動23元素 \\
+\midrule
+元素数 & 31 & 16 & 23 \\
+BCC SQSペア & 445 & 120 & 253 \\
+FCC SQSペア（DFT / King） & 111 / 112 & 29 / 30 & 81 / 82 \\
+B2 / L1$_2$ペア & 465 / 441 & 120 / 120 & 253 / 253 \\
+校正 BCC / FCC & 29 / 35 & 29 / 31 & 29 / 35 \\
+独立テスト BCC / FCC & 17 / 14 & 17 / 5 & 17 / 14 \\
+$q_\text{BCC}$ / $q_\text{FCC}$ & 0.486069 / 0.133399 & 0.486069 / 0.131812 & 0.486069 / 0.133399 \\
+\midrule
+\multicolumn{4}{l}{\textit{独立テストRMSE（$q=1$: BCC / FCC / ALL）}}\\
+全31元素 & 0.01401 / 0.02351 / 0.01890 & & \\
+実用16元素 & & 0.01401 / 0.02974 / 0.01878 & \\
+データ駆動23元素 & & & 0.01401 / 0.02351 / 0.01890 \\
+\multicolumn{4}{l}{\textit{独立テストRMSE（q最適: BCC / FCC / ALL）}}\\
+全31元素 & 0.01573 / 0.01523 / 0.01551 & & \\
+実用16元素 & & 0.01573 / 0.01049 / 0.01470 & \\
+データ駆動23元素 & & & 0.01573 / 0.01523 / 0.01551 \\
+\midrule
+\multicolumn{4}{l}{\textit{Chen安定quinary（10ペア被覆済み: BCC / FCC）}}\\
+全31元素 & 14,887 / 1,555 & & \\
+実用16元素 & & 1,506 / 33 & \\
+データ駆動23元素 & & & 9,438 / 1,322 \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+Chen統合スクリーニングでの$\Omega_\text{sf}$補正中央値は、全31元素でBCC 0.3955\%、FCC 0.0450\%、データ駆動23元素でBCC 0.3436\%、FCC 0.0450\%であった。$|\Delta a/a|>1\%$はそれぞれBCC 1,238件および321件で、FCCはいずれのスコープでも0件である。Beは基礎データベースには30ペア（BCC SQSおよびB2）存在するが、校正集合、独立テスト集合、Chen統合表のいずれにも1件も含まれない。そのため、Be系で別途調査中の未解決事項は、本節以降のHEA予測の結論には影響しない。
 
 \subsection{体積サイズファクターのDFT導出}
 \label{sec:omega}

--- a/paper/hea_lattice_prediction.tex
+++ b/paper/hea_lattice_prediction.tex
@@ -213,23 +213,30 @@ VASP（本研究） & 1,483 & 2,808 & 4,291 \\
 \label{sec:element_scope}
 
 本研究の基礎データベースは31元素を対象とする一方、HEA格子定数の校正・独立テストが実際に依拠する元素スコープは、Alonso~\cite{Alonso2021} Table~2の
-`ALONSO\_TABLE2`と独立テスト集合`INDEPENDENT\_TEST`に出現する元素の和集合として定義した。このデータ駆動の検証対象は次の23元素である：
+\texttt{ALONSO\_TABLE2}と独立テスト集合\texttt{INDEPENDENT\_TEST}に出現する元素の和集合として定義した。このデータ駆動の検証対象は次の23元素である：
 \[
-\{\mathrm{Al,Au,Co,Cr,Cu,Fe,Hf,Ir,Mn,Mo,Nb,Ni,Os,Pd,Pt,Rh,Ru,Ta,Ti,V,W,Zn,Zr}\}.
+\begin{gathered}
+\{\mathrm{Al,Au,Co,Cr,Cu,Fe,Hf,Ir,Mn,Mo,Nb,Ni,Os,}\\
+\mathrm{Pd,Pt,Rh,Ru,Ta,Ti,V,W,Zn,Zr}\}.
+\end{gathered}
 \]
 SiはKing原子体積を持たず、安定構造もBCC/FCCではないため、全スコープの集計から一貫して除外した。したがってFCC-SQSの生のDFT-Vegard参照は120ペア（Siを含む9ペアを含む）であるが、検証スコープでは111ペアとなる。King参照のFCC-SQSは112ペアであり、両者は参照体積の違いによる別の集計である。
 
 実用HEA構成元素を意図した感度分析として、Siを除いた16元素
 \[
-\{\mathrm{Al,Ti,V,Cr,Mn,Fe,Co,Ni,Cu,Zn,Zr,Nb,Mo,Hf,Ta,W}\}
+\begin{gathered}
+\{\mathrm{Al,Ti,V,Cr,Mn,Fe,Co,Ni,Cu,Zn,Zr,Nb,}\\
+\mathrm{Mo,Hf,Ta,W}\}
+\end{gathered}
 \]
-も比較した。表~\ref{tab:element_scope}の$q$とRMSEは、既存のB2/L1$_2$ペアデータベースを`compute\_eq10\_scaled`に渡して再計算した値であり、SQS-BCCの採用モデル（DFT Vegard参照、$q=1$）とは区別する。$q_\text{BCC}$は両スコープで完全に不変、$q_\text{FCC}$も0.133399から0.131812への変化に留まる。一方、実用16元素スコープではFCC独立テストが14合金から5合金へ減少し、FCC検証の化学的多様性が失われるため、主範囲には採用しない。
+も比較した。表~\ref{tab:element_scope}の$q$とRMSEは、既存のB2/L1$_2$ペアデータベースを\texttt{compute\_eq10\_scaled}に渡して再計算した値であり、SQS-BCCの採用モデル（DFT Vegard参照、$q=1$）とは区別する。$q_\text{BCC}$は両スコープで完全に不変、$q_\text{FCC}$も0.133399から0.131812への変化に留まる。一方、実用16元素スコープではFCC独立テストが14合金から5合金へ減少し、FCC検証の化学的多様性が失われるため、主範囲には採用しない。
 
 \begin{table}[H]
 \centering
-\caption{検証対象元素スコープの定量比較。FCC-SQSはDFT-Vegard参照ペア数を示し、括弧内にKing参照ペア数を示す。RMSEの単位は\AA{}。}
+\caption{検証対象元素スコープの定量比較。各スラッシュは左からBCC/FCC、またはDFT-Vegard参照/King参照を示す。RMSEの単位は\AA{}。}
 \label{tab:element_scope}
 \scriptsize
+\resizebox{\linewidth}{!}{%
 \begin{tabular}{@{}lrrr@{}}
 \toprule
 指標 & 全31元素 & 実用16元素 & データ駆動23元素 \\
@@ -242,21 +249,12 @@ B2 / L1$_2$ペア & 465 / 441 & 120 / 120 & 253 / 253 \\
 独立テスト BCC / FCC & 17 / 14 & 17 / 5 & 17 / 14 \\
 $q_\text{BCC}$ / $q_\text{FCC}$ & 0.486069 / 0.133399 & 0.486069 / 0.131812 & 0.486069 / 0.133399 \\
 \midrule
-\multicolumn{4}{l}{\textit{独立テストRMSE（$q=1$: BCC / FCC / ALL）}}\\
-全31元素 & 0.01401 / 0.02351 / 0.01890 & & \\
-実用16元素 & & 0.01401 / 0.02974 / 0.01878 & \\
-データ駆動23元素 & & & 0.01401 / 0.02351 / 0.01890 \\
-\multicolumn{4}{l}{\textit{独立テストRMSE（q最適: BCC / FCC / ALL）}}\\
-全31元素 & 0.01573 / 0.01523 / 0.01551 & & \\
-実用16元素 & & 0.01573 / 0.01049 / 0.01470 & \\
-データ駆動23元素 & & & 0.01573 / 0.01523 / 0.01551 \\
-\midrule
-\multicolumn{4}{l}{\textit{Chen安定quinary（10ペア被覆済み: BCC / FCC）}}\\
-全31元素 & 14,887 / 1,555 & & \\
-実用16元素 & & 1,506 / 33 & \\
-データ駆動23元素 & & & 9,438 / 1,322 \\
+独立テストRMSE（$q=1$: BCC / FCC / ALL） & 0.01401 / 0.02351 / 0.01890 & 0.01401 / 0.02974 / 0.01878 & 0.01401 / 0.02351 / 0.01890 \\
+独立テストRMSE（q最適: BCC / FCC / ALL） & 0.01573 / 0.01523 / 0.01551 & 0.01573 / 0.01049 / 0.01470 & 0.01573 / 0.01523 / 0.01551 \\
+Chen安定quinary（10ペア被覆: BCC / FCC） & 14,887 / 1,555 & 1,506 / 33 & 9,438 / 1,322 \\
 \bottomrule
 \end{tabular}
+}
 \end{table}
 
 Chen統合スクリーニングでの$\Omega_\text{sf}$補正中央値は、全31元素でBCC 0.3955\%、FCC 0.0450\%、データ駆動23元素でBCC 0.3436\%、FCC 0.0450\%であった。$|\Delta a/a|>1\%$はそれぞれBCC 1,238件および321件で、FCCはいずれのスコープでも0件である。Beは基礎データベースには30ペア（BCC SQSおよびB2）存在するが、校正集合、独立テスト集合、Chen統合表のいずれにも1件も含まれない。そのため、Be系で別途調査中の未解決事項は、本節以降のHEA予測の結論には影響しない。


### PR DESCRIPTION
## Summary

「HEA特有元素に絞る」ために、**基礎データベースの31元素**と、**HEA格子定数の校正・独立テストが実際に依拠する元素スコープ**を分離して定義し、絞り込みが結論を変えないことを定量した。新節 `\label{sec:element_scope}`（手法節）と再現スクリプト `paper/element_scope_analysis.py` → `paper/element_scope_metrics.json` を追加。既存の `paper_metrics.json`・図・`chen2023_screening_metrics.json` は不変。

**主範囲はデータ駆動の23元素**。ハードコードせず、校正・テスト集合から自動導出する:

```python
SCOPE_EXCLUDED_ELEMENTS = {"Si"}   # King体積なし・安定構造がBCC/FCCでない
data_driven = (elements(ALONSO_TABLE2) | elements(INDEPENDENT_TEST)) - SCOPE_EXCLUDED_ELEMENTS
# -> Al Au Co Cr Cu Fe Hf Ir Mn Mo Nb Ni Os Pd Pt Rh Ru Ta Ti V W Zn Zr (23)
```

| 指標 | 全31元素 | 実用16元素 | データ駆動23元素 |
|---|---:|---:|---:|
| BCC SQSペア | 445 | 120 | 253 |
| 校正 BCC/FCC | 29/35 | 29/31 | 29/35 |
| 独立テスト BCC/FCC | 17/14 | 17/**5** | 17/14 |
| $q_\text{BCC}$ / $q_\text{FCC}$ | 0.486069 / 0.133399 | 0.486069 / 0.131812 | 0.486069 / 0.133399 |
| Chen安定quinary BCC/FCC | 14,887/1,555 | 1,506/33 | 9,438/1,322 |

「実用HEA構成元素（Al-Ti-V-Cr-Mn-Fe-Co-Ni-Cu-Zn-Zr-Nb-Mo-Hf-Ta-W）に絞る」案は**感度分析としてのみ**残した。採用しない理由は本文にも明記: FCC独立テストが14→5合金に減って貴金属系FCCの検証が成立しなくなる。一方 $q_\text{BCC}$ はスコープ間で完全に不変、$q_\text{FCC}$ も 0.1334→0.1318 で、**絞り込みはモデル校正を動かさない**。

**Beの扱い**: 基礎DBには30ペア（BCC SQS・B2）あるが、校正64合金・独立テスト31合金・Chen統合表16,442件の**いずれにも1件も含まれない**。したがってBe-Coで未解決のセルサイズ間符号反転は、本スコープ以降の結論に影響しない — この事実を本文に明記し、Be-Co自体は本文の主張には使っていない。

**FCC-SQSペア数の3つの数字を定義付きで整理**（従来は文脈依存で混同しうる状態だった）:
- 120 = `fcc_omega_dft` の生のペア数（Si含む9ペアを含む）
- 111 = 上からSiを除いた検証スコープでの値
- 112 = `fcc_omega_king`（King参照）— 本文既存の「141件収束・112ペア」はこちら

$\Omega_\text{sf}$・$q$校正・予測式は既存の単一ソース関数（`load_sqs_data` / `compute_omega_sf_pairwise` / `optimize_gamma` / `compute_eq10_scaled` / `compute_vegard`）を再利用し、再実装していない。Chen部分は `chen2023_lattice_screening.py` の構造別モデル（BCC: SQS+DFT Vegard, $q=1$ / FCC: L1$_2$+King, $q_\text{FCC}$）をそのまま流用、外部データはキャッシュ利用で追加ダウンロードなし。

### 未実施

16原子 vs 128原子のセルサイズ検証節は**入れていない**。128原子（4×4×4）SQSの結果行がこのベースブランチの `data/sqs_results.csv` に存在せず（当該データはPR #452 で未マージ）、ユーザー添付CSVをリポジトリに取り込むことは避けたため。#452 マージ後に別PRで追加する。

### 検証

- `lualatex` 2回、`^!` エラー0・undefined reference/citation 0・**32ページ**（直前31ページ）、新表に起因する Overfull \hbox なし
- `element_scope_metrics.json` と本文の全数値が一致。`paper_metrics.json` / 既存図 / `chen2023_screening_metrics.json` はSHA不変


Link to Devin session: https://app.devin.ai/sessions/3fd8fc4791c84687a3daf026214784b6
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->