### PR TITLE
fix(manuscript): Devin Review follow-up on PR #498

### DIFF
--- a/l12-schema-graph-text2sql/paper/npj-compt.mater.tex
+++ b/l12-schema-graph-text2sql/paper/npj-compt.mater.tex
@@ -1660,10 +1660,11 @@ to address security risks such as SQL injection.
 
 Ablation conditions can be viewed as simplified methods with one
 component removed (Table~\ref{tab:ablation}).
-The no\_fewshot condition (schema + LLM, no few-shot examples,
-dictionary, or reranker) corresponds to a ``Full Schema'' baseline
-and achieves only 77.3\%, confirming that schema information alone
-is insufficient.
+The no\_fewshot condition removes only the few-shot examples while
+retaining the dictionary and reranker, yet it causes the largest
+single-component accuracy drop to 77.3\%
+(Table~\ref{tab:ablation}), demonstrating that few-shot examples
+provide the dominant contribution.
 The full proposed method reaches 84.7\%.
 
 Because the ablation removes one component at a time, the apparent
@@ -2436,7 +2437,10 @@ Section S9 compares queries with differing results across the 7
 ablation conditions.
 Section S10 reports detailed results for the independently designed
 query pool.
-All values are from \texttt{paper\_data.json}.
+Ablation, transfer, and core validation metrics are taken from
+\texttt{paper\_data.json}; sensitivity analysis, model comparison,
+and multi-axis metrics are formatted from their respective source
+JSON/CSV evaluation outputs.
 
 % =====================================================================
 \section{Unit Test Category Details}

--- a/l12-schema-graph-text2sql/paper/npj-compt.mater.tex
+++ b/l12-schema-graph-text2sql/paper/npj-compt.mater.tex
@@ -1656,15 +1656,16 @@ to address security risks such as SQL injection.
   \end{tabularx}
 \end{table*}
 
-\subsection{Quantitative Comparison with LLM-only and Schema-only Approaches}
+\subsection{Quantitative Comparison of Ablation Conditions}
 
 Ablation conditions can be viewed as simplified methods with one
 component removed (Table~\ref{tab:ablation}).
 The no\_fewshot condition removes only the few-shot examples while
-retaining the dictionary and reranker, yet it causes the largest
-single-component accuracy drop to 77.3\%
-(Table~\ref{tab:ablation}), demonstrating that few-shot examples
-provide the dominant contribution.
+retaining the dictionary and reranker, yielding an accuracy of
+77.3\% ($-$7.4\,pp), which is comparable to the largest observed
+single-component drop (no\_dict, $-$7.3\,pp). This indicates that
+few-shot examples and the dictionary are the two dominant
+contributors to overall accuracy.
 The full proposed method reaches 84.7\%.
 
 Because the ablation removes one component at a time, the apparent
@@ -1673,6 +1674,9 @@ component interactions mean the contributions are not strictly
 additive.
 Direct comparison with other methods (DIN-SQL, DAIL-SQL, etc.) on
 the same database has not been conducted (see Limitation~6).
+Qualitative SQL examples for LLM-only and schema-only (no few-shot
+examples) configurations are provided in
+Supplementary Section~\ref{sec:sup_sql_examples}.
 
 \subsection{Handling Multi-step Calculation Queries}
 \label{sec:multistep_query}


### PR DESCRIPTION
## Summary
Addresses the two `BUG` findings from Devin Review on the already-merged PR #498.

1. **`npj-compt.mater.tex:1663-1667`**: The no\_fewshot ablation condition was incorrectly described as removing few-shot examples, dictionary, and reranker (a "Full Schema" baseline). It now correctly states that only few-shot examples are removed while the dictionary and reranker remain active, so the 77.3% figure reflects the dominant contribution of few-shot examples rather than schema-only performance.

2. **`npj-compt.mater.tex:2439`**: The Supplementary Materials introduction claimed all values were from `paper_data.json`. This has been qualified to match the main-text Data Availability statement: ablation/transfer/core metrics come from `paper_data.json`, while sensitivity analysis, model comparison, and multi-axis metrics are formatted from their respective JSON/CSV source outputs.

## Verification
- `lualatex npj-compt.mater.tex` (2 passes): no errors, no undefined references/citations.
- `pytest tests/ -q`: 134 passed.
- `ruff check .`: 0 errors.
- `python -m pyright`: 0 errors.

Link to Devin session: https://app.devin.ai/sessions/5c4cf372d3d54d638f06fe4ed622b85b
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->