### PR TITLE
feat(mi_hub2): 仮説の構造化・Falsifierエージェント・3値判定（Phase 1）

### DIFF
--- a/mi_hub2/src/mi_hub/agent/api.py
+++ b/mi_hub2/src/mi_hub/agent/api.py
@@ -254,3 +254,23 @@ def patch_hypothesis(hypothesis_id: str, req: HypothesisPatch) -> dict[str, Any]
         raise HTTPException(403, str(exc)) from exc
     h = state.hypothesis(hypothesis_id)
     return h.model_dump() if h else {}
+
+
+class JudgementConfirmBody(BaseModel):
+    session_id: str
+    accept: bool = True
+    by: str = "human"
+
+
+# 判定案の確定（3値判定の Human-in-the-loop 確定）
+@app.post("/api/agent/hypotheses/{hypothesis_id}/judgement")
+def confirm_judgement(hypothesis_id: str, req: JudgementConfirmBody) -> dict[str, Any]:
+    m = get_manager()
+    state = _load(req.session_id)
+    try:
+        h = m.confirm_judgement(state, hypothesis_id, accept=req.accept, by=req.by)
+    except ValueError as exc:
+        raise HTTPException(404, str(exc)) from exc
+    except PermissionError as exc:
+        raise HTTPException(403, str(exc)) from exc
+    return h.model_dump()

--- a/mi_hub2/src/mi_hub/agent/judgement.py
+++ b/mi_hub2/src/mi_hub/agent/judgement.py
@@ -9,14 +9,17 @@ from __future__ import annotations
 
 from .models import Hypothesis, HypothesisJudgement, JudgementCriterion
 
-# 効果方向の既定値: 主仮説は「独立変数の増加で目的量が増加する」を正方向とする
 _DIRECTIONS = {"positive", "negative"}
 
 
