### PR TITLE
fix(manuscript): remove remaining no_fewshot/no_dict mischaracterizations

### DIFF
--- a/l12-schema-graph-text2sql/paper/npj-compt.mater.tex
+++ b/l12-schema-graph-text2sql/paper/npj-compt.mater.tex
@@ -1481,21 +1481,24 @@ database once it is substituted for the validation set.
 Our results reaffirm that the primary barrier to data utilization
 in inorganic materials RDBs lies in understanding the schema
 structure.
-Against a normalized schema of 31 tables, the LLM alone
-(no few-shot examples, no dictionary) achieves only 77.3\%
-accuracy (Table~\ref{tab:ablation}, no\_fewshot condition),
-dropping to 48.3\% on Very Hard queries containing
-domain-specific terminology.
-This demonstrates that merely presenting schema information is
+Against a normalized schema of 31 tables, the model with schema
+and reranker but without few-shot examples (no\_fewshot condition)
+still achieves only 77.3\% accuracy, and the model with schema and
+reranker but without the dictionary (no\_dict condition) gives a
+nearly equal 77.4\% (Table~\ref{tab:ablation}). The Very Hard
+tier falls to 48.3\% without few-shot examples and to 37.1\%
+without the dictionary, showing that either omission severely
+impairs handling of domain-specific terminology.
+This demonstrates that schema and reranker information alone are
 insufficient to accurately translate materials researchers' intent
 into SQL.
 
 A natural language interface can effectively reduce this schema
 barrier.
-Adding the materials domain dictionary and few-shot examples
-improves accuracy from 77.3\% to 84.7\%, with particularly
-notable gains on complex queries that heavily use
-domain-specific vocabulary.
+The combined use of few-shot examples and the materials domain
+dictionary restores accuracy to 84.7\%, with particularly notable
+gains on complex queries that heavily use domain-specific
+vocabulary.
 This improvement suggests that NL access to inorganic materials
 RDBs goes beyond mere convenience, substantively enabling access
 to data that was previously inaccessible due to schema barriers.
@@ -1662,8 +1665,9 @@ Ablation conditions can be viewed as simplified methods with one
 component removed (Table~\ref{tab:ablation}).
 The no\_fewshot condition removes only the few-shot examples while
 retaining the dictionary and reranker, yielding an accuracy of
-77.3\% ($-$7.4\,pp), which is comparable to the largest observed
-single-component drop (no\_dict, $-$7.3\,pp). This indicates that
+77.3\% ($-$7.4\,pp), and the no\_dict condition removes only the
+dictionary, yielding 77.4\% ($-$7.3\,pp). These are the two largest
+single-component drops and are almost identical, indicating that
 few-shot examples and the dictionary are the two dominant
 contributors to overall accuracy.
 The full proposed method reaches 84.7\%.

--- a/l12-schema-graph-text2sql/paper/npj-compt.mater.tex
+++ b/l12-schema-graph-text2sql/paper/npj-compt.mater.tex
@@ -1481,17 +1481,19 @@ database once it is substituted for the validation set.
 Our results reaffirm that the primary barrier to data utilization
 in inorganic materials RDBs lies in understanding the schema
 structure.
-Against a normalized schema of 31 tables, the model with schema
-and reranker but without few-shot examples (no\_fewshot condition)
-still achieves only 77.3\% accuracy, and the model with schema and
-reranker but without the dictionary (no\_dict condition) gives a
-nearly equal 77.4\% (Table~\ref{tab:ablation}). The Very Hard
-tier falls to 48.3\% without few-shot examples and to 37.1\%
-without the dictionary, showing that either omission severely
-impairs handling of domain-specific terminology.
-This demonstrates that schema and reranker information alone are
-insufficient to accurately translate materials researchers' intent
-into SQL.
+Against a normalized schema of 31 tables, the model retaining the
+schema, dictionary, and reranker but without few-shot examples
+(no\_fewshot condition) still achieves only 77.3\% accuracy, and
+the model retaining the schema, few-shot examples, and reranker
+but without the dictionary (no\_dict condition) gives a nearly
+equal 77.4\% (Table~\ref{tab:ablation}). The Very Hard tier falls
+to 48.3\% without few-shot examples and to 37.1\% without the
+dictionary, showing that either omission severely impairs
+handling of domain-specific terminology.
+This demonstrates that a schema-aware system cannot accurately
+translate materials researchers' intent into SQL in the absence
+of either few-shot examples or the domain dictionary; both are
+necessary.
 
 A natural language interface can effectively reduce this schema
 barrier.


### PR DESCRIPTION
## Summary
Follow-up to the Devin Review on PR #499. Two closely-related mischaracterizations of the ablation conditions remained in `npj-compt.mater.tex`:

1. **Discussion (`§5.1`, lines 1481-1491):** The text described `no_fewshot` as “LLM alone (no few-shot examples, no dictionary).” In fact, `no_fewshot` retains the dictionary and reranker while removing only few-shot examples. It has been rewritten to compare `no_fewshot` (77.3%) and `no_dict` (77.4%) explicitly and to state that the combined use of few-shot examples and the dictionary restores accuracy to 84.7%.

2. **Ablation comparison subsection (`§4.2`, lines 1661-1668):** The previous wording said the `no_fewshot` drop of $-$7.4\,pp was “comparable to the largest observed single-component drop (`no_dict`, $-$7.3\,pp).” Because `no_fewshot` itself is the largest single-component drop, this was self-contradictory. The text now states that `no_fewshot` and `no_dict` are the two largest and almost identical single-component drops.

## Verification
- `lualatex npj-compt.mater.tex` (2 passes): no error, no undefined references/citations.
- `pytest tests/ -q`: 134 passed.
- `ruff check .`: 0 errors.
- `python -m pyright`: 0 errors.

Link to Devin session: https://app.devin.ai/sessions/5c4cf372d3d54d638f06fe4ed622b85b
Requested by: @minimumtone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minimumtone/machine-learning/pull/500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->