-def expected_direction(h: Hypothesis) -> str:
-    """仮説の期待する効果方向（applicability.expected_direction、既定 positive）。"""
-    d = str(h.applicability.get("expected_direction", "positive")).lower()
-    return d if d in _DIRECTIONS else "positive"
+def expected_direction(h: Hypothesis) -> str | None:
+    """仮説の期待する効果方向（applicability.expected_direction）。
+
+    未設定・不正な値の場合は None（方向不明）を返す。
+    方向不明の仮説は supported / refuted にはしない。
+    """
+    d = str(h.applicability.get("expected_direction", "")).lower()
+    return d if d in _DIRECTIONS else None
 
 
 def judge_hypothesis(
@@ -37,7 +40,8 @@ def judge_hypothesis(
     threshold = 3.0 * (mean_uncertainty + 1e-9)
     significant = abs(slope) > threshold
     observed = "positive" if slope > 0 else "negative"
-    direction_match = significant and observed == direction
+    direction_known = direction is not None
+    direction_match = significant and direction_known and observed == direction
     reproduced = n_independent_groups >= 2
     enough_points = n_points >= 3
 
@@ -50,7 +54,10 @@ def judge_hypothesis(
         JudgementCriterion(
             name="効果方向の一致",
             passed=direction_match,
-            detail=f"予測方向={direction} / 観測方向={observed if significant else '有意でない'}",
+            detail=(
+                f"予測方向={direction if direction_known else '未設定（判定不能）'} / "
+                f"観測方向={observed if significant else '有意でない'}"
+            ),
         ),
         JudgementCriterion(
             name="独立系列での再現",
@@ -64,7 +71,13 @@ def judge_hypothesis(
         ),
     ]
 
-    if significant and not direction_match:
+    if not direction_known:
+        verdict = "inconclusive"
+        rationale = (
+            "仮説の期待効果方向（expected_direction）が未設定のため、"
+            "支持・反証の判定は行わない。適用範囲に期待方向を設定してください。"
+        )
+    elif significant and not direction_match:
         verdict = "refuted"
         rationale = (
             "効果は不確実性に対して有意だが、方向が仮説の予測と逆であり、"

--- a/mi_hub2/src/mi_hub/agent/judgement.py
+++ b/mi_hub2/src/mi_hub/agent/judgement.py
@@ -1,0 +1,96 @@
+"""仮説の3値判定（Supported / Refuted / Inconclusive）。
+
+数値結果に対する決定論的ルール評価で判定案を作る。
+LLM の文章は補助情報であり、判定の主根拠にしない。
+最終確定は研究者（Human-in-the-loop）が行う。
+"""
+
+from __future__ import annotations
+
+from .models import Hypothesis, HypothesisJudgement, JudgementCriterion
+
+# 効果方向の既定値: 主仮説は「独立変数の増加で目的量が増加する」を正方向とする
+_DIRECTIONS = {"positive", "negative"}
+
+
+def expected_direction(h: Hypothesis) -> str:
+    """仮説の期待する効果方向（applicability.expected_direction、既定 positive）。"""
+    d = str(h.applicability.get("expected_direction", "positive")).lower()
+    return d if d in _DIRECTIONS else "positive"
+
+
+def judge_hypothesis(
+    h: Hypothesis,
+    *,
+    slope: float,
+    mean_uncertainty: float,
+    n_points: int,
+    n_independent_groups: int,
+) -> HypothesisJudgement:
+    """効果の有意性・方向・再現性・データ量のルール評価から3値判定案を返す。
+
+    - Refuted: 効果が有意で、かつ方向が仮説の予測と逆（反証条件に該当）
+    - Supported: 効果が有意・方向一致・独立系列で再現・十分なデータ点
+    - Inconclusive: 上記いずれも満たさない（不足している根拠を明示）
+    """
+    direction = expected_direction(h)
+    threshold = 3.0 * (mean_uncertainty + 1e-9)
+    significant = abs(slope) > threshold
+    observed = "positive" if slope > 0 else "negative"
+    direction_match = significant and observed == direction
+    reproduced = n_independent_groups >= 2
+    enough_points = n_points >= 3
+
+    criteria = [
+        JudgementCriterion(
+            name="効果の有意性",
+            passed=significant,
+            detail=f"|slope|={abs(slope):.4g} vs 3σ閾値={threshold:.4g}",
+        ),
+        JudgementCriterion(
+            name="効果方向の一致",
+            passed=direction_match,
+            detail=f"予測方向={direction} / 観測方向={observed if significant else '有意でない'}",
+        ),
+        JudgementCriterion(
+            name="独立系列での再現",
+            passed=reproduced,
+            detail=f"独立モデル系列数={n_independent_groups}（2以上で再現とみなす）",
+        ),
+        JudgementCriterion(
+            name="データ点数",
+            passed=enough_points,
+            detail=f"条件点数={n_points}（3以上を要求）",
+        ),
+    ]
+
+    if significant and not direction_match:
+        verdict = "refuted"
+        rationale = (
+            "効果は不確実性に対して有意だが、方向が仮説の予測と逆であり、"
+            "反証条件（逆方向の有意な傾向）に該当する。"
+        )
+    elif significant and direction_match and reproduced and enough_points:
+        verdict = "supported"
+        rationale = (
+            "効果が有意で方向が予測と一致し、独立なモデル系列でも再現され、"
+            "十分な条件点数で確認された。"
+        )
+    else:
+        verdict = "inconclusive"
+        missing = [c.name for c in criteria if not c.passed]
+        rationale = "判定に必要な基準が不足: " + "、".join(missing)
+
+    return HypothesisJudgement(
+        verdict=verdict,
+        criteria=criteria,
+        metrics={
+            "slope": slope,
+            "mean_uncertainty": mean_uncertainty,
+            "n_points": n_points,
+            "n_independent_groups": n_independent_groups,
+            "expected_direction": direction,
+        },
+        rationale=rationale + "（最終確定は研究者の承認による）",
+        decided_by="rule",
+    )

--- a/mi_hub2/src/mi_hub/agent/llm.py
+++ b/mi_hub2/src/mi_hub/agent/llm.py
@@ -254,13 +254,20 @@ def falsification_review(goal: str, statement: str,
         json.dumps({"hypothesis": statement, "claims": claims[:20]},
                    ensure_ascii=False),
     )
+
+    def _as_list(v: Any) -> list[str]:
+        # LLM 出力の型ゆらぎ（文字列/リスト）を吸収する
+        if isinstance(v, str):
+            return [v.strip()] if v.strip() else []
+        if isinstance(v, list):
+            return [str(x) for x in v if x]
+        return []
+
     if out and isinstance(out.get("counter_queries"), list):
         return {
             "counter_queries": [str(q) for q in out["counter_queries"]][:2],
-            "falsification_conditions": [
-                str(c) for c in out.get("falsification_conditions", []) or []],
-            "alternative_mechanisms": [
-                str(m) for m in out.get("alternative_mechanisms", []) or []],
+            "falsification_conditions": _as_list(out.get("falsification_conditions")),
+            "alternative_mechanisms": _as_list(out.get("alternative_mechanisms")),
         }
     return {
         "counter_queries": [f"{statement} 反例 条件依存性",

--- a/mi_hub2/src/mi_hub/agent/llm.py
+++ b/mi_hub2/src/mi_hub/agent/llm.py
@@ -211,7 +211,9 @@ def generate_hypotheses(goal_statement: str, evidence_claims: list[str]) -> list
         '{"hypotheses": [{"statement", "is_counter", "mechanism", "scope", '
         '"supporting_predictions", "falsification_conditions"}]} を返してください。'
         "mechanism は想定する物理・化学的機構、scope は適用範囲（温度・組成・相など）の"
-        "JSONオブジェクトとすること。falsification_conditions は必ず1件以上含めること。",
+        "JSONオブジェクトとすること。scope には必ず expected_direction キー"
+        '（仮説が予測する効果方向。目的量が増加なら "positive"、減少なら "negative"）'
+        "を含めること。falsification_conditions は必ず1件以上含めること。",
         f"研究目標: {goal_statement}\n証拠: {json.dumps(evidence_claims, ensure_ascii=False)}",
     )
     if out and isinstance(out.get("hypotheses"), list):
@@ -221,7 +223,7 @@ def generate_hypotheses(goal_statement: str, evidence_claims: list[str]) -> list
             "statement": f"主仮説: {goal_statement} に対する主要因が成立する",
             "is_counter": False,
             "mechanism": "対象因子が目的量を支配すると想定",
-            "scope": {},
+            "scope": {"expected_direction": "positive"},
             "supporting_predictions": ["独立モデル群の予測が同方向の傾向を示す"],
             "falsification_conditions": ["独立モデル群の過半が逆方向の傾向を示す"],
         },
@@ -229,7 +231,7 @@ def generate_hypotheses(goal_statement: str, evidence_claims: list[str]) -> list
             "statement": "対立仮説: 別の欠陥・機構が主要因である",
             "is_counter": True,
             "mechanism": "別の欠陥・機構が目的量を支配すると想定",
-            "scope": {},
+            "scope": {"expected_direction": "negative"},
             "supporting_predictions": ["対象因子を除外しても傾向が維持される"],
             "falsification_conditions": ["対象因子除外時に傾向が消失する"],
         },

--- a/mi_hub2/src/mi_hub/agent/llm.py
+++ b/mi_hub2/src/mi_hub/agent/llm.py
@@ -208,8 +208,10 @@ def generate_hypotheses(goal_statement: str, evidence_claims: list[str]) -> list
     """主仮説・対立仮説の候補を生成する（最終採用は人間）。"""
     out = _chat_json(
         "材料科学の仮説候補を生成してください。JSON で "
-        '{"hypotheses": [{"statement", "is_counter", "supporting_predictions", '
-        '"falsification_conditions"}]} を返してください。',
+        '{"hypotheses": [{"statement", "is_counter", "mechanism", "scope", '
+        '"supporting_predictions", "falsification_conditions"}]} を返してください。'
+        "mechanism は想定する物理・化学的機構、scope は適用範囲（温度・組成・相など）の"
+        "JSONオブジェクトとすること。falsification_conditions は必ず1件以上含めること。",
         f"研究目標: {goal_statement}\n証拠: {json.dumps(evidence_claims, ensure_ascii=False)}",
     )
     if out and isinstance(out.get("hypotheses"), list):
@@ -218,16 +220,57 @@ def generate_hypotheses(goal_statement: str, evidence_claims: list[str]) -> list
         {
             "statement": f"主仮説: {goal_statement} に対する主要因が成立する",
             "is_counter": False,
+            "mechanism": "対象因子が目的量を支配すると想定",
+            "scope": {},
             "supporting_predictions": ["独立モデル群の予測が同方向の傾向を示す"],
             "falsification_conditions": ["独立モデル群の過半が逆方向の傾向を示す"],
         },
         {
             "statement": "対立仮説: 別の欠陥・機構が主要因である",
             "is_counter": True,
+            "mechanism": "別の欠陥・機構が目的量を支配すると想定",
+            "scope": {},
             "supporting_predictions": ["対象因子を除外しても傾向が維持される"],
             "falsification_conditions": ["対象因子除外時に傾向が消失する"],
         },
     ]
+
+
+def falsification_review(goal: str, statement: str,
+                         claims: list[str]) -> dict[str, Any]:
+    """仮説への反証検討（Falsifier）: 反対証拠の検索クエリ・反証条件・別機構。
+
+    LLM 不可時は決定論的な既定候補を返す。
+    """
+    out = _chat_json(
+        "あなたは確証バイアスを防ぐ反証担当（Falsifier）です。"
+        f"研究目標「{goal}」の文脈で、与えられた仮説を否定しうる観点を提示してください。"
+        'JSON {"counter_queries": [str], "falsification_conditions": [str], '
+        '"alternative_mechanisms": [str]} を返すこと。'
+        "counter_queries は反対結果・条件依存性・別機構を探す文献検索クエリ（日本語、2件まで）、"
+        "falsification_conditions は測定・計算で判定可能な反証条件、"
+        "alternative_mechanisms は同じ観測を説明しうる別機構の候補とする。"
+        "根拠のない断定はしないこと。",
+        json.dumps({"hypothesis": statement, "claims": claims[:20]},
+                   ensure_ascii=False),
+    )
+    if out and isinstance(out.get("counter_queries"), list):
+        return {
+            "counter_queries": [str(q) for q in out["counter_queries"]][:2],
+            "falsification_conditions": [
+                str(c) for c in out.get("falsification_conditions", []) or []],
+            "alternative_mechanisms": [
+                str(m) for m in out.get("alternative_mechanisms", []) or []],
+        }
+    return {
+        "counter_queries": [f"{statement} 反例 条件依存性",
+                            f"{statement} 別機構 代替要因"],
+        "falsification_conditions": [
+            "独立なモデル系列の過半が予測と逆方向の有意な傾向を示す",
+            "対象因子を除外しても同一の傾向が維持される（別機構の示唆）",
+        ],
+        "alternative_mechanisms": ["別の欠陥・機構が主要因である可能性"],
+    }
 
 
 _INTENTS = {"run", "pause", "resume", "complete", "approve", "reject", "script", "question"}

--- a/mi_hub2/src/mi_hub/agent/loop.py
+++ b/mi_hub2/src/mi_hub/agent/loop.py
@@ -18,6 +18,7 @@ from .graphrag import GraphRAGProvider
 from .models import (
     ApprovalRequest,
     Evidence,
+    Hypothesis,
     JobRecord,
     Observation,
     Plan,
@@ -31,6 +32,7 @@ from .roles import (
     EvaluationAgent,
     EvidenceAgent,
     ExecutionAgent,
+    FalsifierAgent,
     HypothesisAgent,
     ModelSelectionAgent,
     SafetyApprovalAgent,
@@ -95,6 +97,7 @@ class ResearchManager:
         self._roles = {
             "EvidenceAgent": EvidenceAgent(),
             "HypothesisAgent": HypothesisAgent(),
+            "FalsifierAgent": FalsifierAgent(),
             "ModelSelectionAgent": ModelSelectionAgent(),
             "VerificationPlanningAgent": VerificationPlanningAgent(),
             "ExecutionAgent": ExecutionAgent(),
@@ -169,8 +172,11 @@ class ResearchManager:
                   inputs={"query": goal.statement if goal else ""})
         t2 = Task(agent="HypothesisAgent", action="generate_hypotheses",
                   description="主仮説と対立仮説を生成する", depends_on=[t1.task_id])
+        t2b = Task(agent="FalsifierAgent", action="search_counter_evidence",
+                   description="仮説を否定しうる証拠・条件依存性・別機構を探索する（反証優先）",
+                   depends_on=[t2.task_id])
         t3 = Task(agent="ModelSelectionAgent", action="search_models",
-                  description="適用可能なMIntモデルを検索する", depends_on=[t2.task_id])
+                  description="適用可能なMIntモデルを検索する", depends_on=[t2b.task_id])
         t4 = Task(agent="VerificationPlanningAgent", action="plan_verification",
                   description="検証ジョブ（入力条件）を生成する", depends_on=[t3.task_id])
         t5 = Task(agent="ExecutionAgent", action="run_models_bulk",
@@ -179,7 +185,7 @@ class ResearchManager:
         t6 = Task(agent="EvaluationAgent", action="evaluate_hypothesis",
                   description="傾きと不確実性から仮説の判定材料を整理する",
                   depends_on=[t5.task_id])
-        plan = Plan(goal_id=goal.goal_id if goal else "", tasks=[t1, t2, t3, t4, t5, t6])
+        plan = Plan(goal_id=goal.goal_id if goal else "", tasks=[t1, t2, t2b, t3, t4, t5, t6])
         state.plan = plan
         state.plan_history.append(PlanChange(
             plan_id=plan.plan_id, version=plan.version,
@@ -291,6 +297,7 @@ class ResearchManager:
             status = "completed" if task.status != TaskState.FAILED else "failed"
             if task.status != TaskState.FAILED:
                 self._add_science_comment(state, task)
+                self._ask_judgement_confirmation(state, task)
         except Exception as exc:  # ツール層以外の予期しない失敗
             from .errors import record_error
 
@@ -307,6 +314,7 @@ class ResearchManager:
 
     _COMMENT_TARGETS: ClassVar[dict[str, str]] = {
         "HypothesisAgent": "仮説",
+        "FalsifierAgent": "反証検討",
         "EvaluationAgent": "評価結果",
         "ExecutionAgent": "計算結果",
     }
@@ -327,6 +335,32 @@ class ResearchManager:
             })
             state.audit("ResearchManager", "science_comment",
                         task_id=task.task_id, kind=kind)
+
+    def _ask_judgement_confirmation(self, state: SessionState, task: Task) -> None:
+        """評価完了時、ルール評価による判定案の確定を研究者へ明示的に問いかける。"""
+        if task.action != "evaluate_hypothesis" or not task.result:
+            return
+        judgements = task.result.get("judgements") or {}
+        labels = {"supported": "支持（Supported）",
+                  "refuted": "反証（Refuted）",
+                  "inconclusive": "保留（Inconclusive）"}
+        for hid, j in judgements.items():
+            h = state.hypothesis(hid)
+            if h is None:
+                continue
+            verdict = labels.get(j.get("verdict", ""), j.get("verdict", ""))
+            state.chat_history.append({
+                "role": "assistant",
+                "content": (
+                    f"【判定案】仮説「{h.statement}」のルール評価による判定案は"
+                    f"「{verdict}」です。\n根拠: {j.get('rationale', '')}\n"
+                    "この判定を確定しますか？（確定する場合は仮説タブの"
+                    "「判定を確定」、保留のまま検証を続ける場合は「保留のまま続行」を"
+                    "選択してください。最終判定は研究者に委ねられます）"
+                ),
+            })
+            state.audit("ResearchManager", "judgement_proposed",
+                        hypothesis_id=hid, verdict=j.get("verdict"))
 
     def _wire_inputs(self, state: SessionState, task: Task) -> None:
         plan = state.plan
@@ -646,6 +680,33 @@ class ResearchManager:
         state.audit(by, "hypothesis_status_changed",
                     hypothesis_id=hypothesis_id, status=status.value)
         self.store.save(state)
+
+    def confirm_judgement(self, state: SessionState, hypothesis_id: str,
+                          accept: bool, by: str = "human") -> Hypothesis:
+        """ルール評価による判定案を研究者が確定（または保留のまま継続）する。
+
+        確定時は verdict に応じて仮説状態を SUPPORTED / FALSIFIED / INCONCLUSIVE へ遷移する。
+        """
+        if by != "human":
+            raise PermissionError("判定の確定には研究者の承認が必要です")
+        h = state.hypothesis(hypothesis_id)
+        if h is None:
+            raise ValueError(f"仮説が存在しません: {hypothesis_id}")
+        if h.judgement is None:
+            raise ValueError(f"判定案が存在しません: {hypothesis_id}")
+        if accept:
+            mapping = {
+                "supported": HypothesisState.SUPPORTED,
+                "refuted": HypothesisState.FALSIFIED,
+                "inconclusive": HypothesisState.INCONCLUSIVE,
+            }
+            h.status = mapping.get(h.judgement.verdict, HypothesisState.INCONCLUSIVE)
+            h.judgement.confirmed_by_human = True
+        state.audit(by, "judgement_confirmed" if accept else "judgement_deferred",
+                    hypothesis_id=hypothesis_id, verdict=h.judgement.verdict,
+                    status=h.status.value)
+        self.store.save(state)
+        return h
 
     def update_falsification_conditions(self, state: SessionState, hypothesis_id: str,
                                         conditions: list[str], by: str = "human") -> None:

--- a/mi_hub2/src/mi_hub/agent/models.py
+++ b/mi_hub2/src/mi_hub/agent/models.py
@@ -34,17 +34,46 @@ class Evidence(BaseModel):
     limitations: list[str] = Field(default_factory=list)
 
 
+class JudgementCriterion(BaseModel):
+    """3値判定を構成する個別のルール評価。"""
+
+    name: str
+    passed: bool
+    detail: str = ""
+
+
+class HypothesisJudgement(BaseModel):
+    """仮説の3値判定案（Supported / Refuted / Inconclusive）。
+
+    数値結果とルール評価を主根拠とし、LLM の文章だけでは確定しない。
+    最終確定は研究者の承認による。
+    """
+
+    verdict: str = "inconclusive"  # supported / refuted / inconclusive
+    criteria: list[JudgementCriterion] = Field(default_factory=list)
+    metrics: dict[str, Any] = Field(default_factory=dict)
+    rationale: str = ""
+    decided_by: str = "rule"
+    confirmed_by_human: bool = False
+    created_at: float = Field(default_factory=time.time)
+
+
 class Hypothesis(BaseModel):
     hypothesis_id: str = Field(default_factory=lambda: _uid("H"))
     statement: str
     counter_to: str | None = None  # 対立仮説の場合、主仮説ID
+    mechanism: str = ""  # 想定機構
     supporting_predictions: list[str] = Field(default_factory=list)
     falsification_conditions: list[str] = Field(default_factory=list)
     falsification_approved: bool = False  # 反証条件は研究者承認後に固定（§5.3）
     hold_conditions: list[str] = Field(default_factory=list)
     required_inputs: list[str] = Field(default_factory=list)
     required_outputs: list[str] = Field(default_factory=list)
-    applicability: dict[str, Any] = Field(default_factory=dict)
+    applicability: dict[str, Any] = Field(default_factory=dict)  # 適用範囲（scope）
+    source_evidence: list[str] = Field(default_factory=list)  # 根拠となる証拠ID
+    counter_evidence: list[str] = Field(default_factory=list)  # 反対・条件依存の証拠ID
+    alternative_mechanisms: list[str] = Field(default_factory=list)  # 別機構の候補
+    judgement: HypothesisJudgement | None = None  # ルール評価による判定案
     status: HypothesisState = HypothesisState.DRAFT
 
 

--- a/mi_hub2/src/mi_hub/agent/roles.py
+++ b/mi_hub2/src/mi_hub/agent/roles.py
@@ -326,6 +326,9 @@ class EvaluationAgent:
                     HypothesisState.ARCHIVED, HypothesisState.REJECTED_BY_HUMAN,
                 ):
                     continue
+                if h.judgement is not None and h.judgement.confirmed_by_human:
+                    # 研究者が確定した判定は再評価で上書きしない
+                    continue
                 j = judge_hypothesis(
                     h, slope=slope, mean_uncertainty=mean_std,
                     n_points=len(xs), n_independent_groups=len(groups),

--- a/mi_hub2/src/mi_hub/agent/roles.py
+++ b/mi_hub2/src/mi_hub/agent/roles.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from . import llm
 from .errors import record_error, requires_human_review, try_auto_fix
+from .judgement import judge_hypothesis
 from .models import (
     ApprovalRequest,
     Evidence,
@@ -54,6 +55,7 @@ AUTO_ALLOWED_ACTIONS = {
     "generate_next_actions",
     "reuse_results",
     "generate_hypotheses",
+    "search_counter_evidence",
     "evaluate_hypothesis",
 }
 
@@ -117,12 +119,17 @@ class HypothesisAgent:
         candidates = llm.generate_hypotheses(goal, claims)
         added = []
         main_id: str | None = None
+        source_ids = [e.evidence_id for e in state.evidence]
         for c in candidates:
+            scope = c.get("scope")
             h = Hypothesis(
                 statement=c.get("statement", ""),
                 counter_to=main_id if c.get("is_counter") else None,
+                mechanism=str(c.get("mechanism", "") or ""),
                 supporting_predictions=c.get("supporting_predictions", []),
                 falsification_conditions=c.get("falsification_conditions", []),
+                applicability=scope if isinstance(scope, dict) else {},
+                source_evidence=source_ids,
                 status=HypothesisState.PROPOSED,
             )
             state.hypotheses.append(h)
@@ -131,6 +138,60 @@ class HypothesisAgent:
             added.append(h.hypothesis_id)
         task.result_ids = added
         return {"hypothesis_ids": added}
+
+
+class FalsifierAgent:
+    """反証担当（Falsifier）: 確証バイアスを防ぐ。
+
+    仮説を否定しうる文献・条件依存性・別機構を能動的に探し、
+    反証条件の候補を補強する（反証条件の確定は研究者承認による）。
+    """
+
+    _TARGET_STATES = (
+        HypothesisState.PROPOSED,
+        HypothesisState.HUMAN_REVIEWED,
+        HypothesisState.APPROVED_FOR_TESTING,
+    )
+
+    def run(self, state: SessionState, gateway: ToolGateway, task: Task) -> dict[str, Any]:
+        goal = state.goal.statement if state.goal else ""
+        claims = [e.claim for e in state.evidence]
+        counter_ids: list[str] = []
+        added_conditions: dict[str, list[str]] = {}
+        reviewed: list[str] = []
+        for h in state.hypotheses:
+            if h.status not in self._TARGET_STATES:
+                continue
+            review = llm.falsification_review(goal, h.statement, claims)
+            reviewed.append(h.hypothesis_id)
+            for query in review["counter_queries"]:
+                for doc in gateway.search_knowledge(query, limit=3):
+                    ev = Evidence(
+                        source_type=doc.get("source_type", "journal_article"),
+                        claim=doc.get("claim", ""),
+                        conditions=doc.get("conditions", {}),
+                        evidence_type=doc.get("evidence_type", "experiment"),
+                        limitations=list(doc.get("limitations", []))
+                        + ["反証検討（Falsifier）の検索結果。仮説への支持/反対は研究者が判断"],
+                    )
+                    state.evidence.append(ev)
+                    h.counter_evidence.append(ev.evidence_id)
+                    counter_ids.append(ev.evidence_id)
+            new_conds = [c for c in review["falsification_conditions"]
+                         if c not in h.falsification_conditions]
+            if new_conds and not h.falsification_approved:
+                h.falsification_conditions.extend(new_conds)
+                added_conditions[h.hypothesis_id] = new_conds
+            for m in review["alternative_mechanisms"]:
+                if m not in h.alternative_mechanisms:
+                    h.alternative_mechanisms.append(m)
+        task.result_ids = counter_ids
+        return {
+            "hypotheses_reviewed": reviewed,
+            "counter_evidence_ids": counter_ids,
+            "added_falsification_conditions": added_conditions,
+            "note": "反証条件の確定・仮説の採否は研究者が行う",
+        }
 
 
 class ModelSelectionAgent:
@@ -253,6 +314,24 @@ class EvaluationAgent:
         for h in state.hypotheses:
             if h.status == HypothesisState.APPROVED_FOR_TESTING:
                 h.status = HypothesisState.UNDER_EVALUATION
+        groups = set()
+        for r in exec_results:
+            info = gateway.get_model(r["job"]["model_id"])
+            if info is not None:
+                groups.add(info.independence_group)
+        judgements: dict[str, dict[str, Any]] = {}
+        if exec_results:
+            for h in state.hypotheses:
+                if h.counter_to is not None or h.status in (
+                    HypothesisState.ARCHIVED, HypothesisState.REJECTED_BY_HUMAN,
+                ):
+                    continue
+                j = judge_hypothesis(
+                    h, slope=slope, mean_uncertainty=mean_std,
+                    n_points=len(xs), n_independent_groups=len(groups),
+                )
+                h.judgement = j
+                judgements[h.hypothesis_id] = j.model_dump()
         evaluation = StepEvaluation(
             step_result="completed",
             goal_progress_before=state.last_observation.goal_progress if state.last_observation else 0.0,
@@ -267,6 +346,7 @@ class EvaluationAgent:
             "slope": slope,
             "mean_uncertainty": mean_std,
             "verdict_candidate": verdict_candidate,
+            "judgements": judgements,
             "data_gaps": data_gaps,
             "note": "最終判定は研究者が行う（Human-in-the-loop）",
             "evaluation": evaluation.model_dump(),

--- a/mi_hub2/src/mi_hub/agent/ui_streamlit.py
+++ b/mi_hub2/src/mi_hub/agent/ui_streamlit.py
@@ -485,8 +485,19 @@ with agent_col:
         for h in state.hypotheses:
             with st.expander(f"{h.hypothesis_id}: {h.statement[:40]}"):
                 st.write("状態:", h.status.value)
+                if h.mechanism:
+                    st.write("想定機構:", h.mechanism)
+                if h.applicability:
+                    st.write("適用範囲:", h.applicability)
+                if h.supporting_predictions:
+                    st.write("予測:", h.supporting_predictions)
                 st.write("反証条件:", h.falsification_conditions)
                 st.write("反証条件承認済:", h.falsification_approved)
+                if h.alternative_mechanisms:
+                    st.write("別機構の候補（Falsifier）:", h.alternative_mechanisms)
+                if h.counter_evidence:
+                    st.caption(f"反証検討で収集した証拠: {len(h.counter_evidence)} 件"
+                               "（証拠タブを参照）")
                 cols = st.columns(2)
                 if cols[0].button("検証承認", key=f"appr-{h.hypothesis_id}"):
                     m.set_hypothesis_status(
@@ -498,6 +509,28 @@ with agent_col:
                         state, h.hypothesis_id, HypothesisState.REJECTED_BY_HUMAN
                     )
                     st.rerun()
+                if h.judgement is not None:
+                    j = h.judgement
+                    labels = {"supported": "支持（Supported）",
+                              "refuted": "反証（Refuted）",
+                              "inconclusive": "保留（Inconclusive）"}
+                    st.markdown("---")
+                    st.markdown(
+                        f"**判定案（ルール評価）: {labels.get(j.verdict, j.verdict)}**"
+                        + ("（研究者確定済み）" if j.confirmed_by_human else "")
+                    )
+                    st.caption(j.rationale)
+                    st.table([{"基準": c.name,
+                               "判定": "○" if c.passed else "×",
+                               "詳細": c.detail} for c in j.criteria])
+                    if not j.confirmed_by_human:
+                        jc = st.columns(2)
+                        if jc[0].button("判定を確定", key=f"jconf-{h.hypothesis_id}"):
+                            m.confirm_judgement(state, h.hypothesis_id, accept=True)
+                            st.rerun()
+                        if jc[1].button("保留のまま続行", key=f"jdef-{h.hypothesis_id}"):
+                            m.confirm_judgement(state, h.hypothesis_id, accept=False)
+                            st.rerun()
 
         graphrag = next(
             (p for p in m.gateway.knowledge_providers

--- a/mi_hub2/tests/test_agent_acceptance.py
+++ b/mi_hub2/tests/test_agent_acceptance.py
@@ -157,7 +157,7 @@ class TestErrorRecovery:
 
     @staticmethod
     def _advance_to_execution(manager, session):
-        for _ in range(4):
+        for _ in range(len(session.plan.tasks)):
             actions = manager.next_actions(session)
             runnable = [a for a in actions if not a["requires_approval"]]
             if not runnable:

--- a/mi_hub2/tests/test_agent_falsifier.py
+++ b/mi_hub2/tests/test_agent_falsifier.py
@@ -172,6 +172,37 @@ class TestJudgementFlow:
             manager.confirm_judgement(session, main.hypothesis_id,
                                       accept=True, by="agent")
 
+    def test_reevaluation_keeps_confirmed_judgement(self, manager, session):
+        """研究者が確定した判定は再評価で上書きされない。"""
+        _run_full_cycle(manager, session)
+        main = next(h for h in session.hypotheses if h.counter_to is None)
+        manager.confirm_judgement(session, main.hypothesis_id, accept=True)
+        confirmed = main.judgement
+        from mi_hub.agent.models import Task
+        from mi_hub.agent.roles import EvaluationAgent
+
+        exec_task = next(t for t in session.plan.tasks
+                         if t.action == "run_models_bulk")
+        task = Task(agent="EvaluationAgent", action="evaluate_hypothesis",
+                    inputs={"results": exec_task.result["results"]})
+        res = EvaluationAgent().run(session, manager.gateway, task)
+        assert main.judgement is confirmed
+        assert main.judgement.confirmed_by_human
+        assert main.hypothesis_id not in res["judgements"]
+
+    def test_falsification_review_string_fields(self, monkeypatch):
+        """LLM が文字列で返しても一文字に分解されない。"""
+        from mi_hub.agent import llm
+
+        monkeypatch.setattr(llm, "_chat_json", lambda *a, **k: {
+            "counter_queries": ["q1"],
+            "falsification_conditions": "独立系列が逆傾向を示す",
+            "alternative_mechanisms": "別機構",
+        })
+        out = llm.falsification_review("goal", "仮説", [])
+        assert out["falsification_conditions"] == ["独立系列が逆傾向を示す"]
+        assert out["alternative_mechanisms"] == ["別機構"]
+
     def test_confirm_without_judgement_raises(self, manager, session):
         manager.run_auto(session)
         h = session.hypotheses[0]

--- a/mi_hub2/tests/test_agent_falsifier.py
+++ b/mi_hub2/tests/test_agent_falsifier.py
@@ -1,0 +1,180 @@
+"""Phase 1: 仮説の構造化・Falsifier・3値判定の受入テスト。"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from mi_hub.agent.judgement import judge_hypothesis
+from mi_hub.agent.loop import ResearchManager, SessionStore
+from mi_hub.agent.models import Hypothesis, SessionState
+from mi_hub.agent.states import HypothesisState, TaskState
+from mi_hub.agent.tools import ToolGateway
+
+GOAL = (
+    "Ni-Al B2相において、Alアンチサイトが相安定性低下の主要因であるか、"
+    "登録済みモデル群を用いて検証する。"
+)
+
+
+@pytest.fixture()
+def manager(tmp_path):
+    return ResearchManager(gateway=ToolGateway(), store=SessionStore(str(tmp_path)))
+
+
+@pytest.fixture()
+def session(manager):
+    state = manager.create_session(GOAL)
+    manager.generate_plan(state)
+    return state
+
+
+def _run_full_cycle(manager, session):
+    manager.run_auto(session)
+    approval = next(a for a in session.approvals if a.status == "pending")
+    manager.resolve_approval(session, approval.approval_id, True)
+    manager.run_auto(session)
+
+
+# ---------- 仮説の構造化 ----------
+class TestStructuredHypothesis:
+    def test_hypothesis_has_structured_fields(self, manager, session):
+        manager.run_auto(session)
+        h = session.hypotheses[0]
+        assert h.falsification_conditions, "反証条件が必須"
+        assert h.source_evidence, "根拠証拠IDが紐付く"
+        assert isinstance(h.applicability, dict)
+
+    def test_backward_compat_old_session_json(self, tmp_path):
+        """新フィールドが無い旧セッションJSONも読み込める。"""
+        old = {
+            "session_id": "SESSION-old00001",
+            "hypotheses": [{"hypothesis_id": "H-old", "statement": "旧仮説"}],
+        }
+        state = SessionState.model_validate(old)
+        h = state.hypotheses[0]
+        assert h.mechanism == ""
+        assert h.counter_evidence == []
+        assert h.judgement is None
+
+
+# ---------- Falsifier ----------
+class TestFalsifier:
+    def test_plan_contains_falsifier_task(self, session):
+        assert any(t.agent == "FalsifierAgent" for t in session.plan.tasks)
+
+    def test_falsifier_collects_counter_evidence(self, manager, session):
+        manager.run_auto(session)
+        t = next(t for t in session.plan.tasks if t.agent == "FalsifierAgent")
+        assert t.status == TaskState.COMPLETED
+        assert t.result["hypotheses_reviewed"]
+        h = session.hypotheses[0]
+        assert h.counter_evidence, "反対・条件依存の証拠が収集される"
+        assert h.alternative_mechanisms, "別機構の候補が提示される"
+
+    def test_falsifier_respects_approved_conditions(self, manager, session):
+        """研究者承認済みの反証条件は Falsifier が書き換えない。"""
+        manager.run_auto(session)
+        h = session.hypotheses[0]
+        manager.update_falsification_conditions(session, h.hypothesis_id,
+                                                ["固定条件"], by="human")
+        h.falsification_approved = True
+        before = list(h.falsification_conditions)
+        from mi_hub.agent.models import Task
+        from mi_hub.agent.roles import FalsifierAgent
+
+        FalsifierAgent().run(session, manager.gateway, Task(agent="FalsifierAgent"))
+        assert h.falsification_conditions == before
+
+
+# ---------- 3値判定（ルール評価） ----------
+def _h(direction="positive"):
+    return Hypothesis(statement="テスト仮説",
+                      applicability={"expected_direction": direction})
+
+
+class TestJudgementRules:
+    def test_supported(self):
+        j = judge_hypothesis(_h(), slope=1.0, mean_uncertainty=0.01,
+                             n_points=5, n_independent_groups=2)
+        assert j.verdict == "supported"
+        assert all(c.passed for c in j.criteria)
+
+    def test_refuted_on_opposite_direction(self):
+        j = judge_hypothesis(_h(), slope=-1.0, mean_uncertainty=0.01,
+                             n_points=5, n_independent_groups=2)
+        assert j.verdict == "refuted"
+
+    def test_inconclusive_when_not_significant(self):
+        j = judge_hypothesis(_h(), slope=0.01, mean_uncertainty=1.0,
+                             n_points=5, n_independent_groups=2)
+        assert j.verdict == "inconclusive"
+        assert "効果の有意性" in j.rationale
+
+    def test_inconclusive_without_reproduction(self):
+        j = judge_hypothesis(_h(), slope=1.0, mean_uncertainty=0.01,
+                             n_points=5, n_independent_groups=1)
+        assert j.verdict == "inconclusive"
+
+    def test_negative_direction_hypothesis(self):
+        j = judge_hypothesis(_h("negative"), slope=-1.0, mean_uncertainty=0.01,
+                             n_points=5, n_independent_groups=2)
+        assert j.verdict == "supported"
+
+    def test_rationale_defers_to_human(self):
+        j = judge_hypothesis(_h(), slope=1.0, mean_uncertainty=0.01,
+                             n_points=5, n_independent_groups=2)
+        assert "研究者" in j.rationale
+
+
+# ---------- 判定案の生成と確定（Human-in-the-loop） ----------
+class TestJudgementFlow:
+    def test_evaluation_attaches_judgement(self, manager, session):
+        _run_full_cycle(manager, session)
+        main = next(h for h in session.hypotheses if h.counter_to is None)
+        assert main.judgement is not None
+        assert main.judgement.verdict in ("supported", "refuted", "inconclusive")
+        assert main.judgement.decided_by == "rule"
+        assert not main.judgement.confirmed_by_human
+
+    def test_judgement_confirmation_asked_in_chat(self, manager, session):
+        _run_full_cycle(manager, session)
+        assert any("【判定案】" in msg["content"] and "確定しますか" in msg["content"]
+                   for msg in session.chat_history if msg["role"] == "assistant")
+
+    def test_confirm_judgement_sets_status(self, manager, session):
+        _run_full_cycle(manager, session)
+        main = next(h for h in session.hypotheses if h.counter_to is None)
+        manager.confirm_judgement(session, main.hypothesis_id, accept=True)
+        expected = {"supported": HypothesisState.SUPPORTED,
+                    "refuted": HypothesisState.FALSIFIED,
+                    "inconclusive": HypothesisState.INCONCLUSIVE}
+        assert main.status == expected[main.judgement.verdict]
+        assert main.judgement.confirmed_by_human
+        assert session.audit_log[-1].action == "judgement_confirmed"
+
+    def test_defer_judgement_keeps_status(self, manager, session):
+        _run_full_cycle(manager, session)
+        main = next(h for h in session.hypotheses if h.counter_to is None)
+        before = main.status
+        manager.confirm_judgement(session, main.hypothesis_id, accept=False)
+        assert main.status == before
+        assert not main.judgement.confirmed_by_human
+
+    def test_confirm_requires_human(self, manager, session):
+        _run_full_cycle(manager, session)
+        main = next(h for h in session.hypotheses if h.counter_to is None)
+        with pytest.raises(PermissionError):
+            manager.confirm_judgement(session, main.hypothesis_id,
+                                      accept=True, by="agent")
+
+    def test_confirm_without_judgement_raises(self, manager, session):
+        manager.run_auto(session)
+        h = session.hypotheses[0]
+        assert h.judgement is None
+        with pytest.raises(ValueError):
+            manager.confirm_judgement(session, h.hypothesis_id, accept=True)

--- a/mi_hub2/tests/test_agent_falsifier.py
+++ b/mi_hub2/tests/test_agent_falsifier.py
@@ -125,6 +125,22 @@ class TestJudgementRules:
                              n_points=5, n_independent_groups=2)
         assert j.verdict == "supported"
 
+    def test_unknown_direction_never_refuted(self):
+        """期待方向が未設定の仮説は refuted/supported にしない。"""
+        h = Hypothesis(statement="方向未設定の仮説")
+        for slope in (1.0, -1.0):
+            j = judge_hypothesis(h, slope=slope, mean_uncertainty=0.01,
+                                 n_points=5, n_independent_groups=2)
+            assert j.verdict == "inconclusive"
+            assert "expected_direction" in j.rationale
+
+    def test_fallback_hypotheses_have_direction(self):
+        """LLM 不可時の既定仮説にも期待方向が入る。"""
+        from mi_hub.agent import llm
+
+        for c in llm.generate_hypotheses("goal", []):
+            assert c["scope"].get("expected_direction") in ("positive", "negative")
+
     def test_rationale_defers_to_human(self):
         j = judge_hypothesis(_h(), slope=1.0, mean_uncertainty=0.01,
                              n_points=5, n_independent_groups=2)


### PR DESCRIPTION
## Summary
添付指示書（材料工学向け仮説検証・自動化システム）との差分分析で特定した矛盾点のうち、反証優先・構造化仮説・ルールベース3値判定（Phase 1）を実装する。

- **仮説の構造化**: `Hypothesis` に `mechanism` / `source_evidence` / `counter_evidence` / `alternative_mechanisms` / `judgement` を追加（scope は既存 `applicability` を使用）。旧セッション JSON と後方互換（新フィールドは全て default 付き）。
- **FalsifierAgent（反証担当）**: 計画に `search_counter_evidence` タスクを追加（HypothesisAgent の直後）。`llm.falsification_review()` で反対結果・条件依存性・別機構の検索クエリと反証条件候補を生成し、GraphRAG/文献検索で反対証拠を収集して `counter_evidence` に紐付ける。研究者承認済み（`falsification_approved`）の反証条件は書き換えない。LLM 不可時は決定論的フォールバック。
- **3値判定（`judgement.py`）**: `judge_hypothesis()` が効果の有意性（|slope| > 3σ）・効果方向の一致・独立モデル系列での再現（≥2系列）・データ点数（≥3点）のルール評価から Supported / Refuted / Inconclusive の判定案を生成。LLM の文章では確定しない。

```text
verdict = refuted      if 有意 かつ 方向が予測と逆（反証条件該当）
        = supported    if 有意 かつ 方向一致 かつ 独立系列再現 かつ 点数十分
        = inconclusive otherwise（不足基準を rationale に明示）
```

- **Human-in-the-loop 確定**: 評価完了時にチャットで「判定案は『●●』です。この判定を確定しますか？」と明示的に問いかけ、`ResearchManager.confirm_judgement()`（human のみ、agent は PermissionError）で SUPPORTED / FALSIFIED / INCONCLUSIVE へ遷移。UI 仮説タブに機構・反証条件・別機構・判定基準テーブル・「判定を確定」「保留のまま続行」ボタンを追加。API に `POST /api/agent/hypotheses/{id}/judgement` を追加。

テスト: 新規 `test_agent_falsifier.py`（構造化・Falsifier・判定ルール・確定フロー・後方互換の17件）を含む全93件合格、ruff 合格。実 LLM でのエンドツーエンド動作確認済み（Ni-Al B2 例題で機構・反証条件・判定案・確定まで一巡）。

PR #464 の上のスタック PR（GitLab 移行は保留のまま、現行 GitHub 運用を継続）。

Link to Devin session: https://app.devin.ai/sessions/34d6cef6e2bf43a5a42921d909d237b3
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